### PR TITLE
avoid canvas notifications inside React state updater

### DIFF
--- a/web/src/lib/canvas.ts
+++ b/web/src/lib/canvas.ts
@@ -6,7 +6,7 @@
 // (1–12) and rowSpan (1–20). Auto-flow places tiles in order; a resize
 // nudges the numbers, an animation smooths the transition.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { newTerminalSid } from './terminal';
 
 export type TileGeom = { sid: string; colSpan: number; rowSpan: number };
@@ -170,30 +170,36 @@ export function useCanvas(project: string): {
   promoteDraft: (realSid: string) => void;
 } {
   const [state, setState] = useState<CanvasState>(() => loadCanvas(project));
+  const stateRef = useRef(state);
 
   useEffect(() => {
-    setState(loadCanvas(project));
+    const sync = () => {
+      const next = loadCanvas(project);
+      stateRef.current = next;
+      setState(next);
+    };
+    sync();
     let set = listeners.get(project);
     if (!set) {
       set = new Set();
       listeners.set(project, set);
     }
-    const cb = () => setState(loadCanvas(project));
-    set.add(cb);
+    set.add(sync);
     return () => {
-      set!.delete(cb);
+      set!.delete(sync);
       if (set!.size === 0) listeners.delete(project);
     };
   }, [project]);
 
   const update = useCallback(
     (patch: (cur: CanvasState) => CanvasState) => {
-      setState((cur) => {
-        const next = patch(cur);
-        saveCanvas(project, next);
-        notify(project);
-        return next;
-      });
+      const cur = stateRef.current;
+      const next = patch(cur);
+      if (next === cur) return;
+      stateRef.current = next;
+      saveCanvas(project, next);
+      setState(next);
+      notify(project);
     },
     [project],
   );


### PR DESCRIPTION
## Summary

- keep the latest canvas state in a ref for sequential operations
- persist and notify subscribers outside React's state updater
- skip notifications for no-op canvas updates

## Verification

- `pnpm build`
- reproduced the Dispatch failed-card navigation in Vite dev and the production build
- verified card navigation, canvas add, focus, and remove without React #185, cross-component update warnings, or maximum update depth errors

`pnpm --filter @macaron/web typecheck` remains blocked by existing errors in the GenUI vendor tree and third-party `partial-react` / `partial-tsx` packages; none point to `canvas.ts`.

Closes [MAC-7884](https://multica.macaron.xin/issues/bfdc8a4f-e3d0-43ac-9061-08300883dea0 "Smoke test PR #95 Dispatch board (parallel-session Kanban) and upload hi-res step screenshots")
