### PR TITLE
include bundled server runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "croner": "^10.0.1",
     "fastify": "^5.2.0",
     "ignore": "^7.0.5",
+    "node-pty": "^1.1.0",
     "typescript": "^5.7.0",
+    "web-push": "^3.6.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,15 @@ importers:
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add `node-pty` and `web-push` to the root runtime dependencies shipped by the `mcc` tarball. The server bundle externalizes both packages, so consumers must install them from the published root manifest.

Validation:
- `pnpm pack --pack-destination /tmp/mcc-pack-7960`
- Installed the generated tarball into a clean prefix
- Launched the installed `server/dist/index.js` on an isolated home/port
- `/api/health` returned 200

Closes [MAC-7960](https://multica.macaron.xin/issues/90bea9a7-2976-4eb9-a435-f970695ffdff "Resolve, validate, and squash-merge macaron-claude-code PRs")