### PR TITLE
Lazy-import @openai/codex-sdk so the bundled tarball boots

### DIFF
--- a/server/src/lib/codex-runner.ts
+++ b/server/src/lib/codex-runner.ts
@@ -22,12 +22,11 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import {
-  Codex,
-  type CodexOptions,
-  type ThreadEvent,
-  type ThreadItem,
-  type ThreadOptions,
+import type {
+  CodexOptions,
+  ThreadEvent,
+  ThreadItem,
+  ThreadOptions,
 } from '@openai/codex-sdk';
 import { getCodexConfig } from './codex-config.js';
 import type { RunnerEvent, AttachedImage } from './claude-runner.js';
@@ -286,6 +285,10 @@ export async function* runCodex(opts: CodexRunOptions): AsyncGenerator<RunnerEve
   void (async () => {
     let sessionEmitted = false;
     try {
+      // Lazy-import so the default (claude) engine never loads @openai/codex-sdk
+      // — the bundled tarball (server/dist/index.js only) has no node_modules, so
+      // a top-level import would crash boot with ERR_MODULE_NOT_FOUND.
+      const { Codex } = await import('@openai/codex-sdk');
       const codex = new Codex(codexOpts);
       const thread = opts.resume
         ? codex.resumeThread(opts.resume, { ...threadOpts, workingDirectory: opts.cwd })


### PR DESCRIPTION
## Problem

`bunx mcc@<pkg.pr.new tarball>` crashes on boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@openai/codex-sdk' imported from .../mcc/server/dist/index.js
```

The bundle uses `--packages=external`, so `@openai/codex-sdk` stays a runtime import resolved from `node_modules`. But the published tarball ships **only** `server/dist/index.js` (+ `web/dist`, `bin`) — no `node_modules`. `codex-runner.ts` had a top-level `import { Codex }`, so **every** boot loaded codex-sdk — including the default claude engine, which never uses codex.

## Fix

Move `Codex` to a dynamic import inside `runCodex()`; the type-only imports stay top-level (erased at build time). The default engine never reaches `runCodex`, so it never loads codex-sdk — and the codex engine still works (it lazy-imports on first use).

## Verified

- `server/dist/index.js` no longer has a top-level `@openai/codex-sdk` import (only `await import(...)` inside `runCodex`)
- Booted with `@openai/codex-sdk` **removed** from `node_modules` (simulating the tarball) → `Server listening` + `/api/workspaces` 200 ✅
- `tsc --noEmit` clean