### PR TITLE
feat(site): add `/connect` jump gate for tunnel share links

### DIFF
--- a/site/app/lib/connect-target.test.ts
+++ b/site/app/lib/connect-target.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTarget } from './connect-target.ts';
+
+// Table-driven coverage of every normalization branch EVE flagged on PR #144:
+// bare host, https + path/query/hash, http, other schemes, userinfo, token in
+// URL vs field override, and token encoding.
+const cases: Array<{ name: string; url: string; token: string; expect: { href: string } | { error: true } }> = [
+  { name: 'bare host + field token', url: 'x.trycloudflare.com', token: 'tok9', expect: { href: 'https://x.trycloudflare.com/?token=tok9' } },
+  { name: 'bare host, no token', url: 'x.trycloudflare.com', token: '', expect: { href: 'https://x.trycloudflare.com/' } },
+  { name: 'https root + url token kept', url: 'https://x.trycloudflare.com/?token=abc123', token: '', expect: { href: 'https://x.trycloudflare.com/?token=abc123' } },
+  { name: 'https + deep path is forced to root', url: 'https://tunnel.test/deep/path?token=url-token', token: '', expect: { href: 'https://tunnel.test/?token=url-token' } },
+  { name: 'https + path + hash dropped', url: 'https://tunnel.test/a/b#frag', token: 'k', expect: { href: 'https://tunnel.test/?token=k' } },
+  { name: 'field token overrides url token', url: 'https://x.test/?token=inurl', token: 'field-wins', expect: { href: 'https://x.test/?token=field-wins' } },
+  { name: 'token is url-encoded', url: 'https://x.test/', token: 'a b/c+d', expect: { href: 'https://x.test/?token=a+b%2Fc%2Bd' } },
+  { name: 'http is rejected', url: 'http://x.test/?token=abc', token: '', expect: { error: true } },
+  { name: 'ftp scheme is rejected (not treated as bare host)', url: 'ftp://tunnel.test/share?token=url-token', token: '', expect: { error: true } },
+  { name: 'ws scheme is rejected', url: 'ws://tunnel.test/', token: '', expect: { error: true } },
+  { name: 'userinfo is rejected', url: 'https://user:pass@tunnel.test/path?token=url-token', token: '', expect: { error: true } },
+  { name: 'username-only is rejected', url: 'https://user@tunnel.test/', token: '', expect: { error: true } },
+  { name: 'empty input is rejected', url: '', token: '', expect: { error: true } },
+  { name: 'whitespace-only input is rejected', url: '   ', token: '', expect: { error: true } },
+  { name: 'garbage is rejected', url: 'not a url ::::', token: 'x', expect: { error: true } },
+];
+
+for (const c of cases) {
+  test(c.name, () => {
+    const r = buildTarget(c.url, c.token);
+    if ('error' in c.expect) {
+      assert.ok('error' in r, `expected an error for ${JSON.stringify(c.url)}, got ${JSON.stringify(r)}`);
+    } else {
+      assert.deepEqual(r, c.expect);
+    }
+  });
+}

--- a/site/app/lib/connect-target.ts
+++ b/site/app/lib/connect-target.ts
@@ -1,0 +1,36 @@
+// Normalize a pasted tunnel URL (+ optional token) into a safe same-origin
+// jump target `<https-origin>/?token=<t>`. This is the whole security surface
+// of the connector, so it fails closed: only a scheme-less input is assumed
+// https, any explicit non-https scheme or userinfo is rejected, and the path
+// is always forced to root so a token can never ride along to an unexpected
+// host or path. See MAC-8578 / EVE's review on PR #144.
+
+export type BuildResult = { href: string } | { error: string };
+
+// Matches a leading URI scheme per RFC 3986 (`scheme ":"`). If present we parse
+// as-is and validate; only when it's absent do we assume https and prepend it —
+// so `ftp://x` is rejected as non-https, not silently turned into a bare host.
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+export function buildTarget(rawUrl: string, rawToken: string): BuildResult {
+  const input = rawUrl.trim();
+  if (!input) return { error: 'Paste the tunnel URL first.' };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(HAS_SCHEME.test(input) ? input : `https://${input}`);
+  } catch {
+    return { error: 'That does not look like a valid URL.' };
+  }
+
+  if (parsed.protocol !== 'https:') return { error: 'Use the https:// tunnel URL — an access token over http is unsafe.' };
+  if (parsed.username || parsed.password) return { error: 'Remove the user:pass@ part from the URL.' };
+
+  // A token typed into the field wins; otherwise keep one already in the URL.
+  const token = rawToken.trim() || parsed.searchParams.get('token') || '';
+  // Force root: origin drops any pathname/query/hash, so the token can only
+  // land on `<origin>/`, never a deeper path or a different host.
+  const base = new URL('/', parsed.origin);
+  if (token) base.searchParams.set('token', token);
+  return { href: base.toString() };
+}

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -2,6 +2,7 @@ import { index, route, type RouteConfig } from '@react-router/dev/routes';
 
 export default [
   index('routes/home.tsx'),
+  route('connect', 'routes/connect.tsx'),
   route('docs/*', 'routes/docs.tsx'),
   route('api/search', 'routes/search.ts'),
 

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -1,0 +1,94 @@
+import type { Route } from './+types/connect';
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { baseOptions } from '@/lib/layout.shared';
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: 'Connect · Macaron' },
+    { name: 'description', content: 'Open a Macaron WebUI running behind a public tunnel.' },
+  ];
+}
+
+// Pure jump gate: takes a tunnel URL (optionally already carrying ?token=) plus
+// an optional token, normalizes them into `<origin>/?token=<t>`, and hands off
+// via a full navigation. artifacts NEVER stores the token, calls the API, or
+// touches the data plane — the destination SPA is same-origin with the tunnel
+// and owns all of that. This page only redirects.
+function buildTarget(rawUrl: string, rawToken: string): { href: string } | { error: string } {
+  const url = rawUrl.trim();
+  if (!url) return { error: 'Paste the tunnel URL first.' };
+  let parsed: URL;
+  try {
+    parsed = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
+  } catch {
+    return { error: 'That does not look like a valid URL.' };
+  }
+  if (parsed.protocol !== 'https:') return { error: 'Use the https:// tunnel URL — an access token over http is unsafe.' };
+  // A token typed into the field wins; otherwise keep one already in the URL.
+  const token = rawToken.trim() || parsed.searchParams.get('token') || '';
+  parsed.search = '';
+  parsed.hash = '';
+  const base = parsed.toString().replace(/\/$/, '');
+  return { href: token ? `${base}/?token=${encodeURIComponent(token)}` : `${base}/` };
+}
+
+export default function Connect() {
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+
+  const go = () => {
+    const r = buildTarget(url, token);
+    if ('error' in r) { setError(r.error); return; }
+    setError('');
+    window.location.assign(r.href); // full navigation to the same-origin SPA — no token kept here
+  };
+
+  return (
+    <HomeLayout {...baseOptions()}>
+      <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
+        <div className="w-full max-w-md text-left">
+          <h1 className="text-xl font-bold mb-1 text-center">Connect to a session</h1>
+          <p className="text-fd-muted-foreground mb-6 text-center text-sm">
+            Start a tunnel from the Macaron WebUI, then paste its share link here to open it on this device.
+          </p>
+
+          <label className="block text-sm font-medium mb-1">Tunnel URL</label>
+          <input
+            className="w-full rounded-md border border-fd-border bg-fd-background px-3 py-2 text-sm mb-4"
+            placeholder="https://xxxx.trycloudflare.com/?token=…"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') go(); }}
+            autoFocus
+          />
+
+          <label className="block text-sm font-medium mb-1">Access token <span className="text-fd-muted-foreground font-normal">(optional if the link already has one)</span></label>
+          <input
+            className="w-full rounded-md border border-fd-border bg-fd-background px-3 py-2 text-sm mb-4"
+            placeholder="token"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') go(); }}
+          />
+
+          {error && <p className="text-sm text-fd-destructive mb-4">{error}</p>}
+
+          <button
+            type="button"
+            className="w-full inline-flex items-center justify-center gap-2 text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
+            onClick={go}
+          >
+            Open session <ArrowRight className="size-4" />
+          </button>
+
+          <p className="text-xs text-fd-muted-foreground mt-4 text-center">
+            This page only redirects — your token is never stored here and never leaves your browser except in the link you open.
+          </p>
+        </div>
+      </div>
+    </HomeLayout>
+  );
+}

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -3,35 +3,13 @@ import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { useState } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { baseOptions } from '@/lib/layout.shared';
+import { buildTarget } from '@/lib/connect-target';
 
 export function meta({}: Route.MetaArgs) {
   return [
     { title: 'Connect · Macaron' },
     { name: 'description', content: 'Open a Macaron WebUI running behind a public tunnel.' },
   ];
-}
-
-// Pure jump gate: takes a tunnel URL (optionally already carrying ?token=) plus
-// an optional token, normalizes them into `<origin>/?token=<t>`, and hands off
-// via a full navigation. artifacts NEVER stores the token, calls the API, or
-// touches the data plane — the destination SPA is same-origin with the tunnel
-// and owns all of that. This page only redirects.
-function buildTarget(rawUrl: string, rawToken: string): { href: string } | { error: string } {
-  const url = rawUrl.trim();
-  if (!url) return { error: 'Paste the tunnel URL first.' };
-  let parsed: URL;
-  try {
-    parsed = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
-  } catch {
-    return { error: 'That does not look like a valid URL.' };
-  }
-  if (parsed.protocol !== 'https:') return { error: 'Use the https:// tunnel URL — an access token over http is unsafe.' };
-  // A token typed into the field wins; otherwise keep one already in the URL.
-  const token = rawToken.trim() || parsed.searchParams.get('token') || '';
-  parsed.search = '';
-  parsed.hash = '';
-  const base = parsed.toString().replace(/\/$/, '');
-  return { href: token ? `${base}/?token=${encodeURIComponent(token)}` : `${base}/` };
 }
 
 export default function Connect() {

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "dev": "react-router dev",
     "start": "serve ./build/client --config ../../serve.json",
     "typecheck": "react-router typegen && fumadocs-mdx && tsc --noEmit",
+    "test": "node --test 'app/**/*.test.ts'",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
     "paths": {


### PR DESCRIPTION
## What

Adds a `/connect` page to the docs site (artifacts.macaron.im) — a **pure jump gate** for opening a Macaron WebUI that's exposed behind a public tunnel.

Flow: start a tunnel from the WebUI → paste its share link (`https://xxxx.trycloudflare.com/?token=…`) into `/connect` → it normalizes to `<origin>/?token=<t>` and does a full navigation to that same-origin SPA, where `consumeTokenFromUrl()` takes over.

## Why this shape

Per the [MAC-8578](https://multica.macaron.xin/issues/dbe39a11-91be-4755-9c9f-3a644dcf0056 "评估 macaron-claude-code hosted 版方案") architecture review, the WebUI SPA speaks to its server over **same-origin relative `/api/…`** paths and the server ships **no CORS**. So artifacts must never be the data plane — a cross-origin `fetch` to `localhost` would hit CORS + mixed-content walls and force opening the auth surface. This page keeps that invariant hard:

- **Never stores the token** — no `localStorage`, no cookie.
- **Never calls the API** — zero `fetch`.
- **Never touches the data plane** — it only builds a URL and `window.location.assign`s to it.

The token lives only in the link the user opens; artifacts is a façade.

## Guards

`buildTarget()` covers: token-in-URL preserved, separate token field overrides, bare host gets `https://` prefixed, **`http://` rejected** (no plaintext token), empty / malformed input surfaces an inline error.

## Verify

- `pnpm --filter @macaron/docs typecheck` — clean (react-router typegen picks up the new route).
- `buildTarget` logic unit-checked across the cases above.

A (the tunnel share UI in the WebUI Settings page) already exists on `main` and its **real cloudflared tunnel acceptance passed** — remote `/api` without token → 401, correct token → 200, data plane works over the public edge. This PR is B.
