### PR TITLE
fix session actions menu clipping

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1743,10 +1743,11 @@ textarea:focus, select:focus, input:focus {
   flex-direction: column;
 }
 /* The clip above drives the focus collapse/expand animation, but it also
-   traps the slash palette (which floats above the composer). Only while the
-   palette is present, let the container overflow so the menu is visible; the
-   tile ancestors stay overflow:hidden, so nothing escapes the tile itself. */
-.session-input-inner:has(.slash-palette) {
+   traps menus that float above the composer. While one is present, let the
+   container overflow so every row stays clickable; tile ancestors still keep
+   the content inside the tile. */
+.session-input-inner:has(.slash-palette),
+.session-input-inner:has(.actions-menu) {
   overflow: visible;
 }
 .session-input-area.collapsed {


### PR DESCRIPTION
Fix the session actions dropdown being clipped by the composer animation container. The menu now receives the same temporary overflow exception as the slash palette, keeping Create PR and Export visible and pointer-clickable.

Validation:
- `pnpm --filter @macaron/web build`
- Browser smoke on a local git/session fixture: direct pointer click opens the Create pull request dialog with the expected feature branch, main base, and one-commit count
- No browser page errors

Closes [MAC-7960](https://multica.macaron.xin/issues/90bea9a7-2976-4eb9-a435-f970695ffdff "Resolve, validate, and squash-merge macaron-claude-code PRs")