### PR TITLE
Pin rollup platform bindings in optionalDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,10 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.5",
       },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "^4.62.2",
+      },
     },
   },
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "mcc": "bin/mcc.mjs"
+        "mcc": "bin/mcc.mjs",
+        "mcx": "bin/mcx.mjs"
       },
       "devDependencies": {
         "concurrently": "^9.1.0",
@@ -203,7 +204,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -220,7 +220,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -237,7 +236,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -254,7 +252,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -271,7 +268,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -288,7 +284,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -305,7 +300,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -322,7 +316,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -339,7 +332,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -356,7 +348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -373,7 +364,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -390,7 +380,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -407,7 +396,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -424,7 +412,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -441,7 +428,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -458,7 +444,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -475,7 +460,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -492,7 +476,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -509,7 +492,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -526,7 +508,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -543,7 +524,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -560,7 +540,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -577,7 +556,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -594,7 +572,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -611,7 +588,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -628,7 +604,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1047,6 +1022,35 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -3456,6 +3460,10 @@
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.7.0",
         "vite": "^6.0.5"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "^4.62.2"
       }
     },
     "web/node_modules/@antfu/install-pkg": {

--- a/web/package.json
+++ b/web/package.json
@@ -57,5 +57,9 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.7.0",
     "vite": "^6.0.5"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "^4.62.2",
+    "@rollup/rollup-linux-x64-gnu": "^4.62.2"
   }
 }


### PR DESCRIPTION
## Problem

On a clean `npm install`, vite/rollup crashes:

```
Error: Cannot find module @rollup/rollup-darwin-arm64
```

`web/node_modules/rollup` declares `@rollup/rollup-darwin-arm64` in its `optionalDependencies`, but npm never resolves the binding into the lockfile or installs it — a long-standing npm bug ([npm/cli#4828](https://github.com/npm/cli/issues/4828)). The result: `bun dev` / `vite build` only work if someone has previously `npm install`-ed the binding by hand.

## Fix

Declare the platform bindings as `optionalDependencies` in `web/package.json`:

```json
"optionalDependencies": {
  "@rollup/rollup-darwin-arm64": "^4.62.2",
  "@rollup/rollup-linux-x64-gnu": "^4.62.2"
}
```

This forces npm to resolve them, so they land in `package-lock.json` and get installed on every clean install. Each binding carries `os`/`cpu` fields, so only the matching platform installs — safe across macOS arm64 / Linux x64.

## Why optionalDependencies

This is the community-standard placement (facebook/lexical, kubernetes-sigs/headlamp, solidtime, discord/access, …). `devDependencies` would attempt install on every platform and warn on mismatch; `optionalDependencies` skips non-matching platforms silently.

## Verified

- Deleted `node_modules`, ran `npm install` → `@rollup/rollup-darwin-arm64/rollup.darwin-arm64.node` present ✅
- `vite build` → `✓ built in 3.17s` ✅