### PR TITLE
Dev-restart resilience: abort runs on SIGTERM, scrub nested-session env, fix symlink-repair race

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import { HOST, PORT, WEB_DIST } from './config.js';
 import { warmSettingsCache } from './lib/settings-store.js';
+import { abortAllRuns } from './lib/active-runs.js';
 import { checkGenUI } from './lib/genui-check.js';
 
 // Claude Agent SDK kills MCP tool calls after 60s by default. Macaron renders
@@ -64,4 +65,17 @@ try {
 } catch (err) {
   app.log.error(err);
   process.exit(1);
+}
+
+// tsx watch restarts on any src change (git pull included) by SIGTERM, then
+// SIGKILL after 5s. The render_ui MCP bridge lives in this process, so a kill
+// mid-turn silently strands the in-flight SDK run. Abort runs first — SSE
+// consumers then get explicit error/done events — and exit within tsx's window.
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+  process.once(sig, () => {
+    const n = abortAllRuns();
+    app.log.info(`${sig}: aborted ${n} in-flight run(s), shutting down`);
+    setTimeout(() => process.exit(0), 2000).unref();
+    void app.close().then(() => process.exit(0));
+  });
 }

--- a/server/src/lib/active-runs.ts
+++ b/server/src/lib/active-runs.ts
@@ -20,3 +20,10 @@ export function abortRun(sid: string): boolean {
 export function endRun(sid: string): void {
   runs.delete(sid);
 }
+
+export function abortAllRuns(): number {
+  const n = runs.size;
+  for (const ac of runs.values()) ac.abort();
+  runs.clear();
+  return n;
+}

--- a/server/src/lib/macaron-mcp.ts
+++ b/server/src/lib/macaron-mcp.ts
@@ -47,7 +47,8 @@ That way the user sees a meaningful shell within seconds.
 - No \`as any\` casts in JSX
 
 # When to use this tool
-Call render_ui when a visual answer beats prose: dashboards, charts, comparison cards, forms, settings panels, interactive widgets, mini editors, status reports. Don't use it for plain text answers. Don't write a markdown TSX fence in chat — that's a failed answer. After render_ui returns, the host already shows the rendered UI to the user; keep your follow-up reply short (one sentence ack at most).`;
+Call render_ui when a visual answer beats prose: dashboards, charts, comparison cards, forms, settings panels, interactive widgets, mini editors, status reports. Don't use it for plain text answers. Don't write a markdown TSX fence in chat — that's a failed answer. After render_ui returns, the host already shows the rendered UI to the user; keep your follow-up reply short (one sentence ack at most).
+If an earlier render_ui call in this conversation errored with a disconnect / server-not-available message, that was a transient host restart — the bridge is recreated fresh every turn, so just call render_ui again instead of telling the user the tool is broken.`;
 
 const INSTRUCTIONS =
   'Macaron GenUI bridge. The render_ui tool inlines a TSX component into the conversation. ' +

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -14,10 +14,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { HOME, HOST, PORT, MACARON_API_BASE, MACARON_API_KEY } from '../config.js';
 
-// The built-in pass-through provider. Never touches the SDK subprocess env —
-// it inherits process.env unchanged. Whatever ANTHROPIC_BASE_URL /
-// ANTHROPIC_AUTH_TOKEN the user has in their shell (Claude Code login,
-// a GLM relay, LiteLLM, Bedrock, …) is exactly what runs.
+// The built-in pass-through provider. Inherits process.env so whatever
+// ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN the user has in their shell
+// (Claude Code login, a GLM relay, LiteLLM, Bedrock, …) is exactly what runs —
+// unless the server was launched from inside a Claude Code session, in which
+// case that session's leaked vars are scrubbed first (see scrubbedAmbientEnv).
 export const SYSTEM_PROVIDER_ID = 'system';
 // Legacy id kept for one-shot migration only.
 const LEGACY_ANTHROPIC_ID = 'anthropic';
@@ -179,7 +180,10 @@ export async function warmSettingsCache(): Promise<void> {
 
 export async function readPublicSettings(): Promise<PublicSettings> {
   const s = await readSettings();
-  const envBase = process.env.ANTHROPIC_BASE_URL || '';
+  // Derive the display from the same effective env the SDK subprocess gets
+  // (scrubbedAmbientEnv drops vars leaked by an enclosing Claude Code
+  // session), so Settings never advertises a relay the run would discard.
+  const envBase = (scrubbedAmbientEnv() ?? process.env).ANTHROPIC_BASE_URL || '';
   const usingRelay = Boolean(envBase);
   return {
     activeProviderId: s.activeProviderId,
@@ -337,13 +341,29 @@ export async function setYoloMode(enabled: boolean): Promise<void> {
   await persist();
 }
 
+// System-default normally inherits process.env unchanged (env: null). But if
+// this server was itself launched from inside a Claude Code session (`claude`
+// → Bash → mcc/tsx watch), that session's env is in ours: ANTHROPIC_BASE_URL /
+// AUTH_TOKEN point at whatever relay the outer session used, CLAUDE_CONFIG_DIR
+// may relocate transcripts, and CLAUDE_CODE_SESSION_ID marks subprocesses as
+// nested children. "System default" must mean the user's normal ambient Claude
+// auth, so in that case hand the SDK a scrubbed copy instead.
+function scrubbedAmbientEnv(): Record<string, string> | null {
+  if (!process.env.CLAUDECODE && !process.env.CLAUDE_CODE_SESSION_ID) return null;
+  const env = { ...process.env } as Record<string, string>;
+  for (const k of Object.keys(env)) {
+    if (k === 'CLAUDECODE' || k.startsWith('CLAUDE_CODE_') || k.startsWith('ANTHROPIC_') || k === 'CLAUDE_CONFIG_DIR') delete env[k];
+  }
+  return env;
+}
+
 export function getActiveProviderEnv(): {
   model: string | undefined;
   env: Record<string, string> | null;
 } {
   const s = cache ?? makeDefaults();
   if (s.activeProviderId === SYSTEM_PROVIDER_ID) {
-    return { model: DEFAULT_ANTHROPIC_MODEL, env: null };
+    return { model: DEFAULT_ANTHROPIC_MODEL, env: scrubbedAmbientEnv() };
   }
   const p = s.customProviders.find((x) => x.id === s.activeProviderId);
   if (!p) return { model: DEFAULT_ANTHROPIC_MODEL, env: null };

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -8,7 +8,7 @@
 // Cache is warmed at startup so getActiveProviderEnv() is synchronous —
 // hot-path request handlers can call it without awaiting disk I/O.
 
-import { promises as fs, mkdirSync, existsSync, symlinkSync, lstatSync } from 'node:fs';
+import { promises as fs, mkdirSync, existsSync, symlinkSync, lstatSync, readdirSync, renameSync, rmSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
@@ -288,8 +288,14 @@ function ensureIsolatedDir(): string {
       const st = lstatSync(projectsLink);
       // Repair if it's not a symlink or points elsewhere.
       if (!st.isSymbolicLink()) {
-        // A stray dir was created here on an earlier run; replace it.
-        fs.rm(projectsLink, { recursive: true, force: true }).catch(() => {});
+        // A stray real dir was created here on an earlier run — transcripts
+        // may have landed inside. Rescue them into the real projects tree
+        // before replacing the dir with the symlink.
+        for (const name of readdirSync(projectsLink)) {
+          const to = path.join(realProjects, name);
+          if (!existsSync(to)) renameSync(path.join(projectsLink, name), to);
+        }
+        rmSync(projectsLink, { recursive: true, force: true });
         symlinkSync(realProjects, projectsLink);
       }
     } catch {


### PR DESCRIPTION
Four targeted fixes from a real incident: mid-turn, a WebUI session reported "Macaron 的 UI 渲染工具断开了" and refused to render UI, while Bash tools kept working fine.

## What actually happened

The `render_ui` MCP bridge is **in-process** (`createSdkMcpServer`) — it lives and dies with the Fastify server. Dev mode runs under `tsx watch`, which SIGTERMs the server on any source change (`git pull` included — reflog timestamps match the watcher's `Restarting...` log lines to the second), then SIGKILLs after 5s. So a pull mid-turn kills the bridge while the CLI subprocess is still streaming: built-in tools survive, `render_ui` errors with a disconnect, and after resume the model sees that error in history and declares the tool broken.

A npm→bun switch made it worse: the old npm-layout `tsx watch` kept running for two days with `tsx/dist/preflight.cjs` gone, crash-looping on every respawn attempt — a zombie watcher serving nothing.

## Fixes (one commit each)

- dc6147d — SIGTERM/SIGINT handler aborts all in-flight SDK runs before exit, so SSE consumers get explicit `error`/`done` events instead of dead air, well within tsx's 5s window:

https://github.com/mindverse-ltd/macaron-artifacts/blob/41a84736ddc6da4543e765e40b84d2d4c2aa251d/server/src/index.ts#L70-L82

- 871cdf0 — one sentence in the `render_ui` description: a past disconnect error is transient (the bridge is recreated fresh every turn), retry instead of telling the user the tool is broken.

- c757885 — the isolated-dir symlink repair called `fs.rm()` un-awaited then `symlinkSync` (guaranteed `EEXIST`, swallowed; the background rm then deleted the stray dir **with any transcripts inside**). Now sync, and stray project dirs are rescued into `~/.claude/projects/` first:

https://github.com/mindverse-ltd/macaron-artifacts/blob/41a84736ddc6da4543e765e40b84d2d4c2aa251d/server/src/lib/settings-store.ts#L294-L304

- 41a8473 — when the server itself is launched from inside a Claude Code session (`claude` → Bash → `bun dev`), that session's env leaks into ours; the zombie watcher above was carrying a third-party `ANTHROPIC_BASE_URL` + auth token, silently rerouting every "System default" run. Detected via the `CLAUDECODE` / `CLAUDE_CODE_SESSION_ID` markers; scrubbed vars: `CLAUDECODE`, `CLAUDE_CODE_*`, `ANTHROPIC_*`, `CLAUDE_CONFIG_DIR`. `readPublicSettings` derives `detectedEndpoint` from the same effective env, so Settings can't advertise a relay the run would discard:

https://github.com/mindverse-ltd/macaron-artifacts/blob/41a84736ddc6da4543e765e40b84d2d4c2aa251d/server/src/lib/settings-store.ts#L343-L358

## Verification

All exercised end-to-end on throwaway instances (random ports):

| check | result |
| --- | --- |
| nested launch (`CLAUDECODE=1` + fake `ANTHROPIC_BASE_URL`) → `GET /api/settings` | `detectedEndpoint: null`, "login untouched" — scrub active, display synced |
| clean shell + own `ANTHROPIC_BASE_URL` → `GET /api/settings` | `detectedEndpoint: https://my-own-relay.example` — pass-through preserved |
| `kill -TERM` | logs `SIGTERM: aborted 0 in-flight run(s)`, exits promptly |
| stray real `projects/` dir with a fake transcript → trigger `ensureIsolatedDir` | transcript moved to `~/.claude/projects/`, symlink restored |
| `tsc -p server/tsconfig.json --noEmit` | clean |

Not addressed here (follow-up candidate): decoupling session lifetime from dev restarts entirely — a turn interrupted by a restart is still lost, just cleanly now.