### PR TITLE
Make render_ui always load

### DIFF
--- a/server/src/lib/macaron-mcp.ts
+++ b/server/src/lib/macaron-mcp.ts
@@ -80,6 +80,10 @@ export const macaronMcpServer = createSdkMcpServer({
           ],
         };
       },
+      // Keep render_ui visible in the first prompt even when Claude defers MCP
+      // tools behind tool search. The server-level alwaysLoad covers any
+      // future Macaron tools; this keeps the core bridge explicit.
+      { alwaysLoad: true },
     ),
   ],
 });


### PR DESCRIPTION
## Summary

- mark the injected `render_ui` MCP tool with per-tool `alwaysLoad: true`
- keep the existing server-level `alwaysLoad` as the default for future Macaron MCP tools

## Verification

- `npm run build -w @macaron/shared`
- `npm run typecheck -w @macaron/server`
- `npm run build -w @macaron/server`
- in-memory MCP `tools/list` smoke: `render_ui._meta["anthropic/alwaysLoad"] === true`

https://github.com/mindverse-ltd/macaron-claude-code/blob/0df0cc163e281fabc1c7f7b57b012dcd3cc7e874/server/src/lib/macaron-mcp.ts#L83-L86