### PR TITLE
Export a Claude session transcript to Markdown

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export * from './sse.js';
+export * from './transcript-markdown.js';

--- a/shared/src/transcript-markdown.ts
+++ b/shared/src/transcript-markdown.ts
@@ -1,0 +1,144 @@
+import type { Block, Message, SessionDetail } from './types.js';
+
+// Serialize a parsed session transcript to a single clean Markdown document —
+// the same `Message[]` the WebUI already holds, rendered for pasting into a
+// PR, issue or doc. Pure and side-effect free: no DOM, no I/O, never throws.
+// OpenCode's `/export` is the reference behavior.
+
+function slugTitle(text: string, max = 60): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= max) return oneLine;
+  return oneLine.slice(0, max).trimEnd() + '…';
+}
+
+// Pick a fence long enough that nothing inside can break out of it. CommonMark
+// lets an opening fence be closed only by a run of >= as many backticks, so we
+// use one more than the longest run present in the body.
+function fenceFor(body: string): string {
+  let longest = 0;
+  for (const m of body.matchAll(/`+/g)) longest = Math.max(longest, m[0].length);
+  return '`'.repeat(Math.max(3, longest + 1));
+}
+
+function codeFence(body: string, lang = ''): string {
+  const fence = fenceFor(body);
+  return `${fence}${lang}\n${body.replace(/\n+$/, '')}\n${fence}`;
+}
+
+// A one-line hint for the tool-call header, e.g. `Read · foo.ts` or
+// `Bash · npm run build`. Falls back to nothing when no obvious field fits.
+function toolHint(input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const o = input as Record<string, unknown>;
+  const key = ['file_path', 'path', 'command', 'pattern', 'query', 'url', 'prompt'].find(
+    (k) => typeof o[k] === 'string' && o[k],
+  );
+  if (!key) return '';
+  return slugTitle(String(o[key]), 72);
+}
+
+function toolInputJson(input: unknown): string {
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+// tool_use + its paired tool_result render as one collapsed <details>.
+function renderToolUse(
+  block: Extract<Block, { kind: 'tool_use' }>,
+  result: string | undefined,
+): string {
+  const hint = toolHint(block.input);
+  const summary = `🔧 ${block.name}${hint ? ` · ${hint}` : ''}`;
+  const parts = [`<details>`, `<summary>${summary}</summary>`, ''];
+  parts.push('**Input**', '', codeFence(toolInputJson(block.input), 'json'), '');
+  if (result != null && result.trim()) parts.push('**Result**', '', codeFence(result), '');
+  parts.push(`</details>`);
+  return parts.join('\n');
+}
+
+function renderMessage(m: Message, resultByToolId: Map<string, string>): string {
+  const out: string[] = [];
+  for (const b of m.blocks) {
+    switch (b.kind) {
+      case 'text':
+        if (b.text.trim()) out.push(b.text.trim(), '');
+        break;
+      case 'thinking':
+        if (b.text.trim())
+          out.push('<details>', '<summary>💭 Thinking</summary>', '', b.text.trim(), '</details>', '');
+        break;
+      case 'tool_use':
+        out.push(renderToolUse(b, resultByToolId.get(b.id)), '');
+        break;
+      case 'tool_result':
+        // Only surface results not already merged into their tool_use above
+        // (unpaired results are rare but keep them rather than drop context).
+        if ((!b.toolUseId || !resultByToolId.has(b.toolUseId)) && b.text.trim())
+          out.push('<details>', '<summary>🔧 Tool result</summary>', '', codeFence(b.text), '</details>', '');
+        break;
+      case 'image':
+        out.push(`_[image: ${b.mimeType}, ${Math.round(b.data.length / 1024)} KB]_`, '');
+        break;
+      case 'system_event':
+        out.push(`> ※ ${b.text.replace(/\n/g, ' ').trim()}`, '');
+        break;
+    }
+  }
+  const body = out.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  // A message whose only blocks were tool_results already merged upstream
+  // renders empty — skip it (and its role header) rather than emit a bare
+  // "### User" with nothing under it.
+  if (!body) return '';
+  const header = m.role === 'user' ? '### 🧑 User' : m.role === 'assistant' ? '### 🤖 Assistant' : '';
+  return (header ? header + '\n\n' : '') + body;
+}
+
+export function sessionToMarkdown(detail: SessionDetail): string {
+  // Pre-index every tool_result by the tool_use it answers so each call and
+  // its output render together (mirrors the WebUI's paired rendering). Only
+  // pair a result to a tool_use that actually exists — a rare orphan result
+  // (no matching call) still renders standalone rather than vanishing.
+  const toolUseIds = new Set<string>();
+  for (const m of detail.messages)
+    for (const b of m.blocks) if (b.kind === 'tool_use') toolUseIds.add(b.id);
+  const resultByToolId = new Map<string, string>();
+  for (const m of detail.messages)
+    for (const b of m.blocks)
+      if (b.kind === 'tool_result' && b.toolUseId && toolUseIds.has(b.toolUseId) && !resultByToolId.has(b.toolUseId))
+        resultByToolId.set(b.toolUseId, b.text);
+
+  const firstUserText =
+    detail.messages
+      .find((m) => m.role === 'user' && m.blocks.some((b) => b.kind === 'text' && b.text.trim()))
+      ?.blocks.find((b): b is Extract<Block, { kind: 'text' }> => b.kind === 'text' && !!b.text.trim())
+      ?.text ?? '';
+  const model = detail.messages.find((m) => m.model)?.model;
+
+  const title = firstUserText ? slugTitle(firstUserText) : `Session ${detail.sessionId.slice(0, 8)}`;
+  const meta = [
+    `\`${detail.sessionId}\``,
+    detail.cwd ? `**cwd** \`${detail.cwd}\`` : '',
+    detail.gitBranch ? `**branch** \`${detail.gitBranch}\`` : '',
+    model ? `**model** \`${model}\`` : '',
+  ].filter(Boolean);
+
+  const head = [
+    `# ${title}`,
+    '',
+    `> ${meta.join(' · ')}`,
+    `> Exported from macaron · ${detail.messages.length} messages${detail.truncated ? ' · _transcript truncated (older messages omitted)_' : ''}`,
+    '',
+    '---',
+    '',
+  ];
+
+  const body = detail.messages
+    .map((m) => renderMessage(m, resultByToolId))
+    .filter((s) => s.trim())
+    .join('\n\n');
+
+  return head.join('\n') + body + '\n';
+}

--- a/shared/src/transcript-markdown.ts
+++ b/shared/src/transcript-markdown.ts
@@ -38,11 +38,35 @@ function toolHint(input: unknown): string {
 }
 
 function toolInputJson(input: unknown): string {
+  // JSON.stringify(undefined) returns the JS value `undefined` (not a string),
+  // which then blows up fenceFor's `.matchAll` and aborts the whole export — an
+  // absent `input` is real (a partial write during a streaming or aborted tool
+  // call). Coerce every non-string result so the "never throws" contract holds.
+  if (input === undefined) return '';
   try {
-    return JSON.stringify(input, null, 2);
+    const json = JSON.stringify(input, null, 2);
+    return typeof json === 'string' ? json : String(input);
   } catch {
     return String(input);
   }
+}
+
+// Escape the three characters that would otherwise be parsed as raw HTML when
+// interpolated into an HTML context (a <summary>, a heading) or a Markdown
+// inline-HTML span (a blockquote). Untrusted tool names/hints, the title and
+// system-event text must not silently corrupt the exported doc — a faithful
+// paste into a PR/issue is the whole point of the export.
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// A literal </details> or </summary> inside Markdown-rendered content (thinking
+// text) would close the disclosure block wrapping it. Insert a zero-width space
+// after the "<" so the token no longer parses as a closing tag while staying
+// visually identical — thinking is otherwise kept as Markdown so its formatting
+// survives.
+function neutralizeClosers(text: string): string {
+  return text.replace(/<(\/(?:details|summary)>)/gi, '<\u200b$1');
 }
 
 // tool_use + its paired tool_result render as one collapsed <details>.
@@ -51,7 +75,7 @@ function renderToolUse(
   result: string | undefined,
 ): string {
   const hint = toolHint(block.input);
-  const summary = `🔧 ${block.name}${hint ? ` · ${hint}` : ''}`;
+  const summary = `🔧 ${escapeHtml(block.name)}${hint ? ` · ${escapeHtml(hint)}` : ''}`;
   const parts = [`<details>`, `<summary>${summary}</summary>`, ''];
   parts.push('**Input**', '', codeFence(toolInputJson(block.input), 'json'), '');
   if (result != null && result.trim()) parts.push('**Result**', '', codeFence(result), '');
@@ -60,34 +84,46 @@ function renderToolUse(
 }
 
 function renderMessage(m: Message, resultByToolId: Map<string, string>): string {
-  const out: string[] = [];
+  // Collect each block as a self-contained chunk and join with a single blank
+  // line. We must NOT run a global `\n{3,}` collapse over the assembled body:
+  // it would reach inside the code fences (tool input JSON, tool results) and
+  // silently rewrite blank lines that are the user's verbatim content — git
+  // diffs, logs, PEP8 double-blanks. Trimming each chunk's outer edges and
+  // joining with `\n\n` keeps block separation tidy without touching any
+  // fenced interior. (Extra blank runs inside prose render identically anyway.)
+  const chunks: string[] = [];
+  const push = (s: string) => {
+    const t = s.trim();
+    if (t) chunks.push(t);
+  };
   for (const b of m.blocks) {
     switch (b.kind) {
       case 'text':
-        if (b.text.trim()) out.push(b.text.trim(), '');
+        push(b.text);
         break;
       case 'thinking':
         if (b.text.trim())
-          out.push('<details>', '<summary>💭 Thinking</summary>', '', b.text.trim(), '</details>', '');
+          push(`<details>\n<summary>💭 Thinking</summary>\n\n${neutralizeClosers(b.text.trim())}\n</details>`);
         break;
       case 'tool_use':
-        out.push(renderToolUse(b, resultByToolId.get(b.id)), '');
+        push(renderToolUse(b, resultByToolId.get(b.id)));
         break;
       case 'tool_result':
         // Only surface results not already merged into their tool_use above
         // (unpaired results are rare but keep them rather than drop context).
         if ((!b.toolUseId || !resultByToolId.has(b.toolUseId)) && b.text.trim())
-          out.push('<details>', '<summary>🔧 Tool result</summary>', '', codeFence(b.text), '</details>', '');
+          push(`<details>\n<summary>🔧 Tool result</summary>\n\n${codeFence(b.text)}\n</details>`);
         break;
       case 'image':
-        out.push(`_[image: ${b.mimeType}, ${Math.round(b.data.length / 1024)} KB]_`, '');
+        // b.data is base64 (~4 chars per 3 bytes); report the decoded size.
+        push(`_[image: ${b.mimeType}, ${Math.round((b.data.length * 3) / 4 / 1024)} KB]_`);
         break;
       case 'system_event':
-        out.push(`> ※ ${b.text.replace(/\n/g, ' ').trim()}`, '');
+        push(`> ※ ${escapeHtml(b.text.replace(/\n/g, ' ').trim())}`);
         break;
     }
   }
-  const body = out.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  const body = chunks.join('\n\n');
   // A message whose only blocks were tool_results already merged upstream
   // renders empty — skip it (and its role header) rather than emit a bare
   // "### User" with nothing under it.
@@ -126,7 +162,7 @@ export function sessionToMarkdown(detail: SessionDetail): string {
   ].filter(Boolean);
 
   const head = [
-    `# ${title}`,
+    `# ${escapeHtml(title)}`,
     '',
     `> ${meta.join(' · ')}`,
     `> Exported from macaron · ${detail.messages.length} messages${detail.truncated ? ' · _transcript truncated (older messages omitted)_' : ''}`,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -143,6 +143,20 @@ export function basename(p: string): string {
   return parts[parts.length - 1] || p;
 }
 
+// Trigger a client-side download of `text` as a file named `name`. Used by the
+// session Markdown export — no server round-trip since the WebUI already holds
+// the parsed transcript.
+export function downloadTextFile(name: string, text: string, mime = 'text/markdown'): void {
+  const url = URL.createObjectURL(new Blob([text], { type: `${mime};charset=utf-8` }));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 export function fmtAgo(ms: number): string {
   if (!ms) return '—';
   const s = Math.floor((Date.now() - ms) / 1000);

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, 
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { api, basename, type Message, type SessionDetail } from '../lib/api';
+import { sessionToMarkdown } from '@macaron/shared';
+import { api, basename, downloadTextFile, type Message, type SessionDetail } from '../lib/api';
 import { streamSession } from '../lib/sse';
 import { getLive, subscribeLive, clearLive, startNewSession } from '../lib/liveStore';
 import { extractPartialCode } from '../lib/partialJson';
@@ -649,10 +650,12 @@ function SessionActionsMenu({
   disabled,
   busyCompact,
   onCompact,
+  onExport,
 }: {
   disabled: boolean;
   busyCompact: boolean;
   onCompact: () => void;
+  onExport: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -690,6 +693,20 @@ function SessionActionsMenu({
       </button>
       {open && (
         <div className="actions-menu">
+          <button
+            type="button"
+            className="actions-menu-item"
+            disabled={disabled}
+            onClick={() => {
+              setOpen(false);
+              onExport();
+            }}
+          >
+            <span className="actions-menu-body">
+              <span className="actions-menu-label">Export to Markdown</span>
+              <span className="actions-menu-sub">Download the transcript as a .md file</span>
+            </span>
+          </button>
           <button
             type="button"
             className="actions-menu-item"
@@ -953,6 +970,16 @@ export function Session(props: SessionProps = {}) {
       setBusyCompact(false);
     }
   }, [busyCompact, confirm, project, sid, toast]);
+
+  // Export: serialize the loaded transcript to Markdown and download it —
+  // client-side, no server round-trip (we already hold the parsed messages).
+  const handleExport = useCallback(() => {
+    if (!data) return;
+    const md = sessionToMarkdown(data);
+    const name = `${basename(data.cwd) || 'session'}-${sid.slice(0, 8)}.md`;
+    downloadTextFile(name, md);
+    toast(`Exported ${name}`);
+  }, [data, sid, toast]);
 
   // Permission decision: POST to server; server resolves the pending
   // canUseTool promise. Optimistically update the local card so it doesn't
@@ -1662,6 +1689,7 @@ export function Session(props: SessionProps = {}) {
             disabled={isNew || sending}
             busyCompact={busyCompact}
             onCompact={() => void handleCompact()}
+            onExport={handleExport}
           />
           <div className="session-input-spacer" />
           {sending ? (


### PR DESCRIPTION
Closes #26

Adds **Export to Markdown** to the Claude session actions menu (the `···` dropdown that already hosts *Compact*). One click serializes the loaded transcript to a clean `.md` file and downloads it — no server round-trip, since the WebUI already holds the parsed `Message[]`.

## Why client-side

`readSessionMessages` already parses the raw JSONL into a clean `Block[]`/`Message[]` model that `Session.tsx` fetches into `data`. Export is therefore a pure `SessionDetail → string` serializer plus a browser download — no new endpoint, no new dep, no shared-type change beyond the one new file.

## What's in the diff

| File | Change |
| --- | --- |
| `shared/src/transcript-markdown.ts` | **new** — pure `sessionToMarkdown(detail)` serializer (no DOM, no I/O, never throws) |
| `shared/src/index.ts` | re-export the serializer |
| `web/src/lib/api.ts` | `downloadTextFile(name, text)` helper (Blob + object URL + `<a download>`) |
| `web/src/views/Session.tsx` | `Export to Markdown` menu row + `handleExport` wiring |

## Output format

- Roles render as `### 🧑 User` / `### 🤖 Assistant` sections.
- **thinking** and **tool calls** collapse into `<details>` so the transcript reads top-to-bottom but stays explorable.
- Each `tool_use` is **paired to its `tool_result` by `toolUseId`** and rendered together; the rare unpaired result still renders standalone rather than vanishing.
- Code fences pick a backtick run one longer than anything inside, so tool output containing ``` can't break out (CommonMark-safe).
- **images** become `_[image: <mime>, <kb> KB]_` placeholders (base64 blobs would bloat the file); **system events** become `> ※ …` blockquotes.
- Header carries `sessionId` / `cwd` / `branch` / `model`, and honestly notes when `SessionDetail.truncated` dropped older messages.

Filename: `<workspace-basename>-<sessionId-short>.md`.

## Prior art

- **OpenCode `/export`** — renders the loaded conversation to one Markdown doc; the reference behavior for "export the whole session cleanly".
- **[fafawlf/claude-code-web `MarkdownMessage.tsx#L177-L203`](https://github.com/fafawlf/claude-code-web/blob/main/web/src/components/MarkdownMessage.tsx#L177-L203)** — its data model pairs each `tool_result` back to its `tool_use` by id; adopted here for readable pairing.
- **Powellga/Claude-Code-IDE `api_export_session`** — dumps the raw PTY transcript into one fence, block-unaware. We do better because our data is already block-structured.

Neither competitor ships a real block-aware JSONL→Markdown serializer — that's the differentiator here.

## Scope

Claude session view only (v1); Codex has its own view/store and is a trivial follow-up. `npm run typecheck` (shared/server) and `npm run build` pass; verified end-to-end in the browser against a 217-message session (176 KB output).
