### PR TITLE
preserve active turns across refresh

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0))
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/server/src/lib/active-runs.test.ts
+++ b/server/src/lib/active-runs.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { abortRun, claimRun, endRun } from './active-runs.js';
+
+test('a session claim stays owned until its runner releases it', () => {
+  const sid = 'claim-owner-test';
+  const first = new AbortController();
+  const competing = new AbortController();
+
+  assert.equal(claimRun(sid, first), true);
+  assert.equal(claimRun(sid, competing), false);
+  assert.equal(abortRun(sid), true);
+  assert.equal(first.signal.aborted, true);
+  assert.equal(abortRun(sid), false);
+
+  assert.equal(endRun(sid, competing), false);
+  assert.equal(claimRun(sid, competing), false);
+  assert.equal(endRun(sid, first), true);
+  assert.equal(claimRun(sid, competing), true);
+  assert.equal(endRun(sid, competing), true);
+});

--- a/server/src/lib/active-runs.ts
+++ b/server/src/lib/active-runs.ts
@@ -18,6 +18,10 @@ export function claimRun(sid: string, ac: AbortController): boolean {
 export function abortRun(sid: string): boolean {
   const ac = runs.get(sid);
   if (!ac || ac.signal.aborted) return false;
+  // Abort requests cancellation but deliberately keeps the claim. Releasing
+  // it before the SDK iterator settles could let a second resume start while
+  // the old runner is still unwinding and able to write to the same transcript
+  // or live entry. The owning route releases the claim at terminal cleanup.
   ac.abort();
   return true;
 }

--- a/server/src/lib/active-runs.ts
+++ b/server/src/lib/active-runs.ts
@@ -9,14 +9,20 @@ export function registerRun(sid: string, ac: AbortController): void {
   runs.set(sid, ac);
 }
 
-export function abortRun(sid: string): boolean {
-  const ac = runs.get(sid);
-  if (!ac) return false;
-  ac.abort();
-  runs.delete(sid);
+export function claimRun(sid: string, ac: AbortController): boolean {
+  if (runs.has(sid)) return false;
+  runs.set(sid, ac);
   return true;
 }
 
-export function endRun(sid: string): void {
-  runs.delete(sid);
+export function abortRun(sid: string): boolean {
+  const ac = runs.get(sid);
+  if (!ac || ac.signal.aborted) return false;
+  ac.abort();
+  return true;
+}
+
+export function endRun(sid: string, owner?: AbortController): boolean {
+  if (owner && runs.get(sid) !== owner) return false;
+  return runs.delete(sid);
 }

--- a/server/src/lib/live-registry.ts
+++ b/server/src/lib/live-registry.ts
@@ -60,6 +60,9 @@ export function liveEnd(sid: string, payload: SessionStreamEvent): void {
   // Delete only if this exact entry is still current: a later liveStart on the
   // same sid installs a fresh entry, and that turn must outlive this timer.
   ls.gc = setTimeout(() => { if (sessions.get(sid) === ls) sessions.delete(sid); }, KEEP_AROUND_MS);
+  // A replay-cache expiry should never keep a shutting-down server or a test
+  // worker alive by itself. While the server is running, the timer still fires.
+  ls.gc.unref();
 }
 
 export function liveGet(sid: string): LiveSession | undefined {

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -14,13 +14,14 @@ import {
 } from '../lib/session-store.js';
 import { startSSE, sseSend, sseDone } from '../lib/sse.js';
 import { setLabel, deleteLabel } from '../lib/label-store.js';
-import { liveGet } from '../lib/live-registry.js';
-import { runClaude, runFollowup, type AttachedImage } from '../lib/claude-runner.js';
+import { liveGet, liveStart, livePush, liveEnd } from '../lib/live-registry.js';
+import { runClaude, runFollowup, type AttachedImage, type RunOptions, type RunnerEvent } from '../lib/claude-runner.js';
 import { getActiveProviderEnv, getActiveProviderRaw, getFollowupSuggestionsEnabled } from '../lib/settings-store.js';
-import { registerRun, abortRun, endRun } from '../lib/active-runs.js';
+import { claimRun, abortRun, endRun } from '../lib/active-runs.js';
 import { resolvePending } from '../lib/permission-registry.js';
 import { pushPermissionRequest, pushSessionDone } from '../lib/push-notify.js';
 import { listSlashCommands } from '../lib/slash-commands.js';
+import type { SessionStreamEvent } from '@macaron/shared';
 
 type Params = { project: string; sid: string };
 type MessageBody = {
@@ -30,7 +31,12 @@ type MessageBody = {
   images?: AttachedImage[];
 };
 
-export async function registerSessionRoutes(app: FastifyInstance): Promise<void> {
+type SessionRouteOptions = {
+  runClaude?: (opts: RunOptions) => AsyncGenerator<RunnerEvent>;
+};
+
+export async function registerSessionRoutes(app: FastifyInstance, options: SessionRouteOptions = {}): Promise<void> {
+  const runClaudeForRoute = options.runClaude ?? runClaude;
   // Grep claude transcripts for a substring — backs the command palette's
   // message search. Newest-first, capped at `limit` hits (see searchMessages).
   app.get<{ Querystring: { q?: string; limit?: string } }>(
@@ -363,6 +369,14 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       // project name (which claude-cli derives from the cwd).
       const cwd = await resolveSessionCwd(project, sid);
 
+      // A session can only own one runner at a time. Keep the claim until that
+      // runner's terminal cleanup so a refresh/duplicate tab cannot replace its
+      // abort controller or live replay entry with a competing POST.
+      const abortController = new AbortController();
+      if (!claimRun(sid, abortController)) {
+        return reply.status(409).send({ error: 'session already running' });
+      }
+
       startSSE(reply);
       sseSend(reply, { type: 'meta', cwd, sessionId: sid });
 
@@ -373,37 +387,45 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
         try { sseSend(reply, payload); } catch { clientGone = true; }
       };
 
+      // Keep a server-authoritative copy of this turn independent of the
+      // original response. A browser refresh closes that response, but the SDK
+      // keeps running; /live replays this ring and then follows new events.
+      liveStart(sid, { cwd });
+      livePush(sid, { type: 'user-text', text });
+      const relay = (payload: SessionStreamEvent) => {
+        safeSend(payload);
+        livePush(sid, payload);
+      };
+
       // The Settings-selected active provider determines which
       // Anthropic-compatible endpoint the SDK talks to (default = ambient
       // Claude login). Same tools, same jsonl, same everything.
       const { model: providerModel, env: providerEnv } = getActiveProviderEnv();
       void model; // eslint: kept in body for future per-message override
 
-      // Register an abort controller so `/stop` can interrupt this stream.
-      const abortController = new AbortController();
-      registerRun(sid, abortController);
-
       (async () => {
-        for await (const ev of runClaude({ prompt: text, cwd, resume: sid, model: providerModel, permissionMode, images, envOverrides: providerEnv, abortController })) {
-          if (ev.kind === 'delta') safeSend({ type: 'delta', text: ev.text });
+        for await (const ev of runClaudeForRoute({ prompt: text, cwd, resume: sid, model: providerModel, permissionMode, images, envOverrides: providerEnv, abortController })) {
+          if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
           else if (ev.kind === 'tool_use') {
-            safeSend({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
+            relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
           }
           else if (ev.kind === 'tool_input_delta') {
-            safeSend({ type: 'tool_input_delta', id: ev.id, name: ev.name, partial_json: ev.partial_json, accumulated: ev.accumulated });
+            relay({ type: 'tool_input_delta', id: ev.id, name: ev.name, partial_json: ev.partial_json, accumulated: ev.accumulated });
           }
           else if (ev.kind === 'tool_input_done') {
-            safeSend({ type: 'tool_input_done', id: ev.id, name: ev.name, final_json: ev.final_json });
+            relay({ type: 'tool_input_done', id: ev.id, name: ev.name, final_json: ev.final_json });
           }
-          else if (ev.kind === 'tool_result') safeSend({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
-          else if (ev.kind === 'permission_request') { safeSend({ type: 'permission_request', id: ev.id, toolName: ev.toolName, input: ev.input, suggestion: ev.suggestion }); pushPermissionRequest(project, sid, ev.toolName); }
-          else if (ev.kind === 'permission_resolved') safeSend({ type: 'permission_resolved', id: ev.id, decision: ev.decision });
-          else if (ev.kind === 'usage') safeSend({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
-          else if (ev.kind === 'message') safeSend({ type: 'event', event: 'system', subtype: ev.subtype });
-          else if (ev.kind === 'error') safeSend({ type: 'error', error: ev.error });
+          else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
+          else if (ev.kind === 'permission_request') { relay({ type: 'permission_request', id: ev.id, toolName: ev.toolName, input: ev.input, suggestion: ev.suggestion }); pushPermissionRequest(project, sid, ev.toolName); }
+          else if (ev.kind === 'permission_resolved') relay({ type: 'permission_resolved', id: ev.id, decision: ev.decision });
+          else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
+          else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
+          else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
           else if (ev.kind === 'done') {
-            safeSend({ type: 'done', exitCode: ev.exitCode });
-            endRun(sid);
+            const done = { type: 'done' as const, exitCode: ev.exitCode };
+            safeSend(done);
+            liveEnd(sid, done);
+            endRun(sid, abortController);
             pushSessionDone(project, sid);
             // After the main turn: stream a throwaway follow-up-suggestions
             // query resuming the same session (shared prefix → provider cache
@@ -428,9 +450,11 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           }
         }
       })().catch((e: unknown) => {
-        endRun(sid);
+        endRun(sid, abortController);
         const msg = (e as Error).message;
         safeSend({ type: 'error', error: msg });
+        livePush(sid, { type: 'error', error: msg });
+        liveEnd(sid, { type: 'done', exitCode: -1, error: msg });
         if (!clientGone) sseDone(reply);
       });
     },

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -33,10 +33,12 @@ type MessageBody = {
 
 type SessionRouteOptions = {
   runClaude?: (opts: RunOptions) => AsyncGenerator<RunnerEvent>;
+  getActiveProviderEnv?: typeof getActiveProviderEnv;
 };
 
 export async function registerSessionRoutes(app: FastifyInstance, options: SessionRouteOptions = {}): Promise<void> {
   const runClaudeForRoute = options.runClaude ?? runClaude;
+  const getActiveProviderEnvForRoute = options.getActiveProviderEnv ?? getActiveProviderEnv;
   // Grep claude transcripts for a substring — backs the command palette's
   // message search. Newest-first, capped at `limit` hits (see searchMessages).
   app.get<{ Querystring: { q?: string; limit?: string } }>(
@@ -339,7 +341,7 @@ export async function registerSessionRoutes(app: FastifyInstance, options: Sessi
 
       const cwd = await resolveSessionCwd(project, sid);
 
-      const { model: providerModel, env: providerEnv } = getActiveProviderEnv();
+      const { model: providerModel, env: providerEnv } = getActiveProviderEnvForRoute();
       let clientGone = false;
       reply.raw.on('close', () => { clientGone = true; });
       try {
@@ -377,86 +379,125 @@ export async function registerSessionRoutes(app: FastifyInstance, options: Sessi
         return reply.status(409).send({ error: 'session already running' });
       }
 
-      startSSE(reply);
-      sseSend(reply, { type: 'meta', cwd, sessionId: sid });
-
       let clientGone = false;
+      let sseStarted = false;
+      let liveStarted = false;
+      let terminalSent = false;
       reply.raw.on('close', () => { clientGone = true; });
       const safeSend = (payload: Parameters<typeof sseSend>[1]) => {
-        if (clientGone) return;
+        if (!sseStarted || clientGone) return;
         try { sseSend(reply, payload); } catch { clientGone = true; }
       };
 
-      // Keep a server-authoritative copy of this turn independent of the
-      // original response. A browser refresh closes that response, but the SDK
-      // keeps running; /live replays this ring and then follows new events.
-      liveStart(sid, { cwd });
-      livePush(sid, { type: 'user-text', text });
+      const finishMainRun = (exitCode: number, error?: string) => {
+        if (terminalSent) return;
+        terminalSent = true;
+        if (error) {
+          safeSend({ type: 'error', error });
+          if (liveStarted) livePush(sid, { type: 'error', error });
+        }
+        const done = { type: 'done' as const, exitCode, ...(error ? { error } : {}) };
+        safeSend(done);
+        if (liveStarted) liveEnd(sid, done);
+        endRun(sid, abortController);
+      };
+
+      let provider: ReturnType<typeof getActiveProviderEnv>;
+      try {
+        // Mark setup as attempted before each call so a partial synchronous
+        // failure still takes the corresponding terminal cleanup path.
+        sseStarted = true;
+        startSSE(reply);
+        safeSend({ type: 'meta', cwd, sessionId: sid });
+
+        // Keep a server-authoritative copy of this turn independent of the
+        // original response. A browser refresh closes that response, but the SDK
+        // keeps running; /live replays this ring and then follows new events.
+        liveStarted = true;
+        liveStart(sid, { cwd });
+        livePush(sid, { type: 'user-text', text });
+
+        // The Settings-selected active provider determines which
+        // Anthropic-compatible endpoint the SDK talks to (default = ambient
+        // Claude login). Same tools, same jsonl, same everything.
+        provider = getActiveProviderEnvForRoute();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        finishMainRun(-1, msg);
+        if (!clientGone) sseDone(reply);
+        return;
+      }
+
       const relay = (payload: SessionStreamEvent) => {
         safeSend(payload);
         livePush(sid, payload);
       };
 
-      // The Settings-selected active provider determines which
-      // Anthropic-compatible endpoint the SDK talks to (default = ambient
-      // Claude login). Same tools, same jsonl, same everything.
-      const { model: providerModel, env: providerEnv } = getActiveProviderEnv();
+      const { model: providerModel, env: providerEnv } = provider;
       void model; // eslint: kept in body for future per-message override
 
-      (async () => {
-        for await (const ev of runClaudeForRoute({ prompt: text, cwd, resume: sid, model: providerModel, permissionMode, images, envOverrides: providerEnv, abortController })) {
-          if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
-          else if (ev.kind === 'tool_use') {
-            relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
-          }
-          else if (ev.kind === 'tool_input_delta') {
-            relay({ type: 'tool_input_delta', id: ev.id, name: ev.name, partial_json: ev.partial_json, accumulated: ev.accumulated });
-          }
-          else if (ev.kind === 'tool_input_done') {
-            relay({ type: 'tool_input_done', id: ev.id, name: ev.name, final_json: ev.final_json });
-          }
-          else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
-          else if (ev.kind === 'permission_request') { relay({ type: 'permission_request', id: ev.id, toolName: ev.toolName, input: ev.input, suggestion: ev.suggestion }); pushPermissionRequest(project, sid, ev.toolName); }
-          else if (ev.kind === 'permission_resolved') relay({ type: 'permission_resolved', id: ev.id, decision: ev.decision });
-          else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
-          else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
-          else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
-          else if (ev.kind === 'done') {
-            const done = { type: 'done' as const, exitCode: ev.exitCode };
-            safeSend(done);
-            liveEnd(sid, done);
-            endRun(sid, abortController);
-            pushSessionDone(project, sid);
-            // After the main turn: stream a throwaway follow-up-suggestions
-            // query resuming the same session (shared prefix → provider cache
-            // hit, near-free). persistSession:false keeps it off disk. Each
-            // text delta is forwarded as a `followup_delta` event; the WebUI
-            // accumulates + parses incrementally with partial-json. Best-effort
-            // — any failure is swallowed, never blocks the turn's close.
-            // Only on a clean finish (exitCode 0): a Stop (abort → -1) or a
-            // mid-turn error must stay byte-identical to pre-feature behavior,
-            // never spinning up a follow-up query on an aborted transcript.
-            if (!clientGone && ev.exitCode === 0 && getFollowupSuggestionsEnabled()) {
-              try {
-                for await (const delta of runFollowup({ resume: sid, cwd, model: providerModel, envOverrides: providerEnv })) {
-                  if (clientGone) break;
-                  safeSend({ type: 'followup_delta', text: delta });
-                }
-              } catch {
-                /* swallow: follow-up is enrichment, never fatal */
-              }
+      void (async () => {
+        try {
+          for await (const ev of runClaudeForRoute({ prompt: text, cwd, resume: sid, model: providerModel, permissionMode, images, envOverrides: providerEnv, abortController })) {
+            if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
+            else if (ev.kind === 'tool_use') {
+              relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
             }
-            if (!clientGone) sseDone(reply);
+            else if (ev.kind === 'tool_input_delta') {
+              relay({ type: 'tool_input_delta', id: ev.id, name: ev.name, partial_json: ev.partial_json, accumulated: ev.accumulated });
+            }
+            else if (ev.kind === 'tool_input_done') {
+              relay({ type: 'tool_input_done', id: ev.id, name: ev.name, final_json: ev.final_json });
+            }
+            else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
+            else if (ev.kind === 'permission_request') { relay({ type: 'permission_request', id: ev.id, toolName: ev.toolName, input: ev.input, suggestion: ev.suggestion }); pushPermissionRequest(project, sid, ev.toolName); }
+            else if (ev.kind === 'permission_resolved') relay({ type: 'permission_resolved', id: ev.id, decision: ev.decision });
+            else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
+            else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
+            else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
+            else if (ev.kind === 'done') {
+              // `done` is the main-turn ownership boundary. Follow-ups are
+              // non-persisting enrichment, so release the live entry and claim
+              // before generating them: queued/new user turns must be able to
+              // start, while stale follow-up deltas are client-generation gated
+              // and refreshes can regenerate them through /followups.
+              finishMainRun(ev.exitCode);
+              pushSessionDone(project, sid);
+              // After the main turn: stream a throwaway follow-up-suggestions
+              // query resuming the same session (shared prefix → provider cache
+              // hit, near-free). persistSession:false keeps it off disk. Each
+              // text delta is forwarded as a `followup_delta` event; the WebUI
+              // accumulates + parses incrementally with partial-json. Best-effort
+              // — any failure is swallowed, never blocks the turn's close.
+              // Only on a clean finish (exitCode 0): a Stop (abort → -1) or a
+              // mid-turn error must stay byte-identical to pre-feature behavior,
+              // never spinning up a follow-up query on an aborted transcript.
+              if (!clientGone && ev.exitCode === 0 && getFollowupSuggestionsEnabled()) {
+                try {
+                  for await (const delta of runFollowup({ resume: sid, cwd, model: providerModel, envOverrides: providerEnv })) {
+                    if (clientGone) break;
+                    safeSend({ type: 'followup_delta', text: delta });
+                  }
+                } catch {
+                  /* swallow: follow-up is enrichment, never fatal */
+                }
+              }
+              return;
+            }
           }
+          // Production runClaude emits `done` on every settled path, but keep
+          // the route owner-safe if a future/custom iterator simply returns.
+          finishMainRun(-1, 'runner ended without a terminal event');
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          finishMainRun(-1, msg);
+        } finally {
+          // Owner-guarded and idempotent: any settled iterator releases its
+          // claim even if terminal event handling changes later.
+          endRun(sid, abortController);
+          if (!clientGone) sseDone(reply);
         }
-      })().catch((e: unknown) => {
-        endRun(sid, abortController);
-        const msg = (e as Error).message;
-        safeSend({ type: 'error', error: msg });
-        livePush(sid, { type: 'error', error: msg });
-        liveEnd(sid, { type: 'done', exitCode: -1, error: msg });
-        if (!clientGone) sseDone(reply);
-      });
+      })();
     },
   );
 

--- a/server/test/session-live-route.test.ts
+++ b/server/test/session-live-route.test.ts
@@ -116,3 +116,147 @@ test('resumed bypass turn survives original SSE disconnect and replays through /
   assert.match(liveText, /"type":"done","exitCode":0/);
   await liveReader.cancel().catch(() => {});
 });
+
+test('synchronous setup failure ends live replay and releases the run claim', { timeout: 10_000 }, async (t) => {
+  const project = 'setup-failure-project';
+  const sid = 'setup-failure-session';
+  const cwd = path.join(tmpHome, 'setup-failure-repo');
+  await fs.mkdir(path.join(CLAUDE_PROJECTS, project), { recursive: true });
+  await fs.mkdir(cwd, { recursive: true });
+  await fs.writeFile(
+    path.join(CLAUDE_PROJECTS, project, `${sid}.jsonl`),
+    `${JSON.stringify({ type: 'user', cwd, message: { role: 'user', content: 'earlier turn' } })}\n`,
+    'utf8',
+  );
+
+  let providerCalls = 0;
+  let runnerCalls = 0;
+  async function* fakeRunClaude(): AsyncGenerator<RunnerEvent> {
+    runnerCalls += 1;
+    yield { kind: 'done', exitCode: 0 };
+  }
+
+  const app = Fastify({ logger: false });
+  await registerSessionRoutes(app, {
+    runClaude: fakeRunClaude,
+    getActiveProviderEnv: () => {
+      providerCalls += 1;
+      if (providerCalls === 1) throw new Error('provider setup failed');
+      return { model: 'test-model', env: null };
+    },
+  });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    app.server.closeAllConnections();
+    await app.close();
+  });
+
+  const address = app.server.address();
+  assert.ok(address && typeof address !== 'string');
+  const sessionPath = `http://127.0.0.1:${address.port}/api/sessions/claude/${project}/${sid}`;
+
+  const failed = await fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'first attempt' }),
+  });
+  assert.equal(failed.status, 200);
+  const failedText = await failed.text();
+  assert.match(failedText, /"type":"error","error":"provider setup failed"/);
+  assert.match(failedText, /"type":"done","exitCode":-1,"error":"provider setup failed"/);
+  assert.equal(runnerCalls, 0);
+
+  const replay = await fetch(`${sessionPath}/live`, { headers: { Accept: 'text/event-stream' } });
+  assert.equal(replay.status, 200);
+  const replayText = await replay.text();
+  assert.match(replayText, /"type":"error","error":"provider setup failed"/);
+  assert.match(replayText, /"type":"done","exitCode":-1,"error":"provider setup failed"/);
+
+  const retry = await fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'second attempt' }),
+  });
+  assert.equal(retry.status, 200);
+  assert.match(await retry.text(), /"type":"done","exitCode":0/);
+  assert.equal(runnerCalls, 1);
+});
+
+test('abort retains ownership until a runner without done settles', { timeout: 10_000 }, async (t) => {
+  const project = 'abort-owner-project';
+  const sid = 'abort-owner-session';
+  const cwd = path.join(tmpHome, 'abort-owner-repo');
+  await fs.mkdir(path.join(CLAUDE_PROJECTS, project), { recursive: true });
+  await fs.mkdir(cwd, { recursive: true });
+  await fs.writeFile(
+    path.join(CLAUDE_PROJECTS, project, `${sid}.jsonl`),
+    `${JSON.stringify({ type: 'user', cwd, message: { role: 'user', content: 'earlier turn' } })}\n`,
+    'utf8',
+  );
+
+  let finishAbort!: () => void;
+  const abortGate = new Promise<void>((resolve) => { finishAbort = resolve; });
+  let firstRunStarted!: () => void;
+  const firstRunGate = new Promise<void>((resolve) => { firstRunStarted = resolve; });
+  let runnerCalls = 0;
+  let firstOptions: RunOptions | undefined;
+  async function* fakeRunClaude(opts: RunOptions): AsyncGenerator<RunnerEvent> {
+    runnerCalls += 1;
+    if (runnerCalls > 1) {
+      yield { kind: 'done', exitCode: 0 };
+      return;
+    }
+    firstOptions = opts;
+    yield { kind: 'delta', text: 'still running' };
+    firstRunStarted();
+    await new Promise<void>((resolve) => opts.abortController?.signal.addEventListener('abort', () => resolve(), { once: true }));
+    await abortGate;
+    // Deliberately settle without the RunnerEvent contract's terminal `done`.
+  }
+
+  const app = Fastify({ logger: false });
+  await registerSessionRoutes(app, { runClaude: fakeRunClaude });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    finishAbort();
+    app.server.closeAllConnections();
+    await app.close();
+  });
+
+  const address = app.server.address();
+  assert.ok(address && typeof address !== 'string');
+  const sessionPath = `http://127.0.0.1:${address.port}/api/sessions/claude/${project}/${sid}`;
+  const original = await fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'long turn' }),
+  });
+  assert.equal(original.status, 200);
+  const originalText = original.text();
+  await firstRunGate;
+
+  const stopped = await fetch(`${sessionPath}/stop`, { method: 'POST' });
+  assert.deepEqual(await stopped.json(), { ok: true, running: true });
+  assert.equal(firstOptions?.abortController?.signal.aborted, true);
+
+  const competing = await fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'too early' }),
+  });
+  assert.equal(competing.status, 409);
+
+  finishAbort();
+  const terminalText = await originalText;
+  assert.match(terminalText, /runner ended without a terminal event/);
+  assert.match(terminalText, /"type":"done","exitCode":-1/);
+
+  const retry = await fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'after cleanup' }),
+  });
+  assert.equal(retry.status, 200);
+  assert.match(await retry.text(), /"type":"done","exitCode":0/);
+  assert.equal(runnerCalls, 2);
+});

--- a/server/test/session-live-route.test.ts
+++ b/server/test/session-live-route.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Fastify from 'fastify';
+import type { RunOptions, RunnerEvent } from '../src/lib/claude-runner.js';
+
+const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcc-live-route-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const [{ CLAUDE_PROJECTS }, { registerSessionRoutes }] = await Promise.all([
+  import('../src/config.js'),
+  import('../src/routes/sessions.js'),
+]);
+
+after(() => fs.rm(tmpHome, { recursive: true, force: true }));
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  marker: string,
+  initial = '',
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = initial;
+  while (!text.includes(marker)) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text;
+}
+
+test('resumed bypass turn survives original SSE disconnect and replays through /live', { timeout: 10_000 }, async (t) => {
+  const project = 'existing-project';
+  const sid = 'existing-session';
+  const cwd = path.join(tmpHome, 'repo');
+  await fs.mkdir(path.join(CLAUDE_PROJECTS, project), { recursive: true });
+  await fs.mkdir(cwd, { recursive: true });
+  await fs.writeFile(
+    path.join(CLAUDE_PROJECTS, project, `${sid}.jsonl`),
+    `${JSON.stringify({ type: 'user', cwd, message: { role: 'user', content: 'earlier turn' } })}\n`,
+    'utf8',
+  );
+
+  let continueRun!: () => void;
+  let finishRun!: () => void;
+  const continueGate = new Promise<void>((resolve) => { continueRun = resolve; });
+  const finishGate = new Promise<void>((resolve) => { finishRun = resolve; });
+  let observedOptions: RunOptions | undefined;
+
+  async function* fakeRunClaude(opts: RunOptions): AsyncGenerator<RunnerEvent> {
+    observedOptions = opts;
+    yield { kind: 'delta', text: 'before refresh' };
+    await continueGate;
+    yield { kind: 'delta', text: ' after refresh' };
+    await finishGate;
+    yield { kind: 'done', exitCode: 0 };
+  }
+
+  const app = Fastify({ logger: false });
+  await registerSessionRoutes(app, { runClaude: fakeRunClaude });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    app.server.closeAllConnections();
+    await app.close();
+  });
+
+  const address = app.server.address();
+  assert.ok(address && typeof address !== 'string');
+  const base = `http://127.0.0.1:${address.port}`;
+  const sessionPath = `/api/sessions/claude/${project}/${sid}`;
+
+  const original = await fetch(`${base}${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'keep working', permissionMode: 'bypassPermissions' }),
+  });
+  assert.equal(original.status, 200);
+  assert.ok(original.body);
+  const originalReader = original.body.getReader();
+  const originalText = await readUntil(originalReader, 'before refresh');
+  assert.match(originalText, /"type":"meta"/);
+  assert.match(originalText, /before refresh/);
+  await originalReader.cancel();
+
+  assert.equal(observedOptions?.resume, sid);
+  assert.equal(observedOptions?.permissionMode, 'bypassPermissions');
+  assert.equal(observedOptions?.abortController?.signal.aborted, false);
+
+  const duplicate = await fetch(`${base}${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'competing turn', permissionMode: 'default' }),
+  });
+  assert.equal(duplicate.status, 409);
+  assert.deepEqual(await duplicate.json(), { error: 'session already running' });
+
+  const reattached = await fetch(`${base}${sessionPath}/live`, {
+    headers: { Accept: 'text/event-stream' },
+  });
+  assert.equal(reattached.status, 200);
+  assert.ok(reattached.body);
+  const liveReader = reattached.body.getReader();
+  let liveText = await readUntil(liveReader, 'before refresh');
+  assert.match(liveText, /"type":"meta"/);
+  assert.match(liveText, /"type":"user-text","text":"keep working"/);
+
+  continueRun();
+  liveText = await readUntil(liveReader, 'after refresh', liveText);
+  assert.match(liveText, /after refresh/);
+
+  finishRun();
+  liveText = await readUntil(liveReader, '"type":"done"', liveText);
+  assert.match(liveText, /"type":"done","exitCode":0/);
+  await liveReader.cancel().catch(() => {});
+});

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --import tsx --test \"test/*.test.ts\"",
     "typecheck": "tsc -b",
     "preview": "vite preview"
   },
@@ -67,6 +68,7 @@
   "devDependencies": {
     "@macaron/shared": "workspace:*",
     "@vitejs/plugin-react": "^4.3.4",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vite": "^7.3.6"
   }

--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -69,7 +69,13 @@ function appendText(items: LiveTurnItem[], text: string): void {
 // speak the exact same event vocabulary, so keep the switch here and just
 // call `applyLiveEvent(sid, event)` from each stream loop.
 function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown }): void {
-  if (p.type === 'delta') {
+  if (p.type === 'meta') {
+    const s = states.get(sid);
+    if (s && typeof p.cwd === 'string') s.cwd = p.cwd;
+  } else if (p.type === 'user-text') {
+    const s = states.get(sid);
+    if (s) { s.userText = String(p.text || ''); notify(sid); }
+  } else if (p.type === 'delta') {
     const s = states.get(sid);
     if (s) { appendText(s.timeline, String(p.text || '')); notify(sid); }
   } else if (p.type === 'tool_use') {
@@ -174,6 +180,12 @@ function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown })
 
 const states = new Map<string, LiveState>();
 const watchers = new Map<string, Set<(s: LiveState) => void>>();
+type AttachResult = 'attached' | 'not-live';
+type LiveAttachment = { ready: Promise<AttachResult> };
+// A reattach reader stays alive after `ready` resolves. Keep it registered
+// until the SSE closes so StrictMode/remount probes join the same reader
+// instead of replaying the ring into `states` a second time.
+const liveAttachments = new Map<string, LiveAttachment>();
 // Follow-up suggestions are an "add-on" stream: they arrive AFTER the main
 // turn's `done` (which clears the live store), so they ride a separate
 // channel with its own subscribers — independent of `states`/`watchers`
@@ -446,83 +458,89 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
  * or 'not-live' if the run had already ended (nothing to do; caller falls
  * back to reading the jsonl).
  */
-export function attachLive(project: string, sid: string): Promise<'attached' | 'not-live'> {
-  return new Promise((resolve) => {
-    let resolved = false;
-    let seenAnyEvent = false;
-    const settle = (r: 'attached' | 'not-live') => {
-      if (resolved) return;
-      resolved = true;
-      resolve(r);
-    };
+export function attachLive(project: string, sid: string): Promise<AttachResult> {
+  const state = states.get(sid);
+  if (state) return Promise.resolve(state.done ? 'not-live' : 'attached');
 
-    authedFetch(`/api/sessions/claude/${encodeURIComponent(project)}/${encodeURIComponent(sid)}/live`, {
-      method: 'GET',
-      headers: { Accept: 'text/event-stream' },
-    })
-      .then(async (resp) => {
-        if (!resp.ok || !resp.body) {
-          settle('not-live');
-          return;
-        }
-        const reader = resp.body.getReader();
-        const dec = new TextDecoder();
-        let buf = '';
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buf += dec.decode(value, { stream: true });
-          const events = buf.split(/\r?\n\r?\n/);
-          buf = events.pop() || '';
-          for (const ev of events) {
-            const data = ev
-              .split(/\r?\n/)
-              .filter((l) => l.startsWith('data:'))
-              .map((l) => l.slice(5).trimStart())
-              .join('\n')
-              .trim();
-            if (!data || data === '[DONE]') continue;
-            try {
-              const p = JSON.parse(data);
-              // 'live-end' with reason 'not-live' fires when the server had
-              // no active run for this sid — treat as a soft miss so the
-              // caller can fall back to the jsonl.
-              if (p.type === 'live-end') {
-                if (!seenAnyEvent && p.reason === 'not-live') {
-                  settle('not-live');
-                } else {
-                  const s = states.get(sid);
-                  if (s && !s.done) { s.done = true; notify(sid); }
-                  settle('attached');
-                }
-                continue;
-              }
-              // First real event ⇒ ensure a state exists (the initial POST
-              // that created the run is long gone; we can't recover its
-              // meta cwd/userText, but the timeline is what we need).
-              if (!seenAnyEvent) {
-                seenAnyEvent = true;
-                if (!states.has(sid)) {
-                  states.set(sid, {
-                    cwd: '',
-                    userText: '',
-                    timeline: [],
-                    outputTokens: -1,
-                    done: false,
-                  });
-                }
-                settle('attached');
-              }
-              applyLiveEvent(sid, p);
-            } catch {
-              /* skip malformed event */
+  const active = liveAttachments.get(sid);
+  if (active) return active.ready;
+
+  let settleReady!: (result: AttachResult) => void;
+  let readySettled = false;
+  const ready = new Promise<AttachResult>((resolve) => { settleReady = resolve; });
+  const attachment: LiveAttachment = { ready };
+  const settle = (result: AttachResult) => {
+    if (readySettled) return;
+    readySettled = true;
+    settleReady(result);
+  };
+  liveAttachments.set(sid, attachment);
+
+  void (async () => {
+    let seenAnyEvent = false;
+    try {
+      const resp = await authedFetch(`/api/sessions/claude/${encodeURIComponent(project)}/${encodeURIComponent(sid)}/live`, {
+        method: 'GET',
+        headers: { Accept: 'text/event-stream' },
+      });
+      if (!resp.ok || !resp.body) {
+        settle('not-live');
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const events = buf.split(/\r?\n\r?\n/);
+        buf = events.pop() || '';
+        for (const ev of events) {
+          const data = ev
+            .split(/\r?\n/)
+            .filter((l) => l.startsWith('data:'))
+            .map((l) => l.slice(5).trimStart())
+            .join('\n')
+            .trim();
+          if (!data || data === '[DONE]') continue;
+          try {
+            const p = JSON.parse(data);
+            if (p.type === 'live-end' && p.reason === 'not-live' && !seenAnyEvent) {
+              settle('not-live');
+              await reader.cancel();
+              return;
             }
+            if (!seenAnyEvent) {
+              seenAnyEvent = true;
+              states.set(sid, {
+                cwd: p.type === 'meta' && typeof p.cwd === 'string' ? p.cwd : '',
+                userText: '',
+                timeline: [],
+                outputTokens: -1,
+                done: false,
+              });
+              settle('attached');
+            }
+            applyLiveEvent(sid, p);
+          } catch {
+            /* skip malformed event */
           }
         }
-        // Stream closed naturally — mark done if we ever attached.
-        const s = states.get(sid);
-        if (s && !s.done) { s.done = true; notify(sid); }
-      })
-      .catch(() => settle('not-live'));
-  });
+      }
+
+      if (!seenAnyEvent) settle('not-live');
+      const current = states.get(sid);
+      if (current && !current.done) { current.done = true; notify(sid); }
+    } catch {
+      settle('not-live');
+      const current = states.get(sid);
+      if (current && !current.done) { current.done = true; notify(sid); }
+    } finally {
+      if (liveAttachments.get(sid) === attachment) liveAttachments.delete(sid);
+    }
+  })();
+
+  return ready;
 }

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -1508,44 +1508,50 @@ export function Session(props: SessionProps = {}) {
     }
   }, [project, sid]);
 
+  // Pick exactly one source for the current turn. A freshly-created session
+  // already has startNewSession's POST reader writing to liveStore; opening a
+  // second /live reader would replay and append every token again. On a true
+  // page refresh the module store is empty, so probe /live first and only load
+  // the canonical jsonl when the server confirms there is no active stream.
   useEffect(() => {
     setData(null);
     setLiveTurn([]);
     setLiveUser('');
     setShown(PAGE_SIZE);
-    if (isNew) return; // no jsonl yet — empty state until first send
-    // For brand-new sessions the jsonl may not exist yet — suppress the 404 error.
-    load({ silent: isPending });
-    // isPending intentionally excluded from deps — we only want this to fire
-    // on session identity change (project/sid/refreshKey), not on every flip
-    // of the pending flag. It's only used inside as a silent-mode hint on load.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [project, sid, load, isNew, refreshKey]);
-
-  // Reattach probe: on session change, ask the server whether this sid is
-  // mid-turn (page was refreshed while streaming). If yes, attachLive opens
-  // SSE, seeds the live store, and starts feeding deltas — then we flip
-  // `reattached` so isPending becomes true and the existing pending
-  // subscription hook takes over (spinner, stop button, live text).
-  //
-  // `reattached` reset lives here, in the same session-identity effect, so
-  // it can't fight with isPending: flipping reattached → true (which flips
-  // isPending true) does NOT re-run this effect, so no reset-probe loop.
-  useEffect(() => {
     setReattached(false);
     if (isNew || !sid) return;
+
+    const local = getLive(sid);
+    if (local) {
+      setReattached(true);
+      setSending(!local.done);
+      return;
+    }
+
     let cancelled = false;
     void attachLive(project, sid).then((r) => {
       if (cancelled) return;
       if (r === 'attached') {
-        // Show "turn in flight" affordances immediately — the subscribeLive
-        // hook below is gated on isPending and will pick up the state.
+        // A buffered ended replay can reach `done` and be consumed by the
+        // pending subscription before this promise callback runs. Re-read the
+        // store instead of reviving a stream that has already been cleared.
+        const current = getLive(sid);
+        if (!current) {
+          setReattached(false);
+          setPolling(false);
+          setSending(false);
+          return;
+        }
         setReattached(true);
-        setSending(true);
+        setSending(!current.done);
+        return;
       }
+      void load({ silent: true }).finally(() => {
+        if (!cancelled) { setPolling(false); setSending(false); }
+      });
     });
     return () => { cancelled = true; };
-  }, [project, sid, isNew, refreshKey]);
+  }, [project, sid, load, isNew, refreshKey]);
 
   // Global Shift+Tab → cycle permission mode, matching claude-cli's binding.
   // The browser's own "reverse focus" behaviour is preempted; we surface the
@@ -1628,7 +1634,27 @@ export function Session(props: SessionProps = {}) {
         }),
       );
     };
-    if (seed) applyState(seed);
+    const finishLive = () => {
+      setPolling(false);
+      setSending(false);
+      setReattached(false);
+      clearLive(sid);
+      onPendingConsumed?.();
+      // Reattach intentionally renders the authoritative live replay without
+      // JSONL alongside it. Once terminal, restore canonical prior history;
+      // load() leaves the just-finished live buffers mounted if disk flush lags.
+      void load({ silent: true });
+    };
+    if (seed) {
+      applyState(seed);
+      // The retained replay can finish before attachLive's promise callback
+      // enables this subscription. Consume that terminal snapshot immediately
+      // instead of waiting for a future notification that will never arrive.
+      if (seed.done) {
+        finishLive();
+        return;
+      }
+    }
     let rafScheduled = false;
     let pendingState = seed;
     const flush = () => {
@@ -1640,19 +1666,15 @@ export function Session(props: SessionProps = {}) {
       if (s.done) {
         applyState(s);
         unsub();
-        // Don't reload from jsonl here — CLI flushes asynchronously and the
-        // file is often still stale, which would erase the just-streamed
-        // reply. The live buffers we already have in memory are the truth
-        // for this turn; they roll into completedTurns on the next send.
-        setPolling(false);
-        setSending(false);
-        clearLive(sid);
+        // Keep the live buffers mounted while finishLive restores canonical
+        // history. The CLI may still be flushing jsonl, so that reload must not
+        // replace the just-streamed turn.
+        finishLive();
         // Follow-up suggestions stream AFTER `done` over an independent
         // channel (subscribeFollowup), so clearing the live store here is
         // safe — the stop semantics are identical to before the feature.
         // Let the parent (draft-tile owner) drop this sid from its
         // pending set so a later refresh doesn't re-enter this branch.
-        onPendingConsumed?.();
         return;
       }
       if (!rafScheduled) {
@@ -1660,11 +1682,6 @@ export function Session(props: SessionProps = {}) {
         requestAnimationFrame(flush);
       }
     });
-    // Safety: if we're on a stale URL whose live store entry is gone (e.g.
-    // page refresh after streaming finished), fall back to plain load.
-    if (!seed) {
-      load({ silent: true }).then(() => { setPolling(false); setSending(false); });
-    }
     return () => {
       unsub();
     };

--- a/web/test/liveStore.test.ts
+++ b/web/test/liveStore.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { attachLive, clearLive, getLive, startNewSession, subscribeLive } from '../src/lib/liveStore';
+
+const originalFetch = globalThis.fetch;
+const encoder = new TextEncoder();
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function frame(payload: unknown): string {
+  return `data: ${typeof payload === 'string' ? payload : JSON.stringify(payload)}\n\n`;
+}
+
+function sseResponse(events: unknown[]): Response {
+  return new Response(events.map(frame).join('') + frame('[DONE]'), {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function streamedText(sid: string): string {
+  return getLive(sid)?.timeline
+    .filter((item) => item.kind === 'text')
+    .map((item) => item.text)
+    .join('') ?? '';
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail('condition was not met');
+}
+
+test('concurrent reattach probes share one SSE reader and apply each delta once', async () => {
+  const sid = 'single-flight-session';
+  let fetches = 0;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    return sseResponse([
+      { type: 'meta', cwd: '/repo', sessionId: sid },
+      { type: 'user-text', text: 'question' },
+      { type: 'delta', text: 'The ' },
+      { type: 'delta', text: 'user' },
+      { type: 'done', exitCode: 0 },
+    ]);
+  };
+
+  const results = await Promise.all([
+    attachLive('project', sid),
+    attachLive('project', sid),
+  ]);
+  await waitFor(() => getLive(sid)?.done === true);
+
+  assert.deepEqual(results, ['attached', 'attached']);
+  assert.equal(fetches, 1);
+  assert.equal(getLive(sid)?.cwd, '/repo');
+  assert.equal(getLive(sid)?.userText, 'question');
+  assert.equal(streamedText(sid), 'The user');
+  clearLive(sid);
+});
+
+test('an existing new-session POST owner prevents a second live attachment', async () => {
+  const sid = 'post-owned-session';
+  let fetches = 0;
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    return new Response(new ReadableStream<Uint8Array>({
+      start(next) {
+        controller = next;
+        next.enqueue(encoder.encode(
+          frame({ type: 'meta', cwd: '/repo', sessionId: sid }) +
+          frame({ type: 'delta', text: 'only once' }),
+        ));
+      },
+    }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  };
+
+  assert.equal(await startNewSession('project', { text: 'question' }), sid);
+  assert.equal(await attachLive('project', sid), 'attached');
+  assert.equal(fetches, 1);
+  assert.equal(streamedText(sid), 'only once');
+
+  controller.enqueue(encoder.encode(frame({ type: 'done', exitCode: 0 }) + frame('[DONE]')));
+  controller.close();
+  await waitFor(() => getLive(sid)?.done === true);
+  clearLive(sid);
+});
+
+test('an ended replay can be consumed before the attach promise callback runs', async () => {
+  const sid = 'ended-replay-session';
+  globalThis.fetch = async () => sseResponse([
+    { type: 'meta', cwd: '/repo', sessionId: sid },
+    { type: 'user-text', text: 'question' },
+    { type: 'delta', text: 'answer' },
+    { type: 'done', exitCode: 0 },
+  ]);
+
+  let rendered = '';
+  const unsubscribe = subscribeLive(sid, (state) => {
+    rendered = state.timeline
+      .filter((item) => item.kind === 'text')
+      .map((item) => item.text)
+      .join('');
+    if (state.done) clearLive(sid);
+  });
+
+  assert.equal(await attachLive('project', sid), 'attached');
+  assert.equal(rendered, 'answer');
+  assert.equal(getLive(sid), undefined);
+  unsubscribe();
+});


### PR DESCRIPTION
## Summary

- mirror existing-session Claude events through the live registry so refreshed clients replay and follow an active turn
- harden client reattachment with a single SSE reader, restored replay state, terminal cleanup, and canonical history reload
- claim active runs per session so concurrent sends return 409 and abort ownership remains with the running turn
- release both the run claim and live entry when synchronous pre-run setup fails, and synthesize terminal cleanup if a settled iterator omits `done`
- keep non-persisting follow-up suggestions outside main-turn ownership so queued/new turns can start; refresh regenerates suggestions through the idle follow-up route
- add server and web regression coverage for live replay, reattachment, setup failure, and abort ownership

## Verification

- `pnpm --filter @macaron/web test` (3 passed)
- `pnpm --filter @macaron/server test` (28 passed)
- `pnpm --filter @macaron/server typecheck`
- `pnpm build`
- production browser smoke: refreshing an active bypass task preserved one prompt, one processing indicator, one run bar, and one Stop button while deltas continued
- completed replay smoke: result and prior history rendered once with no stale processing controls; no browser errors

Closes [MAC-8556](https://multica.macaron.xin/issues/a178e5c9-75f6-43a6-95bb-e9e2d721cbbc "macaron artifacts session 状态持久化")
