### PR TITLE
Align Codex canvas tile action icons

### DIFF
--- a/web/src/codex/CodexWorkspace.tsx
+++ b/web/src/codex/CodexWorkspace.tsx
@@ -19,6 +19,7 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Copy, RefreshCw, X } from 'lucide-react';
 import { codexApi, type CodexThread, type CodexWorkspace as Wk } from './api';
 import { CodexChat } from './CodexChat';
 import {
@@ -253,26 +254,35 @@ function SortableTile({
         <span className="cx-tile-grip-dots">⋮⋮</span>
         <span className="cx-tile-grip-label">{label}</span>
         <button
+          type="button"
           className="cx-tile-action"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => { e.stopPropagation(); copyResume(); }}
           title="Copy `codex resume` command"
           aria-label="Copy resume command"
-        >⧉</button>
+        >
+          <Copy size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
         <button
+          type="button"
           className="cx-tile-action"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => { e.stopPropagation(); setRefreshKey((k) => k + 1); }}
           title="Refresh"
           aria-label="Refresh"
-        >↻</button>
+        >
+          <RefreshCw size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
         <button
-          className="cx-tile-close"
+          type="button"
+          className="cx-tile-action cx-tile-action-danger"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => { e.stopPropagation(); onRemove(); }}
           title="Remove from canvas"
           aria-label="Remove from canvas"
-        >×</button>
+        >
+          <X size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
       </div>
       <div className="cx-tile-body">
         <CodexChat

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1332,7 +1332,7 @@ body {
   font-weight: 500;
   letter-spacing: -0.05px;
 }
-.cx-tile-action, .cx-tile-close {
+.cx-tile-action {
   width: 24px;
   height: 24px;
   padding: 0;
@@ -1346,16 +1346,24 @@ body {
   cursor: pointer;
   font-size: 12px;
   line-height: 1;
+  flex-shrink: 0;
   opacity: 0;
   transition: opacity 140ms, background 140ms, color 140ms;
 }
+.cx-tile-action svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
 .cx-tile:hover .cx-tile-action,
-.cx-tile:hover .cx-tile-close,
-.cx-tile.focused .cx-tile-action,
-.cx-tile.focused .cx-tile-close { opacity: 1; }
+.cx-tile.focused .cx-tile-action { opacity: 1; }
 .cx-tile-action:hover { background: var(--cx-hover); color: var(--cx-text); }
-.cx-tile-close { font-size: 15px; }
-.cx-tile-close:hover { background: rgba(197, 58, 58, 0.10); color: var(--cx-bad); }
+.cx-tile-action:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--cx-text);
+  outline-offset: 1px;
+}
+.cx-tile-action-danger:hover { background: rgba(197, 58, 58, 0.10); color: var(--cx-bad); }
 
 .cx-tile-body {
   flex: 1;


### PR DESCRIPTION
## Summary

- replace the Codex canvas tile's Unicode copy, refresh, and remove glyphs with Lucide icons
- standardize all three controls on 24px buttons with 14px icons and shared alignment styles
- preserve the remove danger state and add a visible keyboard focus treatment

## Verification

- `pnpm build`
- `pnpm --filter @macaron/server test` (24 passed)
- desktop browser smoke at 1440x900 and 1280x800
- verified idle, tile hover/focused, neutral hover, danger hover, and keyboard focus-visible states
- verified copy payload, refresh requests, remove behavior, and no console/page errors

`pnpm typecheck` remains blocked by existing vendored GenUI and third-party type errors, including unresolved `@genui/unocss`/alias modules and Bun/WASM types. The production build compiles the changed component successfully.

Closes [MAC-8451](https://multica.macaron.xin/issues/4679c13e-05c2-4012-b1f6-52d4430e8b7c "统一 macaron-claude-code 中 Codex 三个按钮的图标并修复对齐")
