### PR TITLE
Render Edit/Write/MultiEdit tool calls as inline diff cards

### DIFF
--- a/web/src/components/DiffCard.tsx
+++ b/web/src/components/DiffCard.tsx
@@ -41,10 +41,21 @@ export function extractDiff(name: string, input: unknown): ParsedDiff | null {
 function countChanges(hunks: DiffHunk[]): { plus: number; minus: number } {
   let plus = 0, minus = 0;
   for (const h of hunks) {
-    if (h.oldText) minus += h.oldText.split('\n').length;
-    if (h.newText) plus += h.newText.split('\n').length;
+    if (h.oldText) minus += toLines(h.oldText).length;
+    if (h.newText) plus += toLines(h.newText).length;
   }
   return { plus, minus };
+}
+
+function toLines(text: string): string[] {
+  return text.replace(/\n$/, '').split('\n');
+}
+
+function isFailureResult(result?: string, isError?: boolean): boolean {
+  if (isError) return true;
+  const t = result?.trim();
+  if (!t) return false;
+  return !/^The file .* (has been (updated|created) successfully|file state is current)/.test(t);
 }
 
 // …parent/file.ext — same tail the plain tool header shows for file tools.
@@ -56,12 +67,14 @@ function shortPath(p: string): string {
 // flood the thread. Mirrors sugyan's 20-line threshold.
 const AUTO_EXPAND_MAX_LINES = 20;
 
-export function DiffCard({ name, diff }: { name: string; diff: ParsedDiff }) {
+export function DiffCard({ name, diff, result, isError }: { name: string; diff: ParsedDiff; result?: string; isError?: boolean }) {
   const { plus, minus } = countChanges(diff.hunks);
-  const [open, setOpen] = useState(plus + minus <= AUTO_EXPAND_MAX_LINES);
+  const canCollapse = plus + minus > AUTO_EXPAND_MAX_LINES;
+  const failed = isFailureResult(result, isError);
+  const [open, setOpen] = useState(!canCollapse);
 
   return (
-    <div className="ti-diff">
+    <div className={'ti-diff' + (failed ? ' err' : '')}>
       <div className="ti-diff-head">
         <span className="ti-dot">●</span>
         <span className="ti-tool-name">{name}</span>
@@ -77,16 +90,24 @@ export function DiffCard({ name, diff }: { name: string; diff: ParsedDiff }) {
           {diff.hunks.map((h, i) => <HunkView key={i} hunk={h} />)}
         </div>
       )}
-      <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
-        {open ? '↑ collapse' : `… expand diff (+${plus} −${minus})`}
-      </button>
+      {failed && result?.trim() && (
+        <div className="ti-tool-out ti-diff-result">
+          <span className="ti-rail">└</span>
+          <div className="ti-tool-body"><pre>{result}</pre></div>
+        </div>
+      )}
+      {canCollapse && (
+        <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
+          {open ? '↑ collapse' : `… expand diff (+${plus} −${minus})`}
+        </button>
+      )}
     </div>
   );
 }
 
 function HunkView({ hunk }: { hunk: DiffHunk }) {
-  const oldLines = hunk.oldText ? hunk.oldText.split('\n') : [];
-  const newLines = hunk.newText ? hunk.newText.split('\n') : [];
+  const oldLines = hunk.oldText ? toLines(hunk.oldText) : [];
+  const newLines = hunk.newText ? toLines(hunk.newText) : [];
   return (
     <div className="ti-diff-hunk">
       {hunk.replaceAll && <div className="ti-diff-tag">replace_all</div>}

--- a/web/src/components/DiffCard.tsx
+++ b/web/src/components/DiffCard.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+
+// Inline diff card for Claude's file-editing tools. Everything needed is
+// already in the tool_use `input` (old/new strings), so this renders straight
+// from the streamed call — no server round-trip and no wait for the result.
+
+const DIFF_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'str_replace', 'str_replace_editor', 'str_replace_based_edit_tool']);
+export function isDiffTool(name: string): boolean {
+  return DIFF_TOOLS.has(name);
+}
+
+export type DiffHunk = { oldText: string; newText: string; replaceAll?: boolean };
+export type ParsedDiff = { filePath: string; hunks: DiffHunk[] };
+
+// Pull the before/after text off the tool input. Shapes:
+//   Write     → { file_path, content }               (whole file, all additions)
+//   Edit      → { file_path, old_string, new_string, replace_all? }
+//   MultiEdit → { file_path, edits: [{ old_string, new_string, replace_all? }] }
+// Returns null when the input is missing/partial (e.g. mid-stream before the
+// full tool_use has landed) so the caller can fall back to the plain tool row.
+export function extractDiff(name: string, input: unknown): ParsedDiff | null {
+  if (!input || typeof input !== 'object') return null;
+  const o = input as Record<string, any>;
+  const filePath = String(o.file_path ?? o.path ?? '');
+  if (name === 'Write') {
+    if (typeof o.content !== 'string') return null;
+    return { filePath, hunks: [{ oldText: '', newText: o.content }] };
+  }
+  if (name === 'MultiEdit') {
+    const raw = Array.isArray(o.edits) ? o.edits : [];
+    const hunks = raw
+      .filter((e: any) => e && (typeof e.old_string === 'string' || typeof e.new_string === 'string'))
+      .map((e: any) => ({ oldText: String(e.old_string ?? ''), newText: String(e.new_string ?? ''), replaceAll: Boolean(e.replace_all) }));
+    return hunks.length ? { filePath, hunks } : null;
+  }
+  // Edit / str_replace variants
+  if (typeof o.old_string !== 'string' && typeof o.new_string !== 'string') return null;
+  return { filePath, hunks: [{ oldText: String(o.old_string ?? ''), newText: String(o.new_string ?? ''), replaceAll: Boolean(o.replace_all) }] };
+}
+
+function countChanges(hunks: DiffHunk[]): { plus: number; minus: number } {
+  let plus = 0, minus = 0;
+  for (const h of hunks) {
+    if (h.oldText) minus += h.oldText.split('\n').length;
+    if (h.newText) plus += h.newText.split('\n').length;
+  }
+  return { plus, minus };
+}
+
+// …parent/file.ext — same tail the plain tool header shows for file tools.
+function shortPath(p: string): string {
+  return p ? '…' + p.split('/').slice(-2).join('/') : '';
+}
+
+// Auto-expand small diffs; collapse anything bigger so a large Write doesn't
+// flood the thread. Mirrors sugyan's 20-line threshold.
+const AUTO_EXPAND_MAX_LINES = 20;
+
+export function DiffCard({ name, diff }: { name: string; diff: ParsedDiff }) {
+  const { plus, minus } = countChanges(diff.hunks);
+  const [open, setOpen] = useState(plus + minus <= AUTO_EXPAND_MAX_LINES);
+
+  return (
+    <div className="ti-diff">
+      <div className="ti-diff-head">
+        <span className="ti-dot">●</span>
+        <span className="ti-tool-name">{name}</span>
+        {diff.filePath && (
+          <span className="ti-diff-path" title={diff.filePath}>{shortPath(diff.filePath)}</span>
+        )}
+        <span className="ti-diff-stat">
+          <span className="ti-diff-plus">+{plus}</span> <span className="ti-diff-minus">−{minus}</span>
+        </span>
+      </div>
+      {open && (
+        <div className="ti-diff-body">
+          {diff.hunks.map((h, i) => <HunkView key={i} hunk={h} />)}
+        </div>
+      )}
+      <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
+        {open ? '↑ collapse' : `… expand diff (+${plus} −${minus})`}
+      </button>
+    </div>
+  );
+}
+
+function HunkView({ hunk }: { hunk: DiffHunk }) {
+  const oldLines = hunk.oldText ? hunk.oldText.split('\n') : [];
+  const newLines = hunk.newText ? hunk.newText.split('\n') : [];
+  return (
+    <div className="ti-diff-hunk">
+      {hunk.replaceAll && <div className="ti-diff-tag">replace_all</div>}
+      {oldLines.map((line, i) => (
+        <div key={`o${i}`} className="ti-diff-row ti-diff-del">
+          <span className="ti-diff-sign">−</span>
+          <span className="ti-diff-code">{line || ' '}</span>
+        </div>
+      ))}
+      {newLines.map((line, i) => (
+        <div key={`n${i}`} className="ti-diff-row ti-diff-add">
+          <span className="ti-diff-sign">+</span>
+          <span className="ti-diff-code">{line || ' '}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -9,13 +9,16 @@
 
 import { extractPartialCode } from './partialJson';
 
+const DIFF_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'str_replace', 'str_replace_editor', 'str_replace_based_edit_tool']);
+const isDiffTool = (name: string) => DIFF_TOOLS.has(name);
+
 // A single item on the timeline. Text chunks and tool calls are stored in
 // one ordered list so the UI renders them in the exact interleaved order
 // they arrive (Claude often emits `text → tool → text → tool → text`, and
 // separating them makes the render look re-ordered).
 export type LiveTurnItem =
   | { kind: 'text'; id: string; text: string }
-  | { kind: 'tool'; id: string; name: string; input: unknown; result?: string }
+  | { kind: 'tool'; id: string; name: string; input: unknown; result?: string; isError?: boolean }
   | {
       kind: 'genui';
       id: string;
@@ -200,6 +203,15 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                       notify(sid);
                     }
                   } catch { /* tolerate */ }
+                } else if (s && isDiffTool(p.name)) {
+                  try {
+                    const obj = JSON.parse(p.final_json);
+                    const t = s.timeline.find((x) => x.kind === 'tool' && x.id === `live-${p.id}`);
+                    if (t && t.kind === 'tool') {
+                      t.input = obj;
+                      notify(sid);
+                    }
+                  } catch { /* tolerate */ }
                 }
               } else if (sid && p.type === 'tool_result') {
                 const s = states.get(sid);
@@ -209,7 +221,7 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                     (x.kind === 'tool' && x.id === `live-${p.tool_use_id}`),
                   );
                   if (t) {
-                    if (t.kind === 'tool') t.result = p.text;
+                    if (t.kind === 'tool') { t.result = p.text; t.isError = Boolean(p.isError); }
                     else if (t.kind === 'genui') {
                       if (p.isError || String(p.text).startsWith('render_ui failed:')) {
                         t.status = 'error';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -712,6 +712,12 @@ textarea:focus, select:focus, input:focus {
   background: var(--surface);
   font-family: var(--font-mono);
 }
+.ti-diff.err {
+  border-color: rgba(192, 82, 74, 0.55);
+}
+.ti-diff.err .ti-dot {
+  color: var(--bad);
+}
 .ti-diff-head {
   display: flex;
   align-items: baseline;
@@ -762,6 +768,11 @@ textarea:focus, select:focus, input:focus {
 .ti-diff-code {
   white-space: pre;
   color: var(--text);
+}
+.ti-diff-result {
+  margin: 0;
+  padding: 6px 10px;
+  border-top: 1px solid var(--border);
 }
 .ti-diff .ti-expand { padding: 4px 10px; }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -703,6 +703,68 @@ textarea:focus, select:focus, input:focus {
 }
 .ti-expand:hover { color: var(--accent); }
 
+/* ---------- inline diff card (Edit / Write / MultiEdit) ---------- */
+.ti-diff {
+  margin: 4px 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--surface);
+  font-family: var(--font-mono);
+}
+.ti-diff-head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 12.5px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.ti-diff-path {
+  color: var(--text-2);
+  word-break: break-all;
+  min-width: 0;
+  flex: 1;
+}
+.ti-diff-stat { flex-shrink: 0; font-size: 11.5px; }
+.ti-diff-plus { color: var(--good); }
+.ti-diff-minus { color: var(--bad); }
+.ti-diff-body {
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.ti-diff-hunk { border-bottom: 1px solid var(--border); }
+.ti-diff-hunk:last-child { border-bottom: 0; }
+.ti-diff-tag {
+  padding: 1px 10px;
+  font-size: 10px;
+  color: var(--muted);
+  background: var(--surface-2);
+}
+.ti-diff-row {
+  display: flex;
+  gap: 2px;
+  white-space: pre;
+  padding-right: 10px;
+}
+.ti-diff-del { background: rgba(192, 82, 74, 0.10); }
+.ti-diff-add { background: rgba(90, 139, 90, 0.12); }
+.ti-diff-sign {
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+  user-select: none;
+}
+.ti-diff-del .ti-diff-sign { color: var(--bad); }
+.ti-diff-add .ti-diff-sign { color: var(--good); }
+.ti-diff-code {
+  white-space: pre;
+  color: var(--text);
+}
+.ti-diff .ti-expand { padding: 4px 10px; }
+
 /* ---------- todo card ---------- */
 .ti-todo {
   margin: 8px 0;

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -53,7 +53,7 @@ type Item =
   | { id: string; kind: 'user'; parts: MsgPart[]; uuid?: string }
   | { id: string; kind: 'assistant'; text: string }
   | { id: string; kind: 'thinking'; text: string }
-  | { id: string; kind: 'tool'; name: string; input: unknown; result?: string }
+  | { id: string; kind: 'tool'; name: string; input: unknown; result?: string; isError?: boolean }
   | { id: string; kind: 'todo'; todos: TodoEntry[] }
   | { id: string; kind: 'system_event'; eventType: string; text: string }
   | { id: string; kind: 'genui'; toolUseId: string; prompt: string; code?: string; status: 'pending' | 'ready' | 'error'; error?: string }
@@ -628,7 +628,7 @@ function ItemView({
       // Edit/Write/MultiEdit render as an inline diff card; every other tool
       // (and any edit whose input hasn't fully streamed yet) uses the plain row.
       const diff = isDiffTool(it.name) ? extractDiff(it.name, it.input) : null;
-      return diff ? <DiffCard name={it.name} diff={diff} /> : <ToolItem name={it.name} input={it.input} result={it.result} />;
+      return diff ? <DiffCard name={it.name} diff={diff} result={it.result} isError={it.isError} /> : <ToolItem name={it.name} input={it.input} result={it.result} />;
     }
     case 'todo':
       return <TodoItem todos={it.todos} />;
@@ -1318,16 +1318,19 @@ export function Session(props: SessionProps = {}) {
             );
           },
           onToolInputDone: ({ id, name, final_json }) => {
-            if (!isRenderUITool(name)) return;
             try {
               const obj = JSON.parse(final_json);
-              if (typeof obj?.code === 'string') {
+              if (isRenderUITool(name) && typeof obj?.code === 'string') {
                 setLiveTurn((cur) =>
                   cur.map((t) =>
                     t.kind === 'genui' && t.toolUseId === id
                       ? { ...t, status: 'ready', code: obj.code }
                       : t,
                   ),
+                );
+              } else if (isDiffTool(name)) {
+                setLiveTurn((cur) =>
+                  cur.map((t) => (t.kind === 'tool' && t.id === `live-${id}` ? { ...t, input: obj } : t)),
                 );
               }
             } catch { /* tolerate parse fail; stream still delivers */ }
@@ -1379,7 +1382,7 @@ export function Session(props: SessionProps = {}) {
                   return { ...t, status: 'ready' };
                 }
                 if (t.kind === 'tool' && (t.id === `live-${tool_use_id}`)) {
-                  return { ...t, result: resultText };
+                  return { ...t, result: resultText, isError };
                 }
                 return t;
               }),

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -17,6 +17,7 @@ import {
 import { useToast } from '../components/Toast';
 import { useConfirm } from '../components/Confirm';
 import { StatusBar, type PermissionMode } from '../components/StatusBar';
+import { DiffCard, isDiffTool, extractDiff } from '../components/DiffCard';
 import { loadHistory, pushHistory } from '../lib/history';
 import { ensureNotificationPermission, notify } from '../lib/notify';
 import StaticGenUIRenderer from '../macaron-vendor/StaticGenUIRenderer';
@@ -623,8 +624,12 @@ function ItemView({
       return <LiveAssistantItem text={it.text} />;
     case 'thinking':
       return <ThinkingItem text={it.text} />;
-    case 'tool':
-      return <ToolItem name={it.name} input={it.input} result={it.result} />;
+    case 'tool': {
+      // Edit/Write/MultiEdit render as an inline diff card; every other tool
+      // (and any edit whose input hasn't fully streamed yet) uses the plain row.
+      const diff = isDiffTool(it.name) ? extractDiff(it.name, it.input) : null;
+      return diff ? <DiffCard name={it.name} diff={diff} /> : <ToolItem name={it.name} input={it.input} result={it.result} />;
+    }
     case 'todo':
       return <TodoItem todos={it.todos} />;
     case 'system_event':


### PR DESCRIPTION
## What

Special-cases `Edit` / `Write` / `MultiEdit` (and `str_replace` aliases) tool calls in the session thread into an inline **diff card** — red/green hunks, `+N −M` counts, file-path header, collapsible — instead of the generic tool row. This is the single most common thing you want to review while an agent edits files.

Closes #21

## How it works

The whole feature is client-side. Claude's edit tools already carry the before/after text *in the tool-call `input`* (`old_string` / `new_string` / `content` / `edits`), and macaron already persists and streams that input verbatim (`shared/src/types.ts` `Block.tool_use.input` → SSE `tool_use` → jsonl). So there's **no server, shared-types, or SSE change** — the card renders straight off the streamed call, live, before the edit even returns.

- `web/src/components/DiffCard.tsx` — new. `isDiffTool()`, `extractDiff()` (parses the three input shapes), `+/−` counts, path tail, red/green hunk rows. `Write` → one all-additions hunk.
- `web/src/views/Session.tsx` — `ItemView`'s `case 'tool'` renders `<DiffCard>` when the input parses, else falls back to the existing `<ToolItem>`.
- `web/src/styles.css` — `.ti-diff-*`, built on the existing `--good` / `--bad` / `--surface` tokens so light **and** dark work for free.

Small diffs (≤ 20 changed lines) auto-expand; larger ones collapse to a `+N −M · expand` summary so a big `Write` doesn't flood the thread. Mid-stream / partial input falls back to the plain tool row, so nothing renders broken.

## Prior art

Modelled on [fafawlf/claude-code-web `DiffBlock.tsx`](https://github.com/fafawlf/claude-code-web/blob/main/web/src/components/DiffBlock.tsx) (reads old/new straight off the tool input — same as us). [sugyan/claude-code-webui](https://github.com/sugyan/claude-code-webui/blob/main/frontend/src/components/MessageComponents.tsx#L165-L238) re-derives from the result's `structuredPatch` and gave the 20-line auto-expand threshold; [Claude Code's VS Code inline diff](https://code.claude.com/docs/en/vs-code) and [sst/opencode's review panel](https://github.com/sst/opencode/blob/dev/packages/app/src/pages/session/review-tab.tsx) are the richer north stars. Full research write-up is in the [issue #21 comment](https://github.com/mindverse-ltd/macaron-claude-code/issues/21#issuecomment-4896805841).

## Verification

- `npm run typecheck` (shared/server) + `npm run build` (vite, 4132 modules) pass. The pre-existing `macaron-vendor` `@/`-alias tsc errors are unrelated (present on clean `main`; vite resolves them via its alias at build time).
- Ran `npm run dev`, opened a real 407-message session with 12 `Edit` + 2 `Write` calls. Confirmed in-browser: `Write` renders as an all-green card (`+14 −0`), `Edit` as a red/green card (`+1 −1`), large edits collapse, and non-edit tools (`TaskUpdate`, `Bash`) still use the plain row.

## Not in this PR (follow-ups)

- **Inline Accept/Reject** — issue #21 explicitly scopes accept/reject as a separate issue, and macaron already renders approvals through a dedicated `PermissionItem` card, so bolting buttons onto the diff would duplicate that flow.
- **Syntax / intra-line highlighting** — macaron ships no highlighter dependency today; adding one is out of scope for a P0 read-only card.
