### PR TITLE
Add optional token auth to safely expose the WebUI on a LAN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,12 @@ MACARON_API_KEY=<your-macaron-api-key>
 # MACARON_PORT=7878
 # MACARON_HOST=127.0.0.1
 
+# Optional — shared token that gates the API when the server is reachable from
+# the network. Localhost requests are never challenged, so leaving this unset
+# keeps local use frictionless. If you bind MACARON_HOST to a non-loopback
+# address (e.g. 0.0.0.0) without setting this, the server auto-generates a
+# token at boot and prints it — set your own here for a stable value.
+# MACARON_AUTH_TOKEN=<a-long-random-string>
+
 # Optional — server log level (default: info).
 # MACARON_LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ MACARON_MODEL=macaron-0.6     # optional
 MACARON_PORT=7878             # optional
 ```
 
+### Exposing on your LAN
+
+By default the server binds to `127.0.0.1`, so only the local machine can reach it — no auth needed. To use the WebUI from your phone or another machine, bind to a routable address and set a shared token:
+
+```bash
+MACARON_HOST=0.0.0.0 MACARON_AUTH_TOKEN=your-long-random-token /macaron
+```
+
+Remote requests must then present the token; localhost stays frictionless (loopback is never challenged). The web app shows a one-field unlock screen, and you can share a ready-to-use link as `http://<host>:7878/?token=your-long-random-token` (the token is stored and stripped from the URL on first load). If you bind to a non-loopback host **without** setting a token, the server generates one at boot and prints it to the log so it's never left wide open.
+
 ## Layout
 
 ```

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,6 +4,10 @@ import path from 'node:path';
 export const PORT = parseInt(process.env.MACARON_PORT || '7878', 10);
 export const HOST = process.env.MACARON_HOST || '127.0.0.1';
 
+// Optional shared token that gates the API when the server is reachable from
+// the network. Empty = auth off (the default for loopback-only binds).
+export const AUTH_TOKEN = process.env.MACARON_AUTH_TOKEN || '';
+
 // Optional env overrides. Users normally set the Macaron API key via the
 // Settings page (persisted to ~/.claude/macaron-config.json); env vars still
 // win for ops-driven / one-shot invocations.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'node:fs';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
-import { HOST, PORT, WEB_DIST } from './config.js';
+import { AUTH_TOKEN, HOST, PORT, WEB_DIST } from './config.js';
+import { makeAuthHook, resolveToken } from './lib/auth.js';
 import { warmSettingsCache } from './lib/settings-store.js';
 import { warmCodexConfigCache } from './lib/codex-config.js';
 import { checkGenUI } from './lib/genui-check.js';
@@ -10,6 +11,7 @@ import { checkGenUI } from './lib/genui-check.js';
 // for complex UIs can take 30-120s, so raise the ceiling to 5 min.
 process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT || '300000';
 import { registerHealthRoutes } from './routes/health.js';
+import { registerAuthRoutes } from './routes/auth.js';
 import { registerWorkspaceRoutes } from './routes/workspaces.js';
 import { registerSessionRoutes } from './routes/sessions.js';
 import { registerSettingsRoutes } from './routes/settings.js';
@@ -24,8 +26,15 @@ const app = Fastify({
   bodyLimit: 2 * 1024 * 1024,
 });
 
+// Gate the API/relay behind a shared token when the server is reachable from
+// the network. resolveToken auto-generates one when bound to a non-loopback
+// host with no token set, so an exposed server is never wide open.
+const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
+app.addHook('onRequest', makeAuthHook(authToken));
+
 await app.register(async (instance) => {
   await registerHealthRoutes(instance);
+  await registerAuthRoutes(instance, authToken);
   await registerSettingsRoutes(instance);
   await registerRelayRoutes(instance);
   await registerWorkspaceRoutes(instance);
@@ -70,6 +79,12 @@ try {
   await warmCodexConfigCache();
   await app.listen({ host: HOST, port: PORT });
   app.log.info(`macaron server listening on http://${HOST}:${PORT}`);
+  if (authGenerated) {
+    app.log.warn(`bound to non-loopback host ${HOST} with no MACARON_AUTH_TOKEN — generated one for this run.`);
+    app.log.warn(`connect from another device with: http://${HOST}:${PORT}/?token=${authToken}`);
+  } else if (authToken) {
+    app.log.info('server auth enabled (MACARON_AUTH_TOKEN) — remote requests require the token.');
+  }
   // Pre-warm the render_ui TS check: the first diagnose pays full program construction. Do it now,
   // at boot, instead of mid-turn while an SSE stream is live. The `import "$macaron/ui"` is what
   // makes this warm the expensive half — it pulls source.tsx and its whole vendored tree into the

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import { AUTH_TOKEN, HOST, PORT, WEB_DIST } from './config.js';
-import { makeAuthHook, resolveToken } from './lib/auth.js';
+import { makeAuthHook, redactTokenInUrl, resolveToken } from './lib/auth.js';
 import { warmSettingsCache } from './lib/settings-store.js';
 import { warmCodexConfigCache } from './lib/codex-config.js';
 import { checkGenUI } from './lib/genui-check.js';
@@ -19,7 +19,22 @@ import { registerRelayRoutes } from './routes/relay.js';
 import { registerCodexRoutes } from './routes/codex.js';
 
 const app = Fastify({
-  logger: { level: process.env.MACARON_LOG_LEVEL || 'info' },
+  logger: {
+    level: process.env.MACARON_LOG_LEVEL || 'info',
+    // pino's default req serializer logs req.url verbatim, so a `?token=` share
+    // link would land in every request line. Strip the token before it's logged.
+    serializers: {
+      req(req) {
+        return {
+          method: req.method,
+          url: redactTokenInUrl(req.url),
+          host: req.host,
+          remoteAddress: req.ip,
+          remotePort: req.socket?.remotePort,
+        };
+      },
+    },
+  },
   // Disable strict trailing-slash for friendlier URLs.
   ignoreTrailingSlash: true,
   // Allow large request bodies (genui prompts can grow).
@@ -81,7 +96,10 @@ try {
   app.log.info(`macaron server listening on http://${HOST}:${PORT}`);
   if (authGenerated) {
     app.log.warn(`bound to non-loopback host ${HOST} with no MACARON_AUTH_TOKEN — generated one for this run.`);
-    app.log.warn(`connect from another device with: http://${HOST}:${PORT}/?token=${authToken}`);
+    // The token is a live credential — keep it out of the structured log (which may be
+    // shipped off-box) and print the connection string straight to stdout so the operator
+    // can still grab it from their own terminal on first launch.
+    console.log(`connect from another device with: http://${HOST}:${PORT}/?token=${authToken}`);
   } else if (authToken) {
     app.log.info('server auth enabled (MACARON_AUTH_TOKEN) — remote requests require the token.');
   }

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -1,0 +1,56 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
+
+// Loopback peers (the local CLI, start.sh's health curl, a browser on the same
+// box) are never challenged — auth only guards access from the network.
+export function isLoopback(ip: string | undefined): boolean {
+  if (!ip) return false;
+  return ip === '127.0.0.1' || ip === '::1' || ip.startsWith('127.') || ip === '::ffff:127.0.0.1' || ip.startsWith('::ffff:127.');
+}
+
+export function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+// Constant-time string compare that also resists length leaks.
+export function tokensMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+// The configured token wins. When the server is bound to a non-loopback host
+// but no token was set, generate one so an exposed server is never wide open.
+export function resolveToken(host: string, configured: string): { token: string; generated: boolean } {
+  if (configured) return { token: configured, generated: false };
+  if (!isLoopbackHost(host)) return { token: randomBytes(24).toString('base64url'), generated: true };
+  return { token: '', generated: false };
+}
+
+// Only the API and provider relay are sensitive; static assets + SPA HTML stay
+// open so a remote browser can load the app shell and its login screen.
+function isProtectedPath(url: string): boolean {
+  return url.startsWith('/api/') || url.startsWith('/relay/');
+}
+
+function isExemptPath(url: string): boolean {
+  return url === '/api/health' || url.startsWith('/api/auth/');
+}
+
+function extractToken(req: FastifyRequest): string {
+  const header = req.headers.authorization;
+  if (header?.startsWith('Bearer ')) return header.slice(7);
+  const q = (req.query as Record<string, unknown> | undefined)?.token;
+  return typeof q === 'string' ? q : '';
+}
+
+// Fastify onRequest hook. No-op when auth is off; otherwise 401s any protected
+// request that isn't from loopback and doesn't carry a valid token.
+export function makeAuthHook(token: string) {
+  return function authHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
+    if (!token || isLoopback(req.ip) || !isProtectedPath(req.url) || isExemptPath(req.url)) return done();
+    if (tokensMatch(extractToken(req), token)) return done();
+    reply.code(401).send({ error: 'authentication required', authRequired: true });
+  };
+}

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -9,7 +9,10 @@ export function isLoopback(ip: string | undefined): boolean {
 }
 
 export function isLoopbackHost(host: string): boolean {
-  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+  // Match the whole IPv4 loopback block 127.0.0.0/8, mirroring isLoopback — a
+  // 127.x bind (e.g. 127.0.0.2) is still fully local and must not trip the
+  // "exposed to the network" auto-generate path.
+  return host === 'localhost' || host === '::1' || host === '127.0.0.1' || host.startsWith('127.');
 }
 
 // Constant-time string compare that also resists length leaks.
@@ -38,6 +41,16 @@ function isExemptPath(url: string): boolean {
   return url === '/api/health' || url.startsWith('/api/auth/');
 }
 
+// The path to match the guard against: the resolved route pattern, which
+// Fastify has already percent-decoded (e.g. /api/workspaces/:project). Matching
+// the raw req.url instead lets an encoded request like /%61pi/... (== /api/...)
+// slip past the prefix check while the router still dispatches it to the real
+// handler. No matched route (static assets, SPA fallback) → req.url, which
+// stays open by intent.
+function routePath(req: FastifyRequest): string {
+  return req.routeOptions?.url ?? req.url;
+}
+
 export function extractToken(req: FastifyRequest): string {
   const header = req.headers.authorization;
   if (header?.startsWith('Bearer ')) return header.slice(7);
@@ -49,7 +62,8 @@ export function extractToken(req: FastifyRequest): string {
 // request that isn't from loopback and doesn't carry a valid token.
 export function makeAuthHook(token: string) {
   return function authHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
-    if (!token || isLoopback(req.ip) || !isProtectedPath(req.url) || isExemptPath(req.url)) return done();
+    const path = routePath(req);
+    if (!token || isLoopback(req.ip) || !isProtectedPath(path) || isExemptPath(path)) return done();
     if (tokensMatch(extractToken(req), token)) return done();
     reply.code(401).send({ error: 'authentication required', authRequired: true });
   };

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -58,6 +58,14 @@ export function extractToken(req: FastifyRequest): string {
   return typeof q === 'string' ? q : '';
 }
 
+// The `token` query param doubles as a share-link credential, so it must never
+// reach the logs. Fastify/pino's default req serializer logs `req.url` verbatim
+// (query and all) on every request — strip any token value before it lands in
+// structured output.
+export function redactTokenInUrl(url: string): string {
+  return url.replace(/([?&]token=)[^&#]*/gi, '$1[redacted]');
+}
+
 // Fastify onRequest hook. No-op when auth is off; otherwise 401s any protected
 // request that isn't from loopback and doesn't carry a valid token.
 export function makeAuthHook(token: string) {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -38,7 +38,7 @@ function isExemptPath(url: string): boolean {
   return url === '/api/health' || url.startsWith('/api/auth/');
 }
 
-function extractToken(req: FastifyRequest): string {
+export function extractToken(req: FastifyRequest): string {
   const header = req.headers.authorization;
   if (header?.startsWith('Bearer ')) return header.slice(7);
   const q = (req.query as Record<string, unknown> | undefined)?.token;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,19 @@
+import type { FastifyInstance } from 'fastify';
+import type { AuthStatusResponse } from '@macaron/shared';
+import { isLoopback, tokensMatch } from '../lib/auth.js';
+
+// `token` is the armed shared secret ('' when auth is off). Registered inside
+// the same encapsulated scope as the other routes, but these two paths are
+// exempt from the auth hook so the login screen can always reach them.
+export async function registerAuthRoutes(app: FastifyInstance, token: string): Promise<void> {
+  // Whether THIS caller must authenticate: a token is armed and they're remote.
+  app.get('/api/auth/status', async (req): Promise<AuthStatusResponse> => {
+    return { required: Boolean(token) && !isLoopback(req.ip) };
+  });
+
+  app.post<{ Body: { token?: string } }>('/api/auth/login', async (req, reply) => {
+    const provided = typeof req.body?.token === 'string' ? req.body.token : '';
+    if (!token || tokensMatch(provided, token)) return { ok: true };
+    return reply.code(401).send({ error: 'invalid token' });
+  });
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,14 +1,17 @@
 import type { FastifyInstance } from 'fastify';
 import type { AuthStatusResponse } from '@macaron/shared';
-import { isLoopback, tokensMatch } from '../lib/auth.js';
+import { extractToken, isLoopback, tokensMatch } from '../lib/auth.js';
 
 // `token` is the armed shared secret ('' when auth is off). Registered inside
 // the same encapsulated scope as the other routes, but these two paths are
 // exempt from the auth hook so the login screen can always reach them.
 export async function registerAuthRoutes(app: FastifyInstance, token: string): Promise<void> {
-  // Whether THIS caller must authenticate: a token is armed and they're remote.
+  // Whether THIS caller must authenticate: a token is armed, they're remote,
+  // and they aren't already carrying a valid token (matching the auth hook so
+  // a stored token survives a page reload instead of re-prompting).
   app.get('/api/auth/status', async (req): Promise<AuthStatusResponse> => {
-    return { required: Boolean(token) && !isLoopback(req.ip) };
+    if (!token || isLoopback(req.ip)) return { required: false };
+    return { required: !tokensMatch(extractToken(req), token) };
   });
 
   app.post<{ Body: { token?: string } }>('/api/auth/login', async (req, reply) => {

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -83,6 +83,7 @@ export type SessionDetail = {
 export type WorkspacesResponse = { workspaces: Workspace[] };
 export type WorkspaceDetailResponse = { workspace: Workspace; sessions: SessionListItem[] };
 export type HealthResponse = { ok: boolean; model: string };
+export type AuthStatusResponse = { required: boolean };
 export type ConfigResponse = {
   macaron: { base: string; model: string; configured: boolean };
 };

--- a/web/src/codex/api.ts
+++ b/web/src/codex/api.ts
@@ -5,6 +5,7 @@ import type {
   SessionDetail,
   Workspace,
 } from '@macaron/shared';
+import { authedFetch } from '../lib/auth';
 
 export type CodexThread = SessionListItem;
 export type CodexWorkspace = Workspace;
@@ -28,13 +29,13 @@ export type PublicCodexProvider = {
 export type PublicCodexSettings = { provider: PublicCodexProvider };
 
 async function getJSON<T>(url: string): Promise<T> {
-  const r = await fetch(url);
+  const r = await authedFetch(url);
   if (!r.ok) throw new Error(`http ${r.status}`);
   return r.json() as Promise<T>;
 }
 
 async function reqJSON<T>(url: string, init: RequestInit): Promise<T> {
-  const r = await fetch(url, init);
+  const r = await authedFetch(url, init);
   if (!r.ok) throw new Error(`http ${r.status}: ${(await r.text()).slice(0, 200)}`);
   return r.json() as Promise<T>;
 }
@@ -48,7 +49,7 @@ export const codexApi = {
     ),
   thread: (sid: string) => getJSON<SessionDetail>(`/api/codex/threads/${encodeURIComponent(sid)}`),
   deleteThread: async (sid: string): Promise<void> => {
-    const r = await fetch(`/api/codex/threads/${encodeURIComponent(sid)}`, { method: 'DELETE' });
+    const r = await authedFetch(`/api/codex/threads/${encodeURIComponent(sid)}`, { method: 'DELETE' });
     if (!r.ok) throw new Error(`http ${r.status}`);
   },
   stopThread: (sid: string) =>

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -9,7 +9,12 @@ import { CodexApp } from './CodexApp';
 import { CodexChat } from './CodexChat';
 import { CodexSettings } from './CodexSettings';
 import { CodexWorkspace } from './CodexWorkspace';
+import { AuthGate } from '../components/AuthGate';
+import { consumeTokenFromUrl } from '../lib/auth';
 import './styles.css';
+
+// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+consumeTokenFromUrl();
 
 const router = createHashRouter([
   {
@@ -27,6 +32,8 @@ const router = createHashRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AuthGate>
+      <RouterProvider router={router} />
+    </AuthGate>
   </React.StrictMode>,
 );

--- a/web/src/codex/stream.ts
+++ b/web/src/codex/stream.ts
@@ -1,6 +1,8 @@
 // SSE consumers for the /api/codex/threads endpoints. Parses `data:` frames
 // into typed events the chat view can consume with simple callbacks.
 
+import { authHeaders } from '../lib/auth';
+
 export type CodexStreamEvent =
   | { type: 'starting'; cwd?: string }
   | { type: 'meta'; sessionId: string; cwd?: string }
@@ -67,7 +69,7 @@ async function pump(resp: Response, h: CodexStreamHandlers): Promise<void> {
 export async function startCodexThread(body: Body, h: CodexStreamHandlers): Promise<void> {
   const resp = await fetch('/api/codex/threads', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body),
   });
   await pump(resp, h);
@@ -76,7 +78,7 @@ export async function startCodexThread(body: Body, h: CodexStreamHandlers): Prom
 export async function sendCodexMessage(sid: string, body: Body, h: CodexStreamHandlers): Promise<void> {
   const resp = await fetch(`/api/codex/threads/${encodeURIComponent(sid)}/message`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body),
   });
   await pump(resp, h);

--- a/web/src/codex/stream.ts
+++ b/web/src/codex/stream.ts
@@ -1,7 +1,7 @@
 // SSE consumers for the /api/codex/threads endpoints. Parses `data:` frames
 // into typed events the chat view can consume with simple callbacks.
 
-import { authHeaders } from '../lib/auth';
+import { authedFetch } from '../lib/auth';
 
 export type CodexStreamEvent =
   | { type: 'starting'; cwd?: string }
@@ -67,18 +67,18 @@ async function pump(resp: Response, h: CodexStreamHandlers): Promise<void> {
 }
 
 export async function startCodexThread(body: Body, h: CodexStreamHandlers): Promise<void> {
-  const resp = await fetch('/api/codex/threads', {
+  const resp = await authedFetch('/api/codex/threads', {
     method: 'POST',
-    headers: { 'content-type': 'application/json', ...authHeaders() },
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
   await pump(resp, h);
 }
 
 export async function sendCodexMessage(sid: string, body: Body, h: CodexStreamHandlers): Promise<void> {
-  const resp = await fetch(`/api/codex/threads/${encodeURIComponent(sid)}/message`, {
+  const resp = await authedFetch(`/api/codex/threads/${encodeURIComponent(sid)}/message`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', ...authHeaders() },
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
   await pump(resp, h);

--- a/web/src/components/AuthGate.tsx
+++ b/web/src/components/AuthGate.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState, type ReactNode, type CSSProperties } from 'react';
+import type { AuthStatusResponse } from '@macaron/shared';
+import { getToken, setToken } from '../lib/auth';
+
+// Gates the app behind the server's shared token when it's reachable from the
+// network. On mount it asks the server whether this caller must authenticate;
+// loopback callers (and servers with auth off) pass straight through. Uses
+// self-contained inline styles so it renders identically in the claude paper
+// theme and the codex zinc theme without depending on either's stylesheet.
+
+type Phase = 'checking' | 'needed' | 'ok';
+
+export function AuthGate({ children }: { children: ReactNode }) {
+  const [phase, setPhase] = useState<Phase>('checking');
+  const [token, setTokenInput] = useState('');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function check() {
+    try {
+      const r = await fetch('/api/auth/status', { headers: getToken() ? { Authorization: `Bearer ${getToken()}` } : {} });
+      const j = (await r.json()) as AuthStatusResponse;
+      setPhase(j.required ? 'needed' : 'ok');
+    } catch {
+      // Server unreachable — don't lock the user out of a purely local UI.
+      setPhase('ok');
+    }
+  }
+
+  useEffect(() => { void check(); }, []);
+
+  // An expired / wrong token anywhere in the app re-arms the gate.
+  useEffect(() => {
+    const onRequired = () => setPhase('needed');
+    window.addEventListener('macaron:auth-required', onRequired);
+    return () => window.removeEventListener('macaron:auth-required', onRequired);
+  }, []);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!token.trim() || busy) return;
+    setBusy(true);
+    setError('');
+    try {
+      const r = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: token.trim() }),
+      });
+      if (!r.ok) { setError('Invalid token'); setBusy(false); return; }
+      setToken(token.trim());
+      setPhase('ok');
+    } catch {
+      setError('Could not reach the server');
+      setBusy(false);
+    }
+  }
+
+  if (phase === 'ok') return <>{children}</>;
+  if (phase === 'checking') return null;
+
+  return (
+    <div style={S.backdrop}>
+      <form style={S.card} onSubmit={submit}>
+        <div style={S.title}>Authentication required</div>
+        <div style={S.subtitle}>This macaron server is protected. Enter its access token to continue.</div>
+        <input
+          style={S.input}
+          type="password"
+          autoFocus
+          placeholder="Access token"
+          value={token}
+          onChange={(e) => setTokenInput(e.target.value)}
+        />
+        {error && <div style={S.error}>{error}</div>}
+        <button style={{ ...S.button, ...(busy ? S.buttonBusy : null) }} type="submit" disabled={busy}>
+          {busy ? 'Checking…' : 'Unlock'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const S: Record<string, CSSProperties> = {
+  backdrop: {
+    position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: '#faf9f5', fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif', padding: 20,
+  },
+  card: {
+    width: '100%', maxWidth: 360, display: 'flex', flexDirection: 'column', gap: 12,
+    background: '#fff', border: '1px solid #e8e6dc', borderRadius: 14, padding: '28px 24px',
+    boxShadow: '0 8px 30px rgba(60,57,41,0.10)',
+  },
+  title: { fontSize: 17, fontWeight: 600, color: '#3d3929' },
+  subtitle: { fontSize: 13, lineHeight: 1.5, color: '#8a8473', marginBottom: 4 },
+  input: {
+    width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 14,
+    border: '1px solid #d9d5c7', borderRadius: 8, background: '#faf9f5', color: '#3d3929', outline: 'none',
+  },
+  error: { fontSize: 12.5, color: '#c0524a' },
+  button: {
+    width: '100%', padding: '10px 12px', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+    border: '1px solid #c96442', borderRadius: 8, background: '#c96442', color: '#fff',
+  },
+  buttonBusy: { opacity: 0.6, cursor: 'default' },
+};

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,9 +16,10 @@ import type {
   SessionDetail,
   HealthResponse,
 } from '@macaron/shared';
+import { authedFetch } from './auth';
 
 export async function getJSON<T>(url: string): Promise<T> {
-  const r = await fetch(url);
+  const r = await authedFetch(url);
   if (!r.ok) throw new Error(`http ${r.status}`);
   return r.json() as Promise<T>;
 }
@@ -51,7 +52,7 @@ export type ProviderInput = {
 };
 
 async function req<T>(url: string, init: RequestInit): Promise<T> {
-  const r = await fetch(url, init);
+  const r = await authedFetch(url, init);
   if (!r.ok) throw new Error(`http ${r.status}: ${(await r.text()).slice(0, 200)}`);
   return r.json() as Promise<T>;
 }
@@ -96,7 +97,7 @@ export const api = {
       `/api/sessions/claude/${encodeURIComponent(project)}/${encodeURIComponent(sid)}`,
     ),
   deleteSession: async (project: string, sid: string): Promise<void> => {
-    const r = await fetch(
+    const r = await authedFetch(
       `/api/sessions/claude/${encodeURIComponent(project)}/${encodeURIComponent(sid)}`,
       { method: 'DELETE' },
     );

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,51 @@
+// Client-side auth for the WebUI. The server gates /api and /relay behind a
+// shared token when reachable from the network; here we store that token and
+// attach it to every request. macaron streams over fetch()+getReader() (not
+// the browser EventSource), so a single Authorization header covers plain
+// requests and streaming reads alike — no cookie / query-token escape hatch.
+
+const KEY = 'macaron_auth_token';
+
+export function getToken(): string {
+  try { return localStorage.getItem(KEY) || ''; } catch { return ''; }
+}
+
+export function setToken(token: string): void {
+  try { localStorage.setItem(KEY, token); } catch { /* private mode */ }
+}
+
+export function clearToken(): void {
+  try { localStorage.removeItem(KEY); } catch { /* private mode */ }
+}
+
+export function authHeaders(): Record<string, string> {
+  const t = getToken();
+  return t ? { Authorization: `Bearer ${t}` } : {};
+}
+
+// fetch wrapper that injects the token and re-gates the UI on 401 (expired /
+// wrong token). Every call site that hits our own server uses this.
+export async function authedFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  const t = getToken();
+  if (t) headers.set('Authorization', `Bearer ${t}`);
+  const resp = await fetch(input, { ...init, headers });
+  if (resp.status === 401) {
+    clearToken();
+    window.dispatchEvent(new Event('macaron:auth-required'));
+  }
+  return resp;
+}
+
+// Bootstrap from a shared link: ?token=... → store it, then strip it from the
+// URL so it doesn't linger in history / referrers. Call once at startup.
+export function consumeTokenFromUrl(): void {
+  try {
+    const url = new URL(window.location.href);
+    const t = url.searchParams.get('token');
+    if (!t) return;
+    setToken(t);
+    url.searchParams.delete('token');
+    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+  } catch { /* non-browser / malformed URL */ }
+}

--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -8,6 +8,7 @@
 // Session subscribes and gets the current buffer + live updates.
 
 import { extractPartialCode } from './partialJson';
+import { authHeaders } from './auth';
 
 // A single item on the timeline. Text chunks and tool calls are stored in
 // one ordered list so the UI renders them in the exact interleaved order
@@ -110,7 +111,7 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
     let sid = '';
     fetch(`/api/workspaces/${encodeURIComponent(project)}/sessions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({
         text,
         permissionMode: opts.permissionMode,

--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -8,7 +8,7 @@
 // Session subscribes and gets the current buffer + live updates.
 
 import { extractPartialCode } from './partialJson';
-import { authHeaders } from './auth';
+import { authedFetch } from './auth';
 
 // A single item on the timeline. Text chunks and tool calls are stored in
 // one ordered list so the UI renders them in the exact interleaved order
@@ -109,9 +109,9 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
   return new Promise((resolve, reject) => {
     let resolved = false;
     let sid = '';
-    fetch(`/api/workspaces/${encodeURIComponent(project)}/sessions`, {
+    authedFetch(`/api/workspaces/${encodeURIComponent(project)}/sessions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         text,
         permissionMode: opts.permissionMode,

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -1,4 +1,6 @@
 // Parse OpenAI-style SSE (Macaron, used by GenUI).
+import { authHeaders } from './auth';
+
 export type OpenAIStreamHandlers = {
   onDelta?: (text: string) => void;
   onReasoning?: (text: string) => void;
@@ -17,7 +19,7 @@ export async function streamOpenAI(
   try {
     resp = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify(body),
       signal: h.signal,
     });
@@ -96,7 +98,7 @@ export async function streamSession(
   try {
     resp = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify(body),
     });
   } catch (e) {

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -1,5 +1,5 @@
 // Parse OpenAI-style SSE (Macaron, used by GenUI).
-import { authHeaders } from './auth';
+import { authedFetch } from './auth';
 
 export type OpenAIStreamHandlers = {
   onDelta?: (text: string) => void;
@@ -17,9 +17,9 @@ export async function streamOpenAI(
 ): Promise<void> {
   let resp: Response;
   try {
-    resp = await fetch(url, {
+    resp = await authedFetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       signal: h.signal,
     });
@@ -96,9 +96,9 @@ export async function streamSession(
 ): Promise<void> {
   let resp: Response;
   try {
-    resp = await fetch(url, {
+    resp = await authedFetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
   } catch (e) {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -36,8 +36,13 @@ import { Workspace } from './views/Workspace';
 import { Settings } from './views/Settings';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
+import { AuthGate } from './components/AuthGate';
+import { consumeTokenFromUrl } from './lib/auth';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import './styles.css';
+
+// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+consumeTokenFromUrl();
 
 // Boot UnoCSS runtime: scans the DOM for utility classes and injects CSS as
 // elements appear. Required because the GenUI preview renders model-generated
@@ -85,11 +90,13 @@ const router = createHashRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ToastProvider>
-      <ConfirmProvider>
-        <RouterProvider router={router} />
-      </ConfirmProvider>
-    </ToastProvider>
+    <AuthGate>
+      <ToastProvider>
+        <ConfirmProvider>
+          <RouterProvider router={router} />
+        </ConfirmProvider>
+      </ToastProvider>
+    </AuthGate>
   </React.StrictMode>,
 );
 


### PR DESCRIPTION
## What

Adds **optional** token auth so you can bind macaron to `0.0.0.0` and reach the WebUI from your phone/laptop on the same LAN without leaving the API wide open. Off by default — a plain loopback boot is byte-for-byte the same experience as today.

Closes #16. Full design write-up is in the [issue thread](https://github.com/mindverse-ltd/macaron-claude-code/issues/16#issuecomment-3141917901).

## The one insight that made this small

macaron's "SSE" is **not** the browser `EventSource` API — every stream is a `fetch()` POST read through `resp.body.getReader()` (`web/src/lib/sse.ts`, `web/src/codex/stream.ts`, `web/src/lib/liveStore.ts`). So streaming requests can carry custom headers, and a single `Authorization: Bearer <token>` on the existing fetch layer covers **both** plain JSON calls and streams uniformly.

That's the hard part the prior art had to work around, and here it just… doesn't exist:

| Project | Stream auth workaround | Why they needed it |
| --- | --- | --- |
| [`nadeko0/claude-code-studio`](https://github.com/nadeko0/claude-code-studio) | httpOnly cookie | browser auto-attaches it on the `EventSource` handshake |
| [`EdanStarfire/claudecode_webui`](https://github.com/EdanStarfire/claudecode_webui) | `?token=` query param | real `EventSource` can't send headers (they avoid SSE via long-poll) |
| [opencode](https://opencode.ai) | HTTP Basic | browser re-attaches creds to same-origin `EventSource` after a 401 |

We keep a `?token=` bootstrap only as a **share-a-URL** convenience (grab → store → strip from the URL), mirroring EdanStarfire's `App.vue`. Steady-state auth is always the Bearer header.

## Auth model

- **Secret**: one shared token via `MACARON_AUTH_TOKEN` (the explicit knob).
- **Frictionless localhost**: the `onRequest` hook exempts loopback peers (`req.ip` in `127.0.0.0/8` / `::1`). The local `mcc`/`mcx` CLI, `start.sh`'s health curl, and a browser on the same box never see a prompt — only remote peers are gated. This is EdanStarfire's `is_localhost` idea applied **per-request** instead of per-boot.
- **Safe by default on LAN**: binding to a non-loopback host (`MACARON_HOST=0.0.0.0`) with no token set **auto-generates** one (`crypto.randomBytes`) and logs the token + a connect URL — you can't accidentally stand up an open server. Loopback-only bind with no token → auth stays fully off (today's behavior).
- **Scope**: only `/api/*` and `/relay/*` are gated (they read your sessions, run the agent, proxy your provider key). Static assets + SPA HTML stay open so a remote browser can load the unlock screen. `/api/health` and `/api/auth/*` are exempt.
- **Constant-time** compare via `crypto.timingSafeEqual` (the prior art's plain `!=` / key lookups are the one thing worth improving).

## Changes

**Server**
- `config.ts` — `AUTH_TOKEN` env export.
- `lib/auth.ts` *(new)* — `isLoopback`, `tokensMatch` (constant-time), `resolveToken(host)` (configured token, or auto-gen on non-loopback), and `makeAuthHook(token)`.
- `routes/auth.ts` *(new)* — `GET /api/auth/status → { required }` (drives the gate) and `POST /api/auth/login { token }`.
- `index.ts` — register the hook before routes + boot `log.warn` when a token is auto-generated.

**Shared**
- `types.ts` — `AuthStatusResponse`.

**Web** (both the claude and codex bundles)
- `lib/auth.ts` *(new)* — `getToken`/`setToken`/`clearToken`, `authHeaders()`, `authedFetch()` (injects the header; on 401 clears the token and fires `macaron:auth-required`), and the `?token=` URL bootstrap.
- Every server-bound fetch → `authedFetch` / `...authHeaders()`: `lib/api.ts`, `lib/sse.ts`, `lib/liveStore.ts`, `codex/api.ts`, `codex/stream.ts`. The dev-only `/node_modules/*` fetch in `StaticGenUIRenderer` is untouched.
- `components/AuthGate.tsx` *(new)* — full-screen unlock card with **self-contained inline styles** so it renders identically under the claude paper theme and the codex zinc theme. Wraps `<RouterProvider>` in both `main.tsx` and `codex/main.tsx`.

**Docs**: `.env.example` block + a short README "Exposing on your LAN" note.

## Verification

- `npm run build` green across `shared → server → web` (4134 modules, both `index.html` + `codex.html` entries emit). Server/shared `tsc` clean.
- Manual runtime scenarios:
  1. **Default loopback boot** → no prompt, UI works as before.
  2. **`MACARON_HOST=0.0.0.0 MACARON_AUTH_TOKEN=…`** → localhost still frictionless; a LAN peer with no token gets `401`, with `Bearer <token>` or `?token=` gets `200` (streaming + `/relay/*` included); `/api/health` stays open; SPA HTML stays open; `POST /api/auth/login` validates.
  3. **`MACARON_HOST=0.0.0.0` with no token** → boots, auto-generates a token, logs the connect URL; LAN no-token `401`, generated-token `200`, loopback `200`.

## Follow-ups (intentionally out of scope)

- Single shared token, no per-user sessions/expiry. A `POST /login → session-token` exchange (nadeko0's model) is a clean follow-up if multi-user revocation is ever needed.
- No rate limit on `/api/auth/login` — acceptable for a LAN tool behind a high-entropy token.
- `trustProxy` stays `false`, so `req.ip` is the real socket peer (correct for loopback detection). Anyone fronting macaron with a reverse proxy would need to revisit that.
