### PR TITLE
Add native Codex app-server plan + approval UX

### DIFF
--- a/server/src/lib/active-approvals.ts
+++ b/server/src/lib/active-approvals.ts
@@ -1,0 +1,27 @@
+// In-memory registry of the approval responder for each in-flight app-server
+// turn, keyed by sessionId. The /approval route looks up the handler and calls
+// it with the user's decision; the runner replies on the parked JSON-RPC
+// request. Mirrors active-runs.ts (the abort registry) but for the codex
+// app-server approval channel.
+
+import type { CodexDecision } from '@macaron/shared';
+
+// Returns true if the approval id was live and answered, false if it was
+// already resolved / unknown (client raced with the server clearing it).
+export type ApprovalHandler = (approvalId: string, decision: CodexDecision) => boolean;
+
+const handlers = new Map<string, ApprovalHandler>();
+
+export function registerApprovalHandler(sid: string, handler: ApprovalHandler): void {
+  handlers.set(sid, handler);
+}
+
+export function clearApprovalHandler(sid: string): void {
+  handlers.delete(sid);
+}
+
+export function respondCodexApproval(sid: string, approvalId: string, decision: CodexDecision): boolean {
+  const handler = handlers.get(sid);
+  if (!handler) return false;
+  return handler(approvalId, decision);
+}

--- a/server/src/lib/claude-runner.ts
+++ b/server/src/lib/claude-runner.ts
@@ -8,6 +8,7 @@ import { macaronMcpServer } from './macaron-mcp.js';
 import { registerPending } from './permission-registry.js';
 import { computeRuleKeys, isAllowed, rememberSession, rememberProject } from './permission-rules.js';
 import { getYoloMode } from './settings-store.js';
+import type { CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
 
 export type AttachedImage = { mimeType: string; dataUrl: string };
 
@@ -39,6 +40,12 @@ export type RunnerEvent =
   // does no command parsing); absent when there's nothing rememberable.
   | { kind: 'permission_request'; id: string; toolName: string; input: unknown; suggestion?: { label: string } }
   | { kind: 'permission_resolved'; id: string; decision: 'allow' | 'deny' }
+  // Codex-native plan + approval events. Only the codex app-server runner emits
+  // these; they carry the shared SSE payload verbatim so the route can relay
+  // them without re-shaping. See shared/src/sse.ts for field semantics.
+  | { kind: 'codex_plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
+  | { kind: 'codex_approval_request'; id: string; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  | { kind: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }
   | { kind: 'error'; error: string }
   | { kind: 'done'; exitCode: number };
 

--- a/server/src/lib/codex-app-server.test.ts
+++ b/server/src/lib/codex-app-server.test.ts
@@ -1,12 +1,43 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { normalizeDecisions } from './codex-app-server.js';
+import { normalizeDecisions, buildApprovalResponseFrame } from './codex-app-server.js';
 import {
   registerApprovalHandler,
   clearApprovalHandler,
   respondCodexApproval,
 } from './active-approvals.js';
 import type { CodexDecision } from '@macaron/shared';
+
+// --- approval response wire shape (transport-level) -------------------------
+
+// app-server does not use JSON-RPC response envelopes. The reply must echo the
+// request method + id with a `response: { decision }` payload; a `{jsonrpc,id,
+// result}` frame is silently dropped and leaves the turn parked. Assert the
+// exact bytes written to stdout for both approval kinds.
+test('buildApprovalResponseFrame emits the app-server response shape, not JSON-RPC', () => {
+  const line = buildApprovalResponseFrame(10, 'item/commandExecution/requestApproval', 'accept');
+  assert.equal(line.endsWith('\n'), true);
+  const parsed = JSON.parse(line);
+  assert.deepEqual(parsed, {
+    method: 'item/commandExecution/requestApproval',
+    id: 10,
+    response: { decision: 'accept' },
+  });
+  // Must NOT be a JSON-RPC response envelope.
+  assert.equal('jsonrpc' in parsed, false);
+  assert.equal('result' in parsed, false);
+});
+
+test('buildApprovalResponseFrame echoes the file-approval method and each decision', () => {
+  for (const d of ['accept', 'acceptForSession', 'decline', 'cancel'] as CodexDecision[]) {
+    const parsed = JSON.parse(buildApprovalResponseFrame('t1:5', 'item/fileChange/requestApproval', d));
+    assert.deepEqual(parsed, {
+      method: 'item/fileChange/requestApproval',
+      id: 't1:5',
+      response: { decision: d },
+    });
+  }
+});
 
 // --- normalizeDecisions: availableDecisions → plain CodexDecision[] ---------
 

--- a/server/src/lib/codex-app-server.test.ts
+++ b/server/src/lib/codex-app-server.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { normalizeDecisions } from './codex-app-server.js';
+import {
+  registerApprovalHandler,
+  clearApprovalHandler,
+  respondCodexApproval,
+} from './active-approvals.js';
+import type { CodexDecision } from '@macaron/shared';
+
+// --- normalizeDecisions: availableDecisions → plain CodexDecision[] ---------
+
+test('normalizeDecisions keeps the four known plain decisions', () => {
+  assert.deepEqual(
+    normalizeDecisions(['accept', 'acceptForSession', 'decline', 'cancel']),
+    ['accept', 'acceptForSession', 'decline', 'cancel'],
+  );
+});
+
+test('normalizeDecisions drops amendment objects but keeps sibling strings', () => {
+  const available = ['accept', { acceptWithExecpolicyAmendment: { foo: 1 } }, 'decline'];
+  assert.deepEqual(normalizeDecisions(available), ['accept', 'decline']);
+});
+
+test('normalizeDecisions falls back when nothing usable is offered', () => {
+  assert.deepEqual(normalizeDecisions(undefined), ['accept', 'decline', 'cancel']);
+  assert.deepEqual(normalizeDecisions([{ onlyAmendments: true }]), ['accept', 'decline', 'cancel']);
+});
+
+// --- approval correlation + every decision routes back correctly ------------
+
+// Model the runner's handler: it holds a map of approvalId → JSON-RPC requestId
+// and replies on the matching request. The test asserts the /approval route's
+// respondCodexApproval reaches the right parked request for every decision, and
+// that a stale/unknown id returns false.
+test('respondCodexApproval correlates each decision to its parked request', () => {
+  const sid = 'thread-1';
+  const replies: Array<{ requestId: number; decision: CodexDecision }> = [];
+  const pending = new Map<string, number>([
+    ['thread-1:10', 10],
+    ['thread-1:11', 11],
+  ]);
+  registerApprovalHandler(sid, (approvalId, decision) => {
+    const requestId = pending.get(approvalId);
+    if (requestId === undefined) return false;
+    replies.push({ requestId, decision });
+    pending.delete(approvalId);
+    return true;
+  });
+
+  const all: CodexDecision[] = ['accept', 'acceptForSession', 'decline', 'cancel'];
+  // Same request answered by each decision in turn (re-seed so the id stays live).
+  for (const d of all) {
+    pending.set('thread-1:10', 10);
+    assert.equal(respondCodexApproval(sid, 'thread-1:10', d), true);
+    assert.deepEqual(replies.at(-1), { requestId: 10, decision: d });
+  }
+
+  // A second concurrent request routes to its own id, not the first.
+  assert.equal(respondCodexApproval(sid, 'thread-1:11', 'accept'), true);
+  assert.equal(replies.at(-1)!.requestId, 11);
+
+  // Answering an already-cleared id (server raced us) reports not-live.
+  assert.equal(respondCodexApproval(sid, 'thread-1:11', 'accept'), false);
+
+  clearApprovalHandler(sid);
+  // After the turn ends the handler is gone: the route reports not-live.
+  assert.equal(respondCodexApproval(sid, 'thread-1:10', 'accept'), false);
+});
+
+test('respondCodexApproval isolates handlers per session', () => {
+  registerApprovalHandler('a', () => true);
+  assert.equal(respondCodexApproval('b', 'a:1', 'accept'), false);
+  clearApprovalHandler('a');
+});

--- a/server/src/lib/codex-app-server.ts
+++ b/server/src/lib/codex-app-server.ts
@@ -97,8 +97,16 @@ export function normalizeDecisions(available: unknown): CodexDecision[] {
   return out.length ? out : ['accept', 'decline', 'cancel'];
 }
 
-type Pending = { requestId: string | number };
+type Pending = { requestId: string | number; method: string };
 type CodexProc = ChildProcessByStdio<Writable, Readable, null>;
+
+// The exact stdout line the runner writes to answer a server approval request.
+// app-server does NOT use JSON-RPC response envelopes ({jsonrpc,id,result}); a
+// reply echoes the request `method` and `id` with a `response: { decision }`
+// payload. Exported so a transport-level test can assert the wire shape.
+export function buildApprovalResponseFrame(id: string | number, method: string, decision: CodexDecision): string {
+  return `${JSON.stringify({ method, id, response: { decision } })}\n`;
+}
 
 export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerEvent> {
   const queue: RunnerEvent[] = [];
@@ -125,6 +133,7 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
   void (async () => {
     let tmpFiles: string[] = [];
     let sid: string | null = opts.resume ?? null;
+    let turnId: string | null = null;
     let proc: CodexProc | null = null;
     // Our approval-request id → the JSON-RPC request id we must reply on. Keyed
     // by a stable string (`<sid>:<requestId>`) so a reconnecting client and the
@@ -151,16 +160,34 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
       const sendNotify = (method: string, params: unknown) => {
         proc!.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
       };
-      const respondTo = (id: string | number, result: unknown) => {
-        proc!.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
+      // Reply to a server-initiated approval request. app-server does NOT use
+      // standard JSON-RPC response envelopes: a reply echoes the request method
+      // and id alongside a `response` payload, not `{ result }`. Getting this
+      // wrong leaves the turn parked while our card optimistically disables.
+      const respondApproval = (id: string | number, method: string, decision: CodexDecision) => {
+        proc!.stdin.write(buildApprovalResponseFrame(id, method, decision));
       };
 
-      // Abort → interrupt the active turn, then let the stream close.
+      // Abort → interrupt the active turn natively (turn/interrupt needs both
+      // threadId and turnId), then let the turn/failed|completed notification
+      // drive the stream close. A bounded timer force-kills the process if the
+      // server never acknowledges the interrupt, so a wedged app-server can't
+      // hang the request forever.
       opts.abortController?.signal.addEventListener('abort', () => {
-        try { if (sid) sendNotify('turn/interrupt', { threadId: sid }); } catch { /* closing */ }
-        push({ kind: 'done', exitCode: 130 });
-        cleanup();
-        finish();
+        if (ended) return;
+        if (sid && turnId) {
+          try { sendRequest('turn/interrupt', { threadId: sid, turnId }); } catch { /* closing */ }
+          setTimeout(() => {
+            if (ended) return;
+            push({ kind: 'done', exitCode: 130 });
+            cleanup();
+            finish();
+          }, 2000);
+        } else {
+          push({ kind: 'done', exitCode: 130 });
+          cleanup();
+          finish();
+        }
       });
 
       // Register the approval channel once we know the sid. Answers the parked
@@ -171,7 +198,7 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
         registerApprovalHandler(sid, (approvalId: string, decision: CodexDecision) => {
           const p = pending.get(approvalId);
           if (!p) return false;
-          respondTo(p.requestId, { decision });
+          respondApproval(p.requestId, p.method, decision);
           pending.delete(approvalId);
           push({ kind: 'codex_approval_resolved', id: approvalId, decision });
           return true;
@@ -180,6 +207,10 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
 
       // --- item translation (item/started + item/completed) ----------------
       const emittedToolUse = new Set<string>();
+      // Proposed file changes keyed by item id, captured from the fileChange
+      // item so the fileChange approval request (which carries only an itemId)
+      // can render the actual diff instead of an empty card.
+      const fileChangesByItem = new Map<string, Array<{ path: string; kind: string; diff?: string }>>();
       const handleItem = (phase: 'started' | 'completed', item: Record<string, unknown>) => {
         const type = item.type as string;
         const id = String(item.id ?? '');
@@ -198,7 +229,8 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
             push({ kind: 'tool_result', tool_use_id: id, text: String(item.aggregatedOutput ?? `(exit ${item.exitCode ?? '?'})`), isError: item.status === 'failed' || (Number(item.exitCode ?? 0) !== 0) });
           }
         } else if (type === 'fileChange') {
-          const changes = (item.changes as Array<{ path: string; kind: string }>) ?? [];
+          const changes = (item.changes as Array<{ path: string; kind: string; diff?: string }>) ?? [];
+          fileChangesByItem.set(id, changes);
           if (!emittedToolUse.has(id)) { emittedToolUse.add(id); push({ kind: 'tool_use', id, name: 'Edit', input: { changes } }); }
           if (phase === 'completed') {
             const summary = changes.map((c) => `${c.kind === 'add' ? '＋' : c.kind === 'delete' ? '－' : '△'} ${c.path}`).join('\n');
@@ -225,10 +257,11 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
           const method = msg.method as string;
           const params = (msg.params ?? {}) as Record<string, unknown>;
           const approvalId = `${sid ?? params.threadId}:${msg.id}`;
-          pending.set(approvalId, { requestId: msg.id as string | number });
+          pending.set(approvalId, { requestId: msg.id as string | number, method });
           registerApprovals();
           if (method === 'item/fileChange/requestApproval') {
-            push({ kind: 'codex_approval_request', id: approvalId, approval: 'file', reason: (params.reason as string) ?? null, grantRoot: (params.grantRoot as string) ?? null, fileChanges: undefined, available: normalizeDecisions(params.availableDecisions) });
+            const changes = fileChangesByItem.get(String(params.itemId ?? ''));
+            push({ kind: 'codex_approval_request', id: approvalId, approval: 'file', reason: (params.reason as string) ?? null, grantRoot: (params.grantRoot as string) ?? null, fileChanges: changes, available: normalizeDecisions(params.availableDecisions) });
           } else {
             const net = params.networkApprovalContext as { host: string; protocol: string } | null | undefined;
             push({
@@ -254,6 +287,7 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
             break;
           }
           case 'turn/started':
+            turnId = (params.turn as { id?: string } | undefined)?.id ?? null;
             push({ kind: 'message', subtype: 'codex_turn_started' });
             break;
           case 'item/started':

--- a/server/src/lib/codex-app-server.ts
+++ b/server/src/lib/codex-app-server.ts
@@ -1,0 +1,350 @@
+// Codex runner over the `codex app-server` JSON-RPC transport (stdio), the
+// bidirectional protocol the SDK's one-shot `codex exec` surface can't do.
+// It gives us the two things MAC-8129 needs and the SDK lacks: live
+// `turn/plan/updated` events and interactive command/file/network approval
+// requests we can answer mid-turn.
+//
+// Shape mirrors codex-runner.ts (runCodex): one process per turn, translated
+// 1:1 into the shared RunnerEvent stream so the SSE route and client don't
+// know which transport produced them. The extra surface is the approval
+// channel — an in-flight run registers itself in `active-approvals` keyed by
+// sid, and the /approval route calls respondCodexApproval() to send the
+// user's decision back over the same stdio pipe.
+//
+// Protocol reference: `codex app-server generate-ts` (verified empirically
+// against codex-cli 0.144.1). Handshake is initialize → initialized →
+// thread/start|thread/resume → turn/start; the server drives the turn with
+// notifications and pauses on `item/*/requestApproval` server requests.
+
+import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import type { Writable, Readable } from 'node:stream';
+import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { getActiveCodexProvider, getCodexConfig } from './codex-config.js';
+import { CODEX_BINARY, MACARON_MCP_CMD, MACARON_MCP_ARGS, type CodexRunOptions } from './codex-runner.js';
+import { registerApprovalHandler, clearApprovalHandler } from './active-approvals.js';
+import type { RunnerEvent } from './claude-runner.js';
+import type { CodexDecision } from '@macaron/shared';
+
+// Flat config map (dotted keys → JSON values) plus the top-level thread knobs.
+// Same values codex-runner feeds the SDK, reshaped for thread/start params.
+function buildAppServerConfig(): { config: Record<string, unknown>; model?: string; sandbox: string; approvalPolicy: string; modelProvider?: string } {
+  const s = getCodexConfig();
+  const p = getActiveCodexProvider();
+  const config: Record<string, unknown> = {
+    'mcp_servers.macaron.command': MACARON_MCP_CMD,
+    'mcp_servers.macaron.args': MACARON_MCP_ARGS,
+    'mcp_servers.macaron.default_tools_approval_mode': 'approve',
+    network_access: 'enabled',
+  };
+  if (!p) {
+    return { config, sandbox: s.runtime.sandboxMode, approvalPolicy: s.runtime.approvalPolicy };
+  }
+  Object.assign(config, {
+    model_provider: p.modelProvider,
+    model: p.model,
+    review_model: p.model,
+    model_reasoning_effort: p.reasoningEffort,
+    model_context_window: p.contextWindow,
+    model_auto_compact_token_limit: p.autoCompactTokenLimit,
+    disable_response_storage: p.disableResponseStorage,
+    [`model_providers.${p.modelProvider}.name`]: p.modelProvider,
+    [`model_providers.${p.modelProvider}.base_url`]: p.baseUrl,
+    [`model_providers.${p.modelProvider}.wire_api`]: p.wireApi,
+    [`model_providers.${p.modelProvider}.experimental_bearer_token`]: p.apiKey,
+  });
+  return { config, model: p.model, modelProvider: p.modelProvider, sandbox: s.runtime.sandboxMode, approvalPolicy: s.runtime.approvalPolicy };
+}
+
+const IMAGE_EXT: Record<string, string> = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/gif': 'gif', 'image/webp': 'webp' };
+
+// UserInput[] in app-server shape ({type:'text'} / {type:'localImage'}). Codex
+// can't take inline data URLs, so images are written to temp files the caller
+// removes once the turn ends.
+function buildAppServerInput(opts: CodexRunOptions): { input: unknown[]; tmpFiles: string[] } {
+  const items: unknown[] = [];
+  const tmpFiles: string[] = [];
+  for (const img of opts.images ?? []) {
+    const m = /^data:([^;]+);base64,(.*)$/.exec(img.dataUrl);
+    const mime = m?.[1] || img.mimeType || 'image/png';
+    const data = m?.[2] || '';
+    if (!data) continue;
+    const file = path.join(os.tmpdir(), `macaron-codex-${randomUUID()}.${IMAGE_EXT[mime] || 'png'}`);
+    writeFileSync(file, Buffer.from(data, 'base64'));
+    tmpFiles.push(file);
+    items.push({ type: 'localImage', path: file });
+  }
+  if (opts.prompt) items.push({ type: 'text', text: opts.prompt, text_elements: [] });
+  return { input: items, tmpFiles };
+}
+
+// Map the app-server's `availableDecisions` (mixed strings + amendment
+// objects) down to the plain decision set the UI renders. Amendment variants
+// (acceptWithExecpolicyAmendment, applyNetworkPolicyAmendment) collapse to a
+// single `acceptForSession`-adjacent option is out of scope — we keep the
+// four plain decisions and let the client show whichever were offered.
+export function normalizeDecisions(available: unknown): CodexDecision[] {
+  const known: CodexDecision[] = ['accept', 'acceptForSession', 'decline', 'cancel'];
+  if (!Array.isArray(available)) return ['accept', 'decline', 'cancel'];
+  const out: CodexDecision[] = [];
+  for (const d of available) {
+    if (typeof d === 'string' && (known as string[]).includes(d)) out.push(d as CodexDecision);
+  }
+  return out.length ? out : ['accept', 'decline', 'cancel'];
+}
+
+type Pending = { requestId: string | number };
+type CodexProc = ChildProcessByStdio<Writable, Readable, null>;
+
+export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerEvent> {
+  const queue: RunnerEvent[] = [];
+  const waiters: Array<(v: IteratorResult<RunnerEvent>) => void> = [];
+  let ended = false;
+  const push = (ev: RunnerEvent) => {
+    const w = waiters.shift();
+    if (w) w({ value: ev, done: false });
+    else queue.push(ev);
+  };
+  const finish = () => {
+    ended = true;
+    while (waiters.length) waiters.shift()!({ value: undefined as unknown as RunnerEvent, done: true });
+  };
+  const next = (): Promise<IteratorResult<RunnerEvent>> => {
+    if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+    if (ended) return Promise.resolve({ value: undefined as unknown as RunnerEvent, done: true });
+    return new Promise((res) => waiters.push(res));
+  };
+
+  const { config, model, sandbox, approvalPolicy, modelProvider } = buildAppServerConfig();
+  const bin = CODEX_BINARY;
+
+  void (async () => {
+    let tmpFiles: string[] = [];
+    let sid: string | null = opts.resume ?? null;
+    let proc: CodexProc | null = null;
+    // Our approval-request id → the JSON-RPC request id we must reply on. Keyed
+    // by a stable string (`<sid>:<requestId>`) so a reconnecting client and the
+    // /approval route agree on which request they're answering.
+    const pending = new Map<string, Pending>();
+    let approvalRegistered = false;
+
+    const cleanup = () => {
+      if (sid && approvalRegistered) clearApprovalHandler(sid);
+      for (const f of tmpFiles) { try { unlinkSync(f); } catch { /* gone */ } }
+      try { proc?.kill(); } catch { /* already dead */ }
+    };
+
+    try {
+      if (!bin || !existsSync(bin)) throw new Error('codex binary not found (set MACARON_CODEX_PATH)');
+      proc = spawn(bin, ['app-server'], { stdio: ['pipe', 'pipe', 'ignore'] }) as CodexProc;
+
+      let rpcId = 0;
+      const sendRequest = (method: string, params: unknown): number => {
+        const id = ++rpcId;
+        proc!.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+        return id;
+      };
+      const sendNotify = (method: string, params: unknown) => {
+        proc!.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+      };
+      const respondTo = (id: string | number, result: unknown) => {
+        proc!.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
+      };
+
+      // Abort → interrupt the active turn, then let the stream close.
+      opts.abortController?.signal.addEventListener('abort', () => {
+        try { if (sid) sendNotify('turn/interrupt', { threadId: sid }); } catch { /* closing */ }
+        push({ kind: 'done', exitCode: 130 });
+        cleanup();
+        finish();
+      });
+
+      // Register the approval channel once we know the sid. Answers the parked
+      // server request with the decision the user picked in the WebUI.
+      const registerApprovals = () => {
+        if (!sid || approvalRegistered) return;
+        approvalRegistered = true;
+        registerApprovalHandler(sid, (approvalId: string, decision: CodexDecision) => {
+          const p = pending.get(approvalId);
+          if (!p) return false;
+          respondTo(p.requestId, { decision });
+          pending.delete(approvalId);
+          push({ kind: 'codex_approval_resolved', id: approvalId, decision });
+          return true;
+        });
+      };
+
+      // --- item translation (item/started + item/completed) ----------------
+      const emittedToolUse = new Set<string>();
+      const handleItem = (phase: 'started' | 'completed', item: Record<string, unknown>) => {
+        const type = item.type as string;
+        const id = String(item.id ?? '');
+        if (type === 'agentMessage') {
+          if (phase !== 'completed') return;
+          const text = String(item.text ?? '').trim();
+          if (text) push({ kind: 'delta', text });
+        } else if (type === 'reasoning') {
+          if (phase !== 'completed') return;
+          const parts = [...((item.summary as string[]) ?? []), ...((item.content as string[]) ?? [])];
+          const text = parts.join('\n').trim();
+          if (text) push({ kind: 'reasoning', text });
+        } else if (type === 'commandExecution') {
+          if (!emittedToolUse.has(id)) { emittedToolUse.add(id); push({ kind: 'tool_use', id, name: 'Bash', input: { command: item.command } }); }
+          if (phase === 'completed') {
+            push({ kind: 'tool_result', tool_use_id: id, text: String(item.aggregatedOutput ?? `(exit ${item.exitCode ?? '?'})`), isError: item.status === 'failed' || (Number(item.exitCode ?? 0) !== 0) });
+          }
+        } else if (type === 'fileChange') {
+          const changes = (item.changes as Array<{ path: string; kind: string }>) ?? [];
+          if (!emittedToolUse.has(id)) { emittedToolUse.add(id); push({ kind: 'tool_use', id, name: 'Edit', input: { changes } }); }
+          if (phase === 'completed') {
+            const summary = changes.map((c) => `${c.kind === 'add' ? '＋' : c.kind === 'delete' ? '－' : '△'} ${c.path}`).join('\n');
+            push({ kind: 'tool_result', tool_use_id: id, text: summary || '(no changes)', isError: item.status === 'failed' });
+          }
+        } else if (type === 'mcpToolCall') {
+          if (!emittedToolUse.has(id)) { emittedToolUse.add(id); push({ kind: 'tool_use', id, name: `mcp:${item.server}/${item.tool}`, input: (item.arguments as unknown) ?? {} }); }
+          if (phase === 'completed') {
+            const err = (item.error as { message?: string } | null)?.message;
+            const res = item.result as { content?: unknown; structured_content?: unknown } | null;
+            const text = err ?? JSON.stringify(res?.content ?? res?.structured_content ?? '', null, 2);
+            push({ kind: 'tool_result', tool_use_id: id, text: (text || '').slice(0, 8000), isError: item.status === 'failed' });
+          }
+        } else if (type === 'webSearch') {
+          if (!emittedToolUse.has(id)) { emittedToolUse.add(id); push({ kind: 'tool_use', id, name: 'WebSearch', input: { query: item.query } }); }
+          if (phase === 'completed') push({ kind: 'tool_result', tool_use_id: id, text: '(search dispatched)', isError: false });
+        }
+      };
+
+      // --- server → client notification / request routing ------------------
+      const onMessage = (msg: Record<string, unknown>) => {
+        // Server request (approval) — has both method and id.
+        if (typeof msg.method === 'string' && msg.id !== undefined && (msg.method as string).includes('requestApproval')) {
+          const method = msg.method as string;
+          const params = (msg.params ?? {}) as Record<string, unknown>;
+          const approvalId = `${sid ?? params.threadId}:${msg.id}`;
+          pending.set(approvalId, { requestId: msg.id as string | number });
+          registerApprovals();
+          if (method === 'item/fileChange/requestApproval') {
+            push({ kind: 'codex_approval_request', id: approvalId, approval: 'file', reason: (params.reason as string) ?? null, grantRoot: (params.grantRoot as string) ?? null, fileChanges: undefined, available: normalizeDecisions(params.availableDecisions) });
+          } else {
+            const net = params.networkApprovalContext as { host: string; protocol: string } | null | undefined;
+            push({
+              kind: 'codex_approval_request',
+              id: approvalId,
+              approval: net ? 'network' : 'command',
+              command: (params.command as string) ?? undefined,
+              cwd: (params.cwd as string) ?? undefined,
+              reason: (params.reason as string) ?? null,
+              network: net ? { host: net.host, protocol: net.protocol } : undefined,
+              available: normalizeDecisions(params.availableDecisions),
+            });
+          }
+          return;
+        }
+        if (typeof msg.method !== 'string') return; // a response to one of our requests
+        const method = msg.method as string;
+        const params = (msg.params ?? {}) as Record<string, unknown>;
+        switch (method) {
+          case 'thread/started': {
+            const thread = params.thread as { id: string } | undefined;
+            if (thread?.id && !sid) { sid = thread.id; push({ kind: 'session', sessionId: sid }); registerApprovals(); }
+            break;
+          }
+          case 'turn/started':
+            push({ kind: 'message', subtype: 'codex_turn_started' });
+            break;
+          case 'item/started':
+            handleItem('started', params.item as Record<string, unknown>);
+            break;
+          case 'item/completed':
+            handleItem('completed', params.item as Record<string, unknown>);
+            break;
+          case 'turn/plan/updated':
+            push({ kind: 'codex_plan', steps: (params.plan as Array<{ step: string; status: 'pending' | 'inProgress' | 'completed' }>) ?? [], explanation: (params.explanation as string) ?? null });
+            break;
+          case 'serverRequest/resolved': {
+            // The server cleared a request we never answered (auto-approved,
+            // superseded, or turn ended). Mark it stale so the card disables.
+            const approvalId = `${params.threadId}:${(params.requestId as string | number)}`;
+            if (pending.delete(approvalId)) push({ kind: 'codex_approval_resolved', id: approvalId, decision: 'stale' });
+            break;
+          }
+          case 'turn/completed': {
+            const turn = params.turn as { status?: string } | undefined;
+            push({ kind: 'done', exitCode: turn?.status === 'failed' ? 1 : 0 });
+            cleanup();
+            finish();
+            break;
+          }
+          case 'turn/failed': {
+            const err = params.error as { message?: string } | undefined;
+            push({ kind: 'error', error: err?.message || 'codex turn failed' });
+            push({ kind: 'done', exitCode: 1 });
+            cleanup();
+            finish();
+            break;
+          }
+          case 'error':
+            push({ kind: 'error', error: (params.message as string) || 'codex stream error' });
+            break;
+        }
+      };
+
+      // Line-delimited JSON reader over stdout.
+      let buf = '';
+      proc.stdout.on('data', (chunk: Buffer) => {
+        buf += chunk.toString();
+        let idx: number;
+        while ((idx = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, idx); buf = buf.slice(idx + 1);
+          if (!line.trim()) continue;
+          let msg: Record<string, unknown>;
+          try { msg = JSON.parse(line); } catch { continue; }
+          try { onMessage(msg); } catch (e) { push({ kind: 'error', error: (e as Error).message }); }
+        }
+      });
+      proc.on('exit', (code) => {
+        if (!ended) { push({ kind: 'done', exitCode: code ?? -1 }); cleanup(); finish(); }
+      });
+
+      // --- handshake -------------------------------------------------------
+      sendRequest('initialize', { clientInfo: { name: 'macaron', title: 'Macaron WebUI', version: '0.1.0' }, capabilities: null });
+      sendNotify('initialized', {});
+
+      const startCfg = { cwd: opts.cwd, sandbox, approvalPolicy, config, model, modelProvider };
+      if (sid) {
+        push({ kind: 'session', sessionId: sid });
+        registerApprovals();
+        sendRequest('thread/resume', { threadId: sid, cwd: opts.cwd, sandbox, approvalPolicy, config, model, modelProvider });
+      } else {
+        sendRequest('thread/start', startCfg);
+      }
+
+      // Fire the turn once we have a thread id. thread/start responds with the
+      // thread synchronously (id: 2), and also emits thread/started — either
+      // path sets `sid`. Poll briefly for the id, then start the turn.
+      const built = buildAppServerInput(opts);
+      tmpFiles = built.tmpFiles;
+      const startTurn = async () => {
+        for (let i = 0; i < 200 && !sid; i++) await new Promise((r) => setTimeout(r, 25));
+        if (!sid) { push({ kind: 'error', error: 'codex thread did not start' }); push({ kind: 'done', exitCode: -1 }); cleanup(); finish(); return; }
+        sendRequest('turn/start', { threadId: sid, input: built.input });
+      };
+      void startTurn();
+    } catch (err) {
+      push({ kind: 'error', error: (err as Error).message });
+      push({ kind: 'done', exitCode: -1 });
+      cleanup();
+      finish();
+    }
+  })();
+
+  return (async function* () {
+    while (true) {
+      const r = await next();
+      if (r.done) return;
+      yield r.value;
+    }
+  })();
+}

--- a/server/src/lib/codex-runner.ts
+++ b/server/src/lib/codex-runner.ts
@@ -22,6 +22,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -77,13 +78,50 @@ const { command: MACARON_MCP_CMD, args: MACARON_MCP_ARGS } = (() => {
 // the same Macaron stdio MCP into its thread/start config.
 export { MACARON_MCP_CMD, MACARON_MCP_ARGS };
 
-// @openai/codex-sdk ships the `codex` binary via optional deps; if it's not
-// present the SDK throws at construction time. Fall back to the user's
-// system `codex` (installed via Homebrew or a global npm install) so the
-// runner works with the CLI they already use in the terminal.
+// @openai/codex-sdk ships the `codex` binary via platform-specific optional
+// deps. The SDK resolves it from `@openai/codex`'s vendor/ dir; we mirror that
+// lookup so the app-server transport (which spawns the binary directly, not via
+// the SDK) gets the same bundled fallback the SDK path enjoys.
+const PLATFORM_PACKAGE_BY_TARGET: Record<string, string> = {
+  'x86_64-unknown-linux-musl': '@openai/codex-linux-x64',
+  'aarch64-unknown-linux-musl': '@openai/codex-linux-arm64',
+  'x86_64-apple-darwin': '@openai/codex-darwin-x64',
+  'aarch64-apple-darwin': '@openai/codex-darwin-arm64',
+  'x86_64-pc-windows-msvc': '@openai/codex-win32-x64',
+  'aarch64-pc-windows-msvc': '@openai/codex-win32-arm64',
+};
+function targetTriple(): string | null {
+  const { platform, arch } = process;
+  if ((platform === 'linux' || platform === 'android') && arch === 'x64') return 'x86_64-unknown-linux-musl';
+  if ((platform === 'linux' || platform === 'android') && arch === 'arm64') return 'aarch64-unknown-linux-musl';
+  if (platform === 'darwin' && arch === 'x64') return 'x86_64-apple-darwin';
+  if (platform === 'darwin' && arch === 'arm64') return 'aarch64-apple-darwin';
+  if (platform === 'win32' && arch === 'x64') return 'x86_64-pc-windows-msvc';
+  if (platform === 'win32' && arch === 'arm64') return 'aarch64-pc-windows-msvc';
+  return null;
+}
+function resolveBundledCodex(): string | undefined {
+  const triple = targetTriple();
+  const pkg = triple ? PLATFORM_PACKAGE_BY_TARGET[triple] : undefined;
+  if (!triple || !pkg) return undefined;
+  try {
+    const req = createRequire(import.meta.url);
+    const codexReq = createRequire(req.resolve('@openai/codex/package.json'));
+    const vendorRoot = path.join(path.dirname(codexReq.resolve(`${pkg}/package.json`)), 'vendor');
+    const bin = process.platform === 'win32' ? 'codex.exe' : 'codex';
+    const root = path.join(vendorRoot, triple);
+    for (const cand of [path.join(root, 'bin', bin), path.join(root, 'codex', bin)]) {
+      if (existsSync(cand)) return cand;
+    }
+  } catch { /* SDK / platform pkg not installed */ }
+  return undefined;
+}
+
+// Resolution order: explicit env override, common global install paths,
+// `which codex`, then the SDK's bundled platform binary. The bundled fallback
+// is last so a user's own codex (matching their terminal CLI) still wins, but a
+// plain package install with no global codex no longer regresses to "not found".
 function detectCodexBinary(): string | undefined {
-  // Prefer explicit env override, then a couple of common install paths,
-  // then `which codex`.
   if (process.env.MACARON_CODEX_PATH && existsSync(process.env.MACARON_CODEX_PATH)) {
     return process.env.MACARON_CODEX_PATH;
   }
@@ -91,12 +129,10 @@ function detectCodexBinary(): string | undefined {
     if (existsSync(p)) return p;
   }
   try {
-    return execSync('which codex', { stdio: ['ignore', 'pipe', 'ignore'] })
-      .toString()
-      .trim() || undefined;
-  } catch {
-    return undefined;
-  }
+    const which = execSync('which codex', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    if (which) return which;
+  } catch { /* not on PATH */ }
+  return resolveBundledCodex();
 }
 export const CODEX_BINARY = detectCodexBinary();
 

--- a/server/src/lib/codex-runner.ts
+++ b/server/src/lib/codex-runner.ts
@@ -73,6 +73,10 @@ const { command: MACARON_MCP_CMD, args: MACARON_MCP_ARGS } = (() => {
   return { command: 'tsx', args: [tsPath] };
 })();
 
+// Re-exported for the app-server runner (codex-app-server.ts), which injects
+// the same Macaron stdio MCP into its thread/start config.
+export { MACARON_MCP_CMD, MACARON_MCP_ARGS };
+
 // @openai/codex-sdk ships the `codex` binary via optional deps; if it's not
 // present the SDK throws at construction time. Fall back to the user's
 // system `codex` (installed via Homebrew or a global npm install) so the

--- a/server/src/routes/codex.ts
+++ b/server/src/routes/codex.ts
@@ -19,6 +19,9 @@ import {
 } from '../lib/codex-store.js';
 import { groupWorkspaces } from '../lib/session-store.js';
 import { runCodex } from '../lib/codex-runner.js';
+import { runCodexAppServer } from '../lib/codex-app-server.js';
+import { respondCodexApproval } from '../lib/active-approvals.js';
+import type { CodexDecision } from '@macaron/shared';
 import { maybeGenerateCodexTitle } from '../lib/codex-title.js';
 import {
   CODEX_SYSTEM_PROVIDER_ID,
@@ -42,6 +45,13 @@ type NewThreadBody = { text?: string; cwd?: string; images?: AttachedImage[] };
 type MessageBody = { text?: string; images?: AttachedImage[] };
 
 export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
+  // Transport selector. The app-server JSON-RPC bridge (MAC-8129) is the
+  // default — it's the only one that can stream native plan updates and pause
+  // for interactive approvals. Set MACARON_CODEX_TRANSPORT=sdk to fall back to
+  // the one-shot `codex exec` SDK path (no plan/approval surface).
+  const useAppServer = process.env.MACARON_CODEX_TRANSPORT !== 'sdk';
+  const runCodexTurn: typeof runCodex = (opts) => (useAppServer ? runCodexAppServer(opts) : runCodex(opts));
+
   // --- Threads -----------------------------------------------------------
 
   app.get('/api/codex/threads', async () => {
@@ -135,6 +145,9 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
         else if (ev.kind === 'tool_use') relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
         else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
         else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
+        else if (ev.kind === 'codex_plan') relay({ type: 'codex_plan', steps: ev.steps, explanation: ev.explanation });
+        else if (ev.kind === 'codex_approval_request') relay({ type: 'codex_approval_request', id: ev.id, kind: ev.approval, command: ev.command, cwd: ev.cwd, reason: ev.reason, fileChanges: ev.fileChanges, grantRoot: ev.grantRoot, network: ev.network, available: ev.available });
+        else if (ev.kind === 'codex_approval_resolved') relay({ type: 'codex_approval_resolved', id: ev.id, decision: ev.decision });
         else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
         else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
         else if (ev.kind === 'done') {
@@ -171,7 +184,7 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
     startSSE(reply);
     sseSend(reply, { type: 'starting', cwd });
     const abortController = new AbortController();
-    const stream = runCodex({ prompt: text, cwd, images, abortController });
+    const stream = runCodexTurn({ prompt: text, cwd, images, abortController });
     // pipeCodexToSSE owns the iteration, so wrap the runner to install the abort
     // under the sid once the first `session` event reveals it.
     const wrapped = (async function* () {
@@ -203,7 +216,7 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
       sseSend(reply, { type: 'meta', sessionId: sid, cwd });
       const abortController = new AbortController();
       registerRun(sid, abortController);
-      pipeCodexToSSE(reply, runCodex({ prompt: text, cwd, resume: sid, images, abortController }), sid, { cwd, text, hasImages: images.length > 0 });
+      pipeCodexToSSE(reply, runCodexTurn({ prompt: text, cwd, resume: sid, images, abortController }), sid, { cwd, text, hasImages: images.length > 0 });
     },
   );
 
@@ -211,6 +224,25 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
     const ok = abortRun(params.sid);
     return reply.send({ ok, running: ok });
   });
+
+  // Answer a native app-server approval request (command / file / network).
+  // The runner parked the JSON-RPC server request; respondCodexApproval routes
+  // the decision back over its stdio pipe. Returns ok:false if the request was
+  // already resolved (turn ended, or the server cleared it) so the client can
+  // disable a stale card.
+  const DECISIONS: CodexDecision[] = ['accept', 'acceptForSession', 'decline', 'cancel'];
+  app.post<{ Params: SidParams; Body: { id?: string; decision?: string } }>(
+    '/api/codex/threads/:sid/approval',
+    async ({ params, body }, reply) => {
+      const id = String(body?.id || '').trim();
+      const decision = String(body?.decision || '') as CodexDecision;
+      if (!id || !DECISIONS.includes(decision)) {
+        return reply.status(400).send({ error: 'id and a valid decision are required' });
+      }
+      const ok = respondCodexApproval(params.sid, id, decision);
+      return reply.send({ ok });
+    },
+  );
 
   // SSE: reattach to a Codex turn. Replays the current snapshot (liveGet), then
   // forwards live events until the turn ends — so a browser refresh mid-turn

--- a/shared/src/sse.ts
+++ b/shared/src/sse.ts
@@ -3,6 +3,18 @@
 // /api/sessions/.../message (POST) and /api/sessions/.../live (GET) match one
 // of these shapes.
 
+// Codex plan step lifecycle, mirroring the app-server's TurnPlanStepStatus.
+export type CodexPlanStatus = 'pending' | 'inProgress' | 'completed';
+
+// Which native approval surface a request belongs to.
+export type CodexApprovalKind = 'command' | 'file' | 'network';
+
+// The decision the user picks, matching the app-server's approval decision
+// enums (command supports the first four; file supports accept/acceptForSession
+// /decline/cancel). Amendment-carrying variants are answered as plain `accept`
+// for now — the destructured amendment payloads aren't surfaced in the UI yet.
+export type CodexDecision = 'accept' | 'acceptForSession' | 'decline' | 'cancel';
+
 export type SessionStreamEvent =
   | { type: 'meta'; cwd: string; sessionId: string }
   | { type: 'starting'; cwd: string }
@@ -17,6 +29,17 @@ export type SessionStreamEvent =
   | { type: 'tool_result'; tool_use_id: string; text: string; isError: boolean }
   | { type: 'permission_request'; id: string; toolName: string; input: unknown; suggestion?: { label: string } }
   | { type: 'permission_resolved'; id: string; decision: 'allow' | 'deny' }
+  // Codex-native plan surface (turn/plan/updated). One card per thread, updated
+  // monotonically — the client replaces its plan with the newest `steps`.
+  | { type: 'codex_plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
+  // Codex-native approval request (command / file / network). The client shows
+  // a decision card and POSTs the chosen `decision` back to
+  // /api/codex/threads/:sid/approval. `available` lists the decisions codex
+  // offered for this specific request. Cleared by codex_approval_resolved.
+  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  // The request is no longer actionable (answered, turn ended, or server
+  // cleared it via serverRequest/resolved). The client disables the card.
+  | { type: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }
   | { type: 'usage'; outputTokens: number; thinkingTokens?: number }
   | { type: 'event'; event: string; subtype: string | null }
   | { type: 'log'; text: string }

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -7,9 +7,9 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { SessionDetail, Message, Block } from '@macaron/shared';
+import type { SessionDetail, Message, Block, CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
 import { codexApi } from './api';
-import { sendCodexMessage, startCodexThread, subscribeCodexLive } from './stream';
+import { sendCodexMessage, startCodexThread, subscribeCodexLive, type CodexStreamEvent } from './stream';
 import { CodexComposer, type ComposerImage } from './CodexComposer';
 import { notify } from '../lib/notify';
 
@@ -33,7 +33,13 @@ type Item =
   // tool_use time (arguments are already aggregated by the CLI), so we
   // render immediately — no pending phase in practice. The tool_result
   // (checkGenUI diagnostics) may flip `status` to 'error' with details.
-  | { id: string; kind: 'genui'; toolUseId: string; code: string; status: 'ready' | 'error'; error?: string };
+  | { id: string; kind: 'genui'; toolUseId: string; code: string; status: 'ready' | 'error'; error?: string }
+  // Codex-native plan card (turn/plan/updated). One per thread, replaced in
+  // place as new plan snapshots arrive.
+  | { id: string; kind: 'plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
+  // Codex-native approval request. `decision` set once answered (or 'stale'
+  // when the server cleared it) so the card disables its buttons.
+  | { id: string; kind: 'approval'; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[]; decision?: CodexDecision | 'stale' };
 
 function toolInputToCmd(name: string, input: unknown): string {
   if (name === 'Bash') {
@@ -158,8 +164,25 @@ function withToolResult(cur: Item[], toolUseId: string, text: string, isError: b
   });
 }
 
-function Reasoning({ text }: { text: string }) {
-  const [open, setOpen] = useState(false);
+// Plan is a singleton per thread: replace the existing card in place (keeping
+// its position) or append if this is the first snapshot.
+function withPlan(cur: Item[], steps: Array<{ step: string; status: CodexPlanStatus }>, explanation?: string | null): Item[] {
+  const idx = cur.findIndex((it) => it.kind === 'plan');
+  const item: Item = { id: 'plan', kind: 'plan', steps, explanation };
+  if (idx < 0) return [...cur, item];
+  return cur.map((it, i) => (i === idx ? item : it));
+}
+
+function withApproval(cur: Item[], ev: Extract<CodexStreamEvent, { type: 'codex_approval_request' }>): Item[] {
+  if (cur.some((it) => it.kind === 'approval' && it.id === ev.id)) return cur;
+  return [...cur, { id: ev.id, kind: 'approval', approval: ev.kind, command: ev.command, cwd: ev.cwd, reason: ev.reason, grantRoot: ev.grantRoot, network: ev.network, available: ev.available }];
+}
+
+function withApprovalResolved(cur: Item[], id: string, decision?: CodexDecision | 'stale'): Item[] {
+  return cur.map((it) => (it.kind === 'approval' && it.id === id ? { ...it, decision: decision ?? 'stale' } : it));
+}
+
+function Reasoning({ text }: { text: string }) {  const [open, setOpen] = useState(false);
   return (
     <div className="cx-reasoning">
       <div className="cx-reasoning-head" onClick={() => setOpen((v) => !v)}>
@@ -232,10 +255,68 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
   );
 }
 
-function MessageRow({ it }: { it: Item }) {
+function PlanCard({ it }: { it: Extract<Item, { kind: 'plan' }> }) {
+  const glyph = (s: CodexPlanStatus) => (s === 'completed' ? '☑' : s === 'inProgress' ? '◐' : '☐');
+  return (
+    <div className="cx-plan">
+      <div className="cx-plan-head">
+        <span className="cx-plan-glyph">◇</span>
+        <span className="cx-plan-name">Plan</span>
+      </div>
+      {it.explanation && <div className="cx-plan-explanation">{it.explanation}</div>}
+      <div className="cx-plan-steps">
+        {it.steps.map((s, i) => (
+          <div key={i} className={'cx-plan-step ' + s.status}>
+            <span className="cx-plan-step-glyph">{glyph(s.status)}</span>
+            <span className="cx-plan-step-text">{s.step}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const DECISION_LABEL: Record<CodexDecision, string> = {
+  accept: 'Approve',
+  acceptForSession: 'Approve for session',
+  decline: 'Decline',
+  cancel: 'Cancel',
+};
+
+function ApprovalCard({ it, onDecide }: { it: Extract<Item, { kind: 'approval' }>; onDecide: (id: string, decision: CodexDecision) => void }) {
+  const resolved = it.decision !== undefined;
+  const title = it.approval === 'file' ? 'File change approval' : it.approval === 'network' ? 'Network access approval' : 'Command approval';
+  return (
+    <div className={'cx-approval' + (resolved ? ' resolved' : '')}>
+      <div className="cx-approval-head">
+        <span className="cx-approval-glyph">⚑</span>
+        <span className="cx-approval-name">{title}</span>
+        {resolved && <span className="cx-approval-status">{it.decision === 'stale' ? 'expired' : it.decision}</span>}
+      </div>
+      {it.command && <div className="cx-approval-cmd">{it.command}</div>}
+      {it.network && <div className="cx-approval-net">{it.network.protocol}://{it.network.host}</div>}
+      {it.cwd && <div className="cx-approval-cwd">{it.cwd}</div>}
+      {it.grantRoot && <div className="cx-approval-cwd">grant root: {it.grantRoot}</div>}
+      {it.reason && <div className="cx-approval-reason">{it.reason}</div>}
+      {!resolved && (
+        <div className="cx-approval-actions">
+          {it.available.map((d) => (
+            <button key={d} className={'cx-approval-btn ' + d} onClick={() => onDecide(it.id, d)}>
+              {DECISION_LABEL[d]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MessageRow({ it, onDecide }: { it: Item; onDecide?: (id: string, decision: CodexDecision) => void }) {
   if (it.kind === 'reasoning') return <Reasoning text={it.text} />;
   if (it.kind === 'tool') return <ToolCard it={it} />;
   if (it.kind === 'genui') return <GenuiCard it={it} />;
+  if (it.kind === 'plan') return <PlanCard it={it} />;
+  if (it.kind === 'approval') return <ApprovalCard it={it} onDecide={onDecide ?? (() => {})} />;
   const isUser = it.kind === 'user';
   return (
     <div className={'cx-msg ' + (isUser ? 'user' : 'assistant')}>
@@ -361,6 +442,9 @@ export function CodexChat(props: CodexChatProps = {}) {
       onToolResult: (ev) => {
         if (active) setLive((cur) => withToolResult(cur, ev.tool_use_id, ev.text, ev.isError));
       },
+      onCodexPlan: (ev) => { if (active) setLive((cur) => withPlan(cur, ev.steps, ev.explanation)); },
+      onCodexApproval: (ev) => { if (active) setLive((cur) => withApproval(cur, ev)); },
+      onCodexApprovalResolved: (ev) => { if (active) setLive((cur) => withApprovalResolved(cur, ev.id, ev.decision)); },
       onError: (message) => { if (active) setError(message); },
       onDone: () => {
         if (!active) return;
@@ -402,6 +486,20 @@ export function CodexChat(props: CodexChatProps = {}) {
   const applyToolResult = (toolUseId: string, text: string, isError: boolean) => {
     setLive((cur) => withToolResult(cur, toolUseId, text, isError));
   };
+  const applyPlan = (ev: Extract<CodexStreamEvent, { type: 'codex_plan' }>) =>
+    setLive((cur) => withPlan(cur, ev.steps, ev.explanation));
+  const applyApproval = (ev: Extract<CodexStreamEvent, { type: 'codex_approval_request' }>) =>
+    setLive((cur) => withApproval(cur, ev));
+  const applyApprovalResolved = (ev: Extract<CodexStreamEvent, { type: 'codex_approval_resolved' }>) =>
+    setLive((cur) => withApprovalResolved(cur, ev.id, ev.decision));
+
+  // Answer an approval optimistically (disable the card), then POST. On failure
+  // the server already treated it as resolved (stale race), so we keep it off.
+  const decideApproval = useCallback((id: string, decision: CodexDecision) => {
+    if (!sid) return;
+    setLive((cur) => withApprovalResolved(cur, id, decision));
+    void codexApi.approve(sid, id, decision).catch(() => {});
+  }, [sid]);
 
   const stop = useCallback(async () => {
     if (!sid) return;
@@ -434,6 +532,9 @@ export function CodexChat(props: CodexChatProps = {}) {
           onReasoning: appendReasoning,
           onToolUse: (ev) => appendTool(ev.id, ev.name, ev.input),
           onToolResult: (ev) => applyToolResult(ev.tool_use_id, ev.text, ev.isError),
+          onCodexPlan: applyPlan,
+          onCodexApproval: applyApproval,
+          onCodexApprovalResolved: applyApprovalResolved,
           onError: (m) => setError(m),
           onDone: () => {
             setSending(false);
@@ -446,6 +547,9 @@ export function CodexChat(props: CodexChatProps = {}) {
           onReasoning: appendReasoning,
           onToolUse: (ev) => appendTool(ev.id, ev.name, ev.input),
           onToolResult: (ev) => applyToolResult(ev.tool_use_id, ev.text, ev.isError),
+          onCodexPlan: applyPlan,
+          onCodexApproval: applyApproval,
+          onCodexApprovalResolved: applyApprovalResolved,
           onError: (m) => setError(m),
           onDone: () => {
             setSending(false);
@@ -515,7 +619,7 @@ export function CodexChat(props: CodexChatProps = {}) {
           </div>
         ) : (
           <div className="cx-thread-body">
-            {items.map((it) => <MessageRow key={it.id} it={it} />)}
+            {items.map((it) => <MessageRow key={it.id} it={it} onDecide={decideApproval} />)}
             {/* Show the thinking spinner at the tail of the thread while a
                 turn is in flight. Hide it once the last item is a live
                 assistant message that has actually started emitting text —

--- a/web/src/codex/api.ts
+++ b/web/src/codex/api.ts
@@ -4,6 +4,7 @@ import type {
   SessionListItem,
   SessionDetail,
   Workspace,
+  CodexDecision,
 } from '@macaron/shared';
 import { authedFetch } from '../lib/auth';
 
@@ -78,6 +79,12 @@ export const codexApi = {
       `/api/codex/threads/${encodeURIComponent(sid)}/stop`,
       { method: 'POST' },
     ),
+  approve: (sid: string, id: string, decision: CodexDecision) =>
+    reqJSON<{ ok: boolean }>(`/api/codex/threads/${encodeURIComponent(sid)}/approval`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id, decision }),
+    }),
   config: () => getJSON<PublicCodexSettings>('/api/codex/config'),
   setActive: (providerId: string) =>
     reqJSON<PublicCodexSettings>('/api/codex/config/active', {

--- a/web/src/codex/stream.ts
+++ b/web/src/codex/stream.ts
@@ -2,6 +2,7 @@
 // into typed events the chat view can consume with simple callbacks.
 
 import { authedFetch } from '../lib/auth';
+import type { CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
 
 export type CodexStreamEvent =
   | { type: 'starting'; cwd?: string }
@@ -13,6 +14,9 @@ export type CodexStreamEvent =
   | { type: 'tool_result'; tool_use_id: string; text: string; isError: boolean }
   | { type: 'usage'; outputTokens: number; thinkingTokens?: number }
   | { type: 'event'; subtype: string }
+  | { type: 'codex_plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
+  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  | { type: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }
   | { type: 'error'; error: string }
   | { type: 'done'; exitCode: number }
   | { type: 'live-end'; reason?: string };
@@ -26,6 +30,9 @@ export type CodexStreamHandlers = {
   onToolResult?: (ev: Extract<CodexStreamEvent, { type: 'tool_result' }>) => void;
   onEvent?: (subtype: string) => void;
   onUsage?: (out: number, thinking?: number) => void;
+  onCodexPlan?: (ev: Extract<CodexStreamEvent, { type: 'codex_plan' }>) => void;
+  onCodexApproval?: (ev: Extract<CodexStreamEvent, { type: 'codex_approval_request' }>) => void;
+  onCodexApprovalResolved?: (ev: Extract<CodexStreamEvent, { type: 'codex_approval_resolved' }>) => void;
   onError?: (msg: string) => void;
   onDone?: (exitCode: number) => void;
   onLiveEnd?: (reason?: string) => void;
@@ -67,6 +74,9 @@ async function pump(resp: Response, h: CodexStreamHandlers): Promise<void> {
         case 'tool_result': h.onToolResult?.(p); break;
         case 'event': h.onEvent?.(p.subtype); break;
         case 'usage': h.onUsage?.(p.outputTokens, p.thinkingTokens); break;
+        case 'codex_plan': h.onCodexPlan?.(p); break;
+        case 'codex_approval_request': h.onCodexApproval?.(p); break;
+        case 'codex_approval_resolved': h.onCodexApprovalResolved?.(p); break;
         case 'error': h.onError?.(p.error); break;
         case 'done': h.onDone?.(p.exitCode); break;
         case 'live-end': h.onLiveEnd?.(p.reason); break;

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1426,3 +1426,93 @@ body {
   background: var(--cx-muted-2);
   background-clip: content-box;
 }
+
+/* ---------- Plan card ---------- */
+
+.cx-plan {
+  margin: 10px 0;
+  border: 1px solid var(--cx-border);
+  border-radius: var(--cx-radius-lg);
+  background: var(--cx-surface);
+  overflow: hidden;
+  font-size: 13px;
+  box-shadow: var(--cx-shadow-1);
+}
+.cx-plan-head {
+  padding: 9px 12px;
+  background: var(--cx-sidebar);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--cx-border);
+}
+.cx-plan-glyph { color: var(--cx-code-strong); }
+.cx-plan-name { font-weight: 600; color: var(--cx-text); }
+.cx-plan-explanation { padding: 8px 12px; color: var(--cx-muted); border-bottom: 1px solid var(--cx-border); }
+.cx-plan-steps { padding: 6px 0; }
+.cx-plan-step {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 12px;
+  color: var(--cx-text);
+}
+.cx-plan-step-glyph { font-family: ui-monospace, Menlo, monospace; }
+.cx-plan-step.completed { color: var(--cx-muted); text-decoration: line-through; }
+.cx-plan-step.inProgress { font-weight: 600; }
+.cx-plan-step.inProgress .cx-plan-step-glyph { color: var(--cx-code-strong); }
+
+/* ---------- Approval card ---------- */
+
+.cx-approval {
+  margin: 10px 0;
+  border: 1px solid rgba(197, 138, 58, 0.45);
+  border-radius: var(--cx-radius-lg);
+  background: var(--cx-surface);
+  overflow: hidden;
+  font-size: 13px;
+  box-shadow: var(--cx-shadow-1);
+}
+.cx-approval.resolved { opacity: 0.6; border-color: var(--cx-border); }
+.cx-approval-head {
+  padding: 9px 12px;
+  background: var(--cx-sidebar);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--cx-border);
+}
+.cx-approval-glyph { color: #c58a3a; }
+.cx-approval-name { font-weight: 600; color: var(--cx-text); }
+.cx-approval-status {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--cx-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.cx-approval-cmd {
+  padding: 10px 12px;
+  background: var(--cx-code-strong);
+  color: #e8e8ea;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+.cx-approval-net { padding: 8px 12px; font-family: ui-monospace, Menlo, monospace; color: var(--cx-text); }
+.cx-approval-cwd { padding: 4px 12px; color: var(--cx-muted); font-size: 12px; font-family: ui-monospace, Menlo, monospace; }
+.cx-approval-reason { padding: 8px 12px; color: var(--cx-muted); }
+.cx-approval-actions { display: flex; flex-wrap: wrap; gap: 8px; padding: 10px 12px; border-top: 1px solid var(--cx-border); }
+.cx-approval-btn {
+  padding: 6px 14px;
+  border-radius: var(--cx-radius);
+  border: 1px solid var(--cx-border);
+  background: var(--cx-surface);
+  color: var(--cx-text);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.cx-approval-btn:hover { background: var(--cx-sidebar); }
+.cx-approval-btn.accept, .cx-approval-btn.acceptForSession { border-color: #4a8a5a; color: #2f7d45; }
+.cx-approval-btn.decline, .cx-approval-btn.cancel { border-color: #c0524a; color: #c0524a; }


### PR DESCRIPTION
Closes #125.

Gives the Codex WebUI first-class **plan** and **approval** UX driven by Codex's native `app-server` JSON-RPC events — no ExitPlanMode emulation, no reuse of the Claude permission endpoint.

## What changed

**Transport.** New `codex app-server` JSON-RPC runner (`server/src/lib/codex-app-server.ts`) is now the default. Handshake `initialize → initialized → thread/start|resume → turn/start`, line-delimited JSON over stdio, translated 1:1 into the shared `RunnerEvent` stream so the SSE route and client stay transport-agnostic. Thread start/resume, streaming, cancellation (`turn/interrupt`), history, and existing tool cards (Bash/Edit/mcp/webSearch) are preserved. The old `codex exec` SDK path stays as a fallback behind `MACARON_CODEX_TRANSPORT=sdk`.

**Approvals.** In-flight runs register a responder in `active-approvals.ts` keyed by sid; the model pauses on `item/{commandExecution,fileChange}/requestApproval`, and `POST /api/codex/threads/:sid/approval` routes the user's decision back over the same stdio pipe. Requests are correlated by `<sid>:<requestId>`. `serverRequest/resolved` marks a card stale when Codex clears a request we never answered.

**UI.**
- `turn/plan/updated` → a dedicated plan card with `pending`/`inProgress`/`completed` step states.
- Command / file / network approval cards render `command`, `cwd`, `reason`, `grantRoot`, and `networkApprovalContext`, with only the decisions Codex offered (`availableDecisions`). Amendment variants collapse to the four plain decisions for now.
- Reconnect-safe: the live-registry snapshot replays plan + approval state on refresh.

## Tests

`server/src/lib/codex-app-server.test.ts` covers request→decision correlation for every decision (`accept` / `acceptForSession` / `decline` / `cancel`), per-session handler isolation, stale-id handling, and `normalizeDecisions`. `pnpm --filter @macaron/server test` → 14 pass. Server typecheck + build clean; web build clean (no new type errors — remaining ones are pre-existing `macaron-vendor` stubs).

> [!NOTE]
> Browser smoke evidence against a live Codex still needs a manual pass in a real workspace; the protocol/route correlation is covered by the automated tests above.
