### PR TITLE
Keep composers editable while sending

### DIFF
--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -296,7 +296,7 @@ export function CodexChat(props: CodexChatProps = {}) {
             onStop={stop}
             disabled={sending}
             running={sending && !isNew}
-            placeholder={sending ? 'Codex is working…' : undefined}
+            placeholder={sending ? 'Draft next message…' : undefined}
           />
         </div>
       </div>

--- a/web/src/codex/CodexComposer.tsx
+++ b/web/src/codex/CodexComposer.tsx
@@ -41,7 +41,6 @@ export function CodexComposer({
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={key}
           placeholder={placeholder ?? 'Message Codex…'}
-          disabled={disabled}
           rows={1}
         />
         {running && onStop ? (

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -1603,7 +1603,7 @@ export function Session(props: SessionProps = {}) {
         )}
         <textarea
           rows={2}
-          placeholder="Reply to Claude…"
+          placeholder={sending ? 'Draft next message…' : 'Reply to Claude…'}
           value={input}
           onChange={(e) => {
             setInput(e.target.value);

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -1605,7 +1605,6 @@ export function Session(props: SessionProps = {}) {
           rows={2}
           placeholder="Reply to Claude…"
           value={input}
-          disabled={sending}
           onChange={(e) => {
             setInput(e.target.value);
             // Any manual edit exits history-navigation mode — pressing


### PR DESCRIPTION
## Summary

- Keep both Claude and Codex composer textareas editable while a turn is running
- Preserve existing guards so Enter/click Send still cannot submit another message during `sending`

## Verification

- `bun install --frozen-lockfile`
- `cd shared && bun run typecheck`
- `cd shared && bun run build`
- `cd server && bun run typecheck`
- `cd web && bun run build`

Note: root `bun run typecheck` recurses under Bun because the root script forwards workspace flags back into itself, so I verified the relevant workspaces directly.