### PR TITLE
Document `bunx mcc@…` / `bunx mcx@…` single-command launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The published tarball ships the prebuilt server + web bundles and exposes two bi
 
 ```bash
 bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Codex  → http://localhost:7979
 ```
 
 `bunx` resolves by bin name, so `mcx@…` runs the Codex launcher from the same `mcc` package. Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/mindverse-ltd/macaron-claude-code/commits/main)). Both accept `--host` / `--port`; run with `--help` for the full list.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifac
 codex plugin add macaron@macaron
 ```
 
+### Run without installing
+
+The published tarball ships the prebuilt server + web bundles and exposes two bins — `mcc` (Claude WebUI, port `7878`) and `mcx` (Codex WebUI, port `7979`). Launch either in one command, no plugin install needed:
+
+```bash
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
+```
+
+`bunx` resolves by bin name, so `mcx@…` runs the Codex launcher from the same `mcc` package. Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/mindverse-ltd/macaron-claude-code/commits/main)). Both accept `--host` / `--port`; run with `--help` for the full list.
+
 Verify:
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -31,7 +31,7 @@ codex plugin add macaron@macaron
 
 ```bash
 bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Codex  → http://localhost:7979
 ```
 
 `bunx` 按 bin 名解析，所以 `mcx@…` 会从同一个 `mcc` 包里跑起 Codex 启动器。`<sha>` 换成 `main` 上的某个 commit。两个 bin 都支持 `--host` / `--port`，`--help` 看全部参数。

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,6 +25,17 @@ codex plugin add macaron@macaron
 
 装完在会话里说 `open macaron web ui` 打开。
 
+### 不装插件，一句 bunx 拉起
+
+发布的 tarball 自带预构建的 server + web 产物，并暴露两个 bin —— `mcc`（Claude WebUI，端口 `7878`）和 `mcx`（Codex WebUI，端口 `7979`）。任选一个一句话拉起：
+
+```bash
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
+```
+
+`bunx` 按 bin 名解析，所以 `mcx@…` 会从同一个 `mcc` 包里跑起 Codex 启动器。`<sha>` 换成 `main` 上的某个 commit。两个 bin 都支持 `--host` / `--port`，`--help` 看全部参数。
+
 ## 使用
 
 进 WebUI 后：


### PR DESCRIPTION
Docs-only. Adds the `bunx` single-command launch to `README.md` and `docs/USAGE.md`, covering both bins:

- `bunx mcc@…` — Claude WebUI (port `7878`)
- `bunx mcx@…` — Codex WebUI (port `7979`)

The underlying feature already ships — this PR just documents it. Both bins and the prebuilt-tarball publishing were delivered by 98b57a9 (`mcx` alongside `mcc`) and e7ddd2c (ship prebuilt dist; codex default port 7979); CI publishes via `pkg-pr-new publish --no-compact --bin`. No code changes here.

Verified end-to-end that `bunx mcx@<mcc pkg.pr.new url>` resolves and runs the `mcx` bin (bunx matches by bin name, so the Codex launcher runs out of the same `mcc` package).

Closes [MAC-8449](https://multica.macaron.xin/issues/4454fdfb-25f3-46f4-a3bb-22e85571dd4a "为 macaron-claude-code Codex WebUI 提供单命令运行方式").
