### PR TITLE
Restore queue handlers dropped by the queue merge on main

### DIFF
--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -1846,6 +1846,77 @@ export function Session(props: SessionProps = {}) {
     [project, sid, input, sending, load, images, permissionMode, isolate, isNew, navigate, toast, onCreated, rollLiveIntoHistory, history],
   );
 
+  // Enqueue a message typed while a turn is running. macaron's runner is
+  // single-shot (no stdin into the live turn), so we hold it client-side and
+  // auto-send it once the turn finishes.
+  const enqueue = useCallback((text: string) => {
+    const t = text.trim();
+    if (!t) return;
+    setQueue((q) => [...q, { id: queueId(), text: t }]);
+  }, []);
+
+  // The composer's submit path: while a turn runs, Enter/Send queues the text
+  // instead of being blocked; when idle it sends immediately. Images ride the
+  // immediate path only (first increment), so they stay attached while busy.
+  const submitComposer = useCallback(() => {
+    const text = input.trim();
+    if (!text && images.length === 0) return;
+    if (sending) {
+      if (!text) return; // nothing queueable (images can't be queued yet)
+      enqueue(text);
+      setInput('');
+      setHistoryIdx(null);
+      draftInputRef.current = '';
+      return;
+    }
+    void send();
+  }, [input, images, sending, enqueue, send]);
+
+  // Send now: interrupt the running turn and send this message next. macaron's
+  // only interrupt primitive is /stop (abort the subprocess), so we push the
+  // text to the FRONT of the queue and stop — the idle-edge dequeue effect
+  // below then sends it first. Graceful mid-tool steer would need the SDK's
+  // streaming-input mode, which the single-shot runner doesn't use (follow-up).
+  const handleSendNow = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+    setQueue((q) => [{ id: queueId('q-now'), text }, ...q]);
+    setInput('');
+    setHistoryIdx(null);
+    draftInputRef.current = '';
+    void handleStop();
+  }, [input, handleStop]);
+
+  const removeQueued = useCallback((id: string) => {
+    setQueue((q) => q.filter((m) => m.id !== id));
+  }, []);
+
+  const moveQueued = useCallback((id: string, dir: -1 | 1) => {
+    setQueue((q) => {
+      const i = q.findIndex((m) => m.id === id);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= q.length) return q;
+      const next = [...q];
+      [next[i], next[j]] = [next[j]!, next[i]!];
+      return next;
+    });
+  }, []);
+
+  // Edit a queued message: pull it back into the composer (removing it from
+  // the queue). If the composer already holds a draft, keep that safe by
+  // prepending it back onto the queue front.
+  const editQueued = useCallback((id: string) => {
+    setQueue((q) => {
+      const target = q.find((m) => m.id === id);
+      if (!target) return q;
+      const rest = q.filter((m) => m.id !== id);
+      const draft = input.trim();
+      setInput(target.text);
+      if (draft) return [{ id: queueId('q-draft'), text: draft }, ...rest];
+      return rest;
+    });
+  }, [input]);
+
   // Idle-edge dequeue: when a turn finishes (running true→false), auto-send the
   // next queued message. Edge-guarded so exactly one message goes per turn —
   // send() flips `sending` back to true synchronously, re-arming the guard.


### PR DESCRIPTION
## What

Restores six composer/queue handlers — `enqueue`, `submitComposer`, `handleSendNow`, `removeQueued`, `moveQueued`, `editQueued` — that are **referenced but never defined** on `main` (`web/src/views/Session.tsx`).

## Why

The message-queueing feature landed on `main` via `bf1aa9a` referencing these handlers (`submitComposer()` on Enter/submit, `onRemove`/`onMove`/`onEdit` wired to `PendingQueue`, `handleSendNow` on the send-now button) but the merge dropped their definitions. `main` therefore does not typecheck, and the composer would `ReferenceError` on submit at runtime. CI (`pkg.pr.new`) only runs the vite/esbuild publish, which tolerates free identifiers, so it landed green.

Surfaced by the incremental review of macaron-claude-code#64's conflict-resolution merge ([MAC-7787](https://multica.macaron.xin/issues/3b4c35bb-6763-4935-ab6d-0b57920e2cd3 "Review the conflict-resolution merge delta on PR #64 (merge 31cbb6a)")) — the #64 merge restored these on its own branch, but plain `main` (now at `2d10bed`) is still broken, and #64 no longer merges cleanly. This is the minimal direct fix.

## Fix

Ported the handler block verbatim from the original complete queue PR `d9926d7`, inserted right after `send()` (before the idle-edge dequeue effect that already exists on `main`). Two mechanical adaptations to match current `main`:

- Uses `main`'s existing `queueId(prefix)` helper instead of `d9926d7`'s inlined `` `${prefix}-${Date.now()}-…` `` id generation — same id shape, behavior-preserving.
- No `mention.close()` calls (that's macaron-claude-code#64's autocomplete feature, not on `main`).

`submitComposer` calls `void send()` with no args (main's `send(opts?)` treats absent `opts` as the user submitting the draft), and `handleSendNow` front-loads the queue then `handleStop()`s so the dequeue effect sends it next — matching main's opts-based programmatic-send contract.

## Verification

- Before: `tsc -b web` reports 6 `TS2304: Cannot find name` errors on `Session.tsx` (`submitComposer` ×2, `removeQueued`, `moveQueued`, `editQueued`, `handleSendNow`).
- After: those 6 errors are gone; no new `src/**` errors introduced.

(This env can't run the full pnpm@10 install — needs Node 22 — so the run also shows pre-existing `Cannot find module 'react'` install noise unrelated to this change; the handler-resolution errors are the signal, and they're resolved.)

## Follow-up (out of scope)

`main` has no `tsc` gate in CI, which is why broken TypeScript merges green. Worth adding a typecheck step to the PR workflow so this class of drop is caught.
