### PR TITLE
Fix pnpm setup version mismatch

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.4
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
Closes [MAC-7839](https://multica.macaron.xin/issues/3b939b5f-90f3-4308-a837-09d1a559c2ed "Fix pnpm version mismatch breaking macaron-claude-code CI across PR branches")

## Summary

- remove the conflicting pnpm version from the pkg.pr.new workflow
- let pnpm/action-setup use the canonical pnpm@10.28.2 declaration in package.json

## Verification

- git diff --check
- confirmed the workflow no longer declares pnpm 10.34.4
