### PR TITLE
remove duplicate Remote access card

### DIFF
--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -355,7 +355,6 @@ export function Settings() {
         </label>
       </div>
 
-      <RemoteAccess />
       <ConfigFilesSection />
       <RemoteAccess />
 


### PR DESCRIPTION
PR #63 merged before the requested smoke-test follow-up could be pushed, so this is the minimal post-merge fix.

- Removes the merge-added duplicate `RemoteAccess` instance.
- Keeps the original instance after `ConfigFilesSection`.
- Eliminates the duplicate tunnel polling and controls along with the duplicate card.

Verification:

- `pnpm run build` passes.
- Browser DOM count finds exactly one `Remote access` heading on the full Settings page.
- Full-page browser capture at 1440 px wide shows one Remote access card and no browser errors.
- Root `typecheck` reaches the web package, then fails on pre-existing latest-main GenUI vendor dependency/type-path errors unrelated to `Settings.tsx`; shared and server typechecks pass.

Related smoke-test issue: [MAC-7915](https://multica.macaron.xin/issues/adebe247-7383-445c-b6f8-0b857057c15a "Smoke test PR #63: Add zero-config remote access via cloudflared/ngrok tunnels").
