### PR TITLE
Recover session cwd from a tail read when a big paste truncates the head

### DIFF
--- a/server/src/lib/session-store.ts
+++ b/server/src/lib/session-store.ts
@@ -35,6 +35,7 @@ type CacheEntry = { mtimeMs: number; size: number; summary: SessionSummary };
 // File-keyed mtime cache so we only re-parse jsonl when claude appends to it.
 const summaryCache = new Map<string, CacheEntry>();
 const HEAD_BYTES = 96 * 1024;
+const CWD_TAIL_BYTES = 64 * 1024;
 
 export async function deleteSession(project: string, sid: string): Promise<void> {
   const filePath = path.join(CLAUDE_PROJECTS, project, `${sid}.jsonl`);
@@ -238,6 +239,40 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
     }
   } catch {
     /* swallow */
+  }
+
+  // cwd sits at the END of each jsonl line (after `message`), so a huge first
+  // paste can push the head's only cwd-bearing line past HEAD_BYTES, truncating
+  // it unparseably. The same cwd repeats on every later line, and trailing lines
+  // are usually small — so when the head read came up empty on a truncated file,
+  // recover cwd (and gitBranch) from a tail read instead.
+  if (summary.truncated && !summary.cwd) {
+    try {
+      const fh = await fs.open(filePath, 'r');
+      try {
+        const len = Math.min(st.size, CWD_TAIL_BYTES);
+        const buf = Buffer.alloc(len);
+        await fh.read(buf, 0, len, st.size - len);
+        const text = buf.toString('utf8');
+        const lines = text.split('\n');
+        // Drop the first slice — it's a partial line cut by the seek offset.
+        for (let i = 1; i < lines.length; i++) {
+          const line = lines[i]!;
+          if (!line.trim()) continue;
+          try {
+            const o = JSON.parse(line);
+            if (o.cwd) summary.cwd = o.cwd;
+            if (!summary.gitBranch && o.gitBranch) summary.gitBranch = o.gitBranch;
+          } catch {
+            /* skip malformed line */
+          }
+        }
+      } finally {
+        await fh.close();
+      }
+    } catch {
+      /* swallow — fall back to decoded project name upstream */
+    }
   }
 
   summaryCache.set(filePath, { mtimeMs: st.mtimeMs, size: st.size, summary });


### PR DESCRIPTION
## Problem

Opening or messaging certain sessions silently does nothing — follow-up chips never appear, and `/message` runs `claude --resume` in the wrong directory. The root cause is cwd resolution, not the model.

`readSessionSummary` reads only the first `HEAD_BYTES` (96 KB) of a jsonl and `JSON.parse`s each **complete** line to harvest `cwd`. claude-cli writes `cwd` at the **end** of every user/assistant line — after `message`, whose `content` can hold a huge paste. When a session's first message is a giant paste (the line runs 98 KB–883 KB), that line is truncated by the 96 KB window, fails to parse, and its trailing `cwd` is lost. No later complete line fits in the window either, so `summary.cwd` comes back empty.

Both consumers then fall back to `decodeClaudeProjectName`, which is **lossy** — it turns every `-` into `/`, so `…-macaron-macaron-claude-code` decodes to `/Users/muspi/merol/Desktop/macaron/macaron/claude/code`, a path that doesn't exist. `resolveSessionCwd` returns that, `claude --resume` starts in a bogus dir, and the follow-up stream yields nothing and dies silently.

## Fix

Add a tail fallback inside `readSessionSummary`: when the file was `truncated` **and** `cwd` is still empty, do one seek-to-EOF read (64 KB), drop the partial leading line, and scan the complete trailing lines for `cwd` (backfilling `gitBranch` too). Mirrors the existing `SESSION_TAIL_BYTES` tail read in `readSessionMessages`.

- **Fires only on the pathology** — guarded by `truncated && !summary.cwd`. The head-success sessions never pay for it, so no hot-path regression despite `listAllSessions` calling this at 32-way concurrency.
- **Fixes both consumers at once** — `resolveSessionCwd` and the new-session cwd derivation in `routes/workspaces.ts` both read `readSessionSummary().cwd`; putting the fallback in the shared reader repairs both with zero call-site changes.
- **Cache-safe** — result is still stored in `summaryCache` keyed by mtime+size, so the tail read happens once per file version.

https://github.com/mindverse-ltd/macaron-claude-code/blob/e81509d141ba1cd9f8764e767bd7b221895c1796/server/src/lib/session-store.ts#L244-L276

## Verification

- **Whole-corpus simulation** over all 507 local sessions: source split is `head 489 / tail 15 / none 3`, zero head-resolving sessions regress. The 3 `none` are degenerate `mcc-test` files with no `cwd` anywhere — decoded-name fallback is correct there.
- **Real-corpus function-level check** on the `macaron-claude-code` project (37 sessions): before → `/Users/muspi/merol/Desktop/macaron/macaron/claude/code` (does not exist); after → `/Users/muspi-merol/Desktop/macaron/macaron-claude-code` (real). All 15 paste-truncated sessions rescued.
- `tsc --noEmit` → exit 0.

## Not in scope

`decodeClaudeProjectName`'s lossiness itself — it's a last-resort fallback and can't be made lossless from the encoded name alone (`-` is ambiguously a separator or a literal dash). The tail read removes reliance on it for the real cases.