### PR TITLE
Fix: inject `@unocss/reset` so GenUI preview doesn't leak native button styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@unocss/reset": {
+      "version": "66.7.4",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-66.7.4.tgz",
+      "integrity": "sha512-DYUxI/WVIFCMYKc8/jXCQvp26SmB5UvZ3fYEI1jLeb9BHZYtINvHfs1tIDTWSXOIP1s/yOPFeBDx9bm1PBF4zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "license": "MIT"
@@ -2333,6 +2342,7 @@
         "@radix-ui/react-switch": "^1.3.1",
         "@radix-ui/react-tabs": "^1.1.15",
         "@unocss/preset-wind3": "^66.7.3",
+        "@unocss/reset": "^66.7.4",
         "@unocss/runtime": "^66.7.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-switch": "^1.3.1",
     "@radix-ui/react-tabs": "^1.1.15",
     "@unocss/preset-wind3": "^66.7.3",
+    "@unocss/reset": "^66.7.4",
     "@unocss/runtime": "^66.7.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,6 +19,11 @@ import * as Motion from 'motion/react';
 // CSS variables that source.tsx + components/ui depend on
 import './macaron-vendor/base.css';
 
+// $macaron/ui primitives assume a Tailwind element reset (button/input/list normalize);
+// without it native <button> UA borders leak through the GenUI preview (e.g. Tabs triggers).
+// Imported before styles.css so the app's hand-written paper theme wins on conflicts.
+import '@unocss/reset/tailwind.css';
+
 // UnoCSS runtime — generates utility classes from DOM (matches macaron's uno.config.ts)
 import initUnocssRuntime from '@unocss/runtime';
 import presetWind3 from '@unocss/preset-wind3';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1029,7 +1029,9 @@ textarea:focus, select:focus, input:focus {
 .md h1 { font-size: 18px; }
 .md h2 { font-size: 16px; }
 .md h3 { font-size: 14.5px; }
-.md ul, .md ol { margin: 0 0 10px; padding-left: 22px; }
+/* restore list markers cleared by @unocss/reset's `ul,ol{list-style:none}` */
+.md ul { margin: 0 0 10px; padding-left: 22px; list-style: disc; }
+.md ol { margin: 0 0 10px; padding-left: 22px; list-style: decimal; }
 .md li { margin: 2px 0; }
 .md li > p { margin: 0; }
 .md strong { font-weight: 600; color: var(--text); }


### PR DESCRIPTION
## What

The GenUI preview rendered `$macaron/ui` `Tabs` triggers with a dark oval border — native `<button>` UA styling leaking through the intended `rounded-full` pill.

## Why

`$macaron/ui` primitives (Radix-backed, rendering native `<button>`/`<input>`) assume a **Tailwind element reset** is present. Upstream `macaron-genui-demo` supplies it on a separate line — `injectReset: "@unocss/reset/tailwind.css"` in `astro.config.ts` — **not** via `@genui/unocss`.

When we vendored the component layer (`components/ui/*`, `standalone-uno`, `base.css`) and drive utilities through the global `@unocss/runtime`, that reset line had no equivalent, so it was silently dropped.

Verified the reset is genuinely a separate concern, not something the preset provides:

| config | preflight output |
|---|---|
| our global runtime — `presetWind3({ dark: 'class' })` | 2261 chars, **all `--un-*` variables**; zero `button` / `border-width` |
| `@genui/unocss` scope | 136 chars of scoped utilities; **zero reset** |

> [!NOTE]
> `@genui/unocss`'s job is scoping utility generation, not element reset. Switching to it would **not** have fixed this. Filed upstream: MindLab-Research/macaron-genui-demo#1351 (proposing a configurable scoped `injectReset`).

## Changes

- `web/src/main.tsx` — `import '@unocss/reset/tailwind.css'`, placed **before** `styles.css` so the hand-written paper theme wins on conflicts
- `web/package.json` — add `@unocss/reset`
- `web/src/styles.css` — the reset's `ul,ol{list-style:none}` also stripped chat markdown bullets; restore `list-style` on `.md` lists

## Test plan

Verified in-browser against a live session (`agent-browser`):

- [x] Tabs render as clean pills — dark oval borders gone; click-to-switch works
- [x] Chat markdown lists show `disc` / `decimal` markers again (DOM probe + screenshot)
- [x] Main UI buttons unaffected (all class-styled, already normalized by `styles.css`)