### PR TITLE
Fix new-thread Codex approvals, file diff rendering, and network port

### DIFF
--- a/server/src/lib/claude-runner.ts
+++ b/server/src/lib/claude-runner.ts
@@ -44,7 +44,7 @@ export type RunnerEvent =
   // these; they carry the shared SSE payload verbatim so the route can relay
   // them without re-shaping. See shared/src/sse.ts for field semantics.
   | { kind: 'codex_plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
-  | { kind: 'codex_approval_request'; id: string; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  | { kind: 'codex_approval_request'; id: string; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string; port?: number }; available: CodexDecision[] }
   | { kind: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }
   | { kind: 'error'; error: string }
   | { kind: 'done'; exitCode: number };

--- a/server/src/lib/codex-app-server.ts
+++ b/server/src/lib/codex-app-server.ts
@@ -263,7 +263,7 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
             const changes = fileChangesByItem.get(String(params.itemId ?? ''));
             push({ kind: 'codex_approval_request', id: approvalId, approval: 'file', reason: (params.reason as string) ?? null, grantRoot: (params.grantRoot as string) ?? null, fileChanges: changes, available: normalizeDecisions(params.availableDecisions) });
           } else {
-            const net = params.networkApprovalContext as { host: string; protocol: string } | null | undefined;
+            const net = params.networkApprovalContext as { host: string; protocol: string; port?: number } | null | undefined;
             push({
               kind: 'codex_approval_request',
               id: approvalId,
@@ -271,7 +271,7 @@ export function runCodexAppServer(opts: CodexRunOptions): AsyncGenerator<RunnerE
               command: (params.command as string) ?? undefined,
               cwd: (params.cwd as string) ?? undefined,
               reason: (params.reason as string) ?? null,
-              network: net ? { host: net.host, protocol: net.protocol } : undefined,
+              network: net ? { host: net.host, protocol: net.protocol, port: net.port } : undefined,
               available: normalizeDecisions(params.availableDecisions),
             });
           }

--- a/shared/src/sse.ts
+++ b/shared/src/sse.ts
@@ -36,7 +36,7 @@ export type SessionStreamEvent =
   // a decision card and POSTs the chosen `decision` back to
   // /api/codex/threads/:sid/approval. `available` lists the decisions codex
   // offered for this specific request. Cleared by codex_approval_resolved.
-  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string; port?: number }; available: CodexDecision[] }
   // The request is no longer actionable (answered, turn ended, or server
   // cleared it via serverRequest/resolved). The client disables the card.
   | { type: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -40,7 +40,7 @@ type Item =
   | { id: string; kind: 'plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
   // Codex-native approval request. `decision` set once answered (or 'stale'
   // when the server cleared it) so the card disables its buttons.
-  | { id: string; kind: 'approval'; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[]; decision?: CodexDecision | 'stale' };
+  | { id: string; kind: 'approval'; approval: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string; port?: number }; available: CodexDecision[]; decision?: CodexDecision | 'stale' };
 
 function toolInputToCmd(name: string, input: unknown): string {
   if (name === 'Bash') {
@@ -176,7 +176,7 @@ function withPlan(cur: Item[], steps: Array<{ step: string; status: CodexPlanSta
 
 function withApproval(cur: Item[], ev: Extract<CodexStreamEvent, { type: 'codex_approval_request' }>): Item[] {
   if (cur.some((it) => it.kind === 'approval' && it.id === ev.id)) return cur;
-  return [...cur, { id: ev.id, kind: 'approval', approval: ev.kind, command: ev.command, cwd: ev.cwd, reason: ev.reason, grantRoot: ev.grantRoot, network: ev.network, available: ev.available }];
+  return [...cur, { id: ev.id, kind: 'approval', approval: ev.kind, command: ev.command, cwd: ev.cwd, reason: ev.reason, fileChanges: ev.fileChanges, grantRoot: ev.grantRoot, network: ev.network, available: ev.available }];
 }
 
 function withApprovalResolved(cur: Item[], id: string, decision?: CodexDecision | 'stale'): Item[] {
@@ -295,10 +295,16 @@ function ApprovalCard({ it, onDecide }: { it: Extract<Item, { kind: 'approval' }
         {resolved && <span className="cx-approval-status">{it.decision === 'stale' ? 'expired' : it.decision}</span>}
       </div>
       {it.command && <div className="cx-approval-cmd">{it.command}</div>}
-      {it.network && <div className="cx-approval-net">{it.network.protocol}://{it.network.host}</div>}
+      {it.network && <div className="cx-approval-net">{it.network.protocol}://{it.network.host}{it.network.port != null ? `:${it.network.port}` : ''}</div>}
       {it.cwd && <div className="cx-approval-cwd">{it.cwd}</div>}
       {it.grantRoot && <div className="cx-approval-cwd">grant root: {it.grantRoot}</div>}
       {it.reason && <div className="cx-approval-reason">{it.reason}</div>}
+      {it.fileChanges?.map((c, i) => (
+        <div key={i} className="cx-approval-file">
+          <div className="cx-approval-file-head">{c.kind === 'add' ? '＋' : c.kind === 'delete' ? '－' : '△'} {c.path}</div>
+          {c.diff && <pre className="cx-approval-diff">{c.diff}</pre>}
+        </div>
+      ))}
       {!resolved && (
         <div className="cx-approval-actions">
           {it.available.map((d) => (
@@ -391,6 +397,10 @@ export function CodexChat(props: CodexChatProps = {}) {
   // changes, not on every keystroke.
   const runtimeRef = useRef<CodexRuntimeOverride>({});
   const setRuntime = useCallback((ov: CodexRuntimeOverride) => { runtimeRef.current = ov; }, []);
+  // On a brand-new thread the route `sid` stays empty until `onDone` navigates,
+  // but approvals arrive mid-turn — so approve/stop must target the sid the
+  // server reveals via `meta`. Captured here the instant it streams in.
+  const liveSidRef = useRef('');
   // True only after the user kicks off a turn on THIS mount. A server-side
   // reattach also flips `sending`, but must not create a completion notification.
   const streamedRef = useRef(false);
@@ -503,14 +513,16 @@ export function CodexChat(props: CodexChatProps = {}) {
   // Answer an approval optimistically (disable the card), then POST. On failure
   // the server already treated it as resolved (stale race), so we keep it off.
   const decideApproval = useCallback((id: string, decision: CodexDecision) => {
-    if (!sid) return;
+    const target = sid || liveSidRef.current;
+    if (!target) return;
     setLive((cur) => withApprovalResolved(cur, id, decision));
-    void codexApi.approve(sid, id, decision).catch(() => {});
+    void codexApi.approve(target, id, decision).catch(() => {});
   }, [sid]);
 
   const stop = useCallback(async () => {
-    if (!sid) return;
-    try { await codexApi.stopThread(sid); } catch { /* nop */ }
+    const target = sid || liveSidRef.current;
+    if (!target) return;
+    try { await codexApi.stopThread(target); } catch { /* nop */ }
   }, [sid]);
 
   const submit = useCallback(async (opts?: { text?: string }) => {
@@ -534,7 +546,7 @@ export function CodexChat(props: CodexChatProps = {}) {
       if (isNew) {
         let newSid = '';
         await startCodexThread({ text, images: wire, runtime: runtimeRef.current }, {
-          onMeta: (s) => { newSid = s; },
+          onMeta: (s) => { newSid = s; liveSidRef.current = s; },
           onDelta: appendAssistantDelta,
           onReasoning: appendReasoning,
           onToolUse: (ev) => appendTool(ev.id, ev.name, ev.input),

--- a/web/src/codex/stream.ts
+++ b/web/src/codex/stream.ts
@@ -16,7 +16,7 @@ export type CodexStreamEvent =
   | { type: 'usage'; outputTokens: number; thinkingTokens?: number }
   | { type: 'event'; subtype: string }
   | { type: 'codex_plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
-  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string }; available: CodexDecision[] }
+  | { type: 'codex_approval_request'; id: string; kind: CodexApprovalKind; command?: string; cwd?: string; reason?: string | null; fileChanges?: Array<{ path: string; kind: string; diff?: string }>; grantRoot?: string | null; network?: { host: string; protocol: string; port?: number }; available: CodexDecision[] }
   | { type: 'codex_approval_resolved'; id: string; decision?: CodexDecision | 'stale' }
   | { type: 'error'; error: string }
   | { type: 'done'; exitCode: number }

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1524,6 +1524,19 @@ body {
 .cx-approval-net { padding: 8px 12px; font-family: ui-monospace, Menlo, monospace; color: var(--cx-text); }
 .cx-approval-cwd { padding: 4px 12px; color: var(--cx-muted); font-size: 12px; font-family: ui-monospace, Menlo, monospace; }
 .cx-approval-reason { padding: 8px 12px; color: var(--cx-muted); }
+.cx-approval-file { padding: 4px 12px; }
+.cx-approval-file-head { font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: var(--cx-text); }
+.cx-approval-diff {
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  background: var(--cx-code-strong);
+  color: #e8e8ea;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  border-radius: var(--cx-radius);
+}
 .cx-approval-actions { display: flex; flex-wrap: wrap; gap: 8px; padding: 10px 12px; border-top: 1px solid var(--cx-border); }
 .cx-approval-btn {
   padding: 6px 14px;


### PR DESCRIPTION
Follow-up fixes for the three issues the [MAC-8129](https://multica.macaron.xin/issues/3e98e4be-6923-462d-8bee-6b0ea72d3a37 "Codex-native plan and approval UI via app-server events") smoke test flagged on the merged app-server UX (#130).

## Blocker: new-thread approvals were dropped

On a brand-new thread the route `sid` is empty until the turn finishes and navigates, but approval requests arrive **mid-turn**. `decideApproval`/`stop` guarded on `if (!sid) return`, so the `Approve` click never POSTed and the card stayed pending while the app-server turn remained parked. Now the sid the server reveals via `onMeta` is captured into `liveSidRef` immediately, and both handlers target `sid || liveSidRef.current`.

## Network approval showed no port

Threaded an optional `port` through the network approval context (`shared` → runner → route → web), and the card renders `protocol://host:port` when present.

> Note: codex-cli 0.144.1's real `NetworkApprovalContext` only carries `host` + `protocol` (no port) — confirmed via `codex app-server generate-ts`. The smoke fixture sent a port, so this makes the UI honor one if a future codex build emits it, but a live codex today still won't populate it.

## File approval showed no diff

The web `Item` type never carried `fileChanges`, so proposed diffs were dropped before render even though the server already attaches them. Added `fileChanges` to the approval item + `withApproval`, and the card now lists each changed path with its diff.

Server tests 7/7, `@macaron/shared` + `@macaron/server` typecheck, and the full web build are green on Node 22.