### PR TITLE
Fix pkg.pr.new preview URLs

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -30,4 +30,6 @@ jobs:
       # runs `npm pack`, which fires the root `prepack` hook (build shared →
       # bundle server → build web), so the tarball ships prebuilt server/dist +
       # web/dist and runs without Vite at runtime — no separate build step needed.
-      - run: bun run pkg-pr-new publish
+      # Force long-form URLs because compact URLs require npm repository metadata;
+      # `mcc` is only published through pkg.pr.new, and --bin shows a CLI command.
+      - run: bun run pkg-pr-new publish --no-compact --bin


### PR DESCRIPTION
## Summary

- force pkg.pr.new to emit long-form `owner/repo/package@ref` preview URLs with `--no-compact`
- mark the package as a CLI preview with `--bin`, so comments show an executable command instead of an install-only command

## Why

The current pkg.pr.new comment emits compact `https://pkg.pr.new/mcc@43` URLs, but `mcc` is not published to npm with repository metadata for compact URL resolution. pkg.pr.new documents `--no-compact` as the way to force long-form URLs like `https://pkg.pr.new/tinylibs/tinybench/tinybench@a832a55`, and `--bin` as the CLI-app flag for executable preview commands.

## Verification

- `bun install --frozen-lockfile`
- `bun run pkg-pr-new publish --help`
- `bun run pkg-pr-new publish --no-compact --bin --help`
- `git diff --check`