### PR TITLE
deploy the docs site to Vercel

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,39 @@
+name: Vercel Production Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - site/**
+      - .github/workflows/vercel.yml
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: site
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: corepack enable
+      - name: Install Vercel CLI
+        run: pnpm add --global vercel@latest
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+      - name: Build deployment artifacts
+        run: vercel build --prod --token="${{ secrets.VERCEL_TOKEN }}"
+      - name: Deploy to production
+        run: vercel deploy --prebuilt --prod --token="${{ secrets.VERCEL_TOKEN }}"


### PR DESCRIPTION
## Summary

- add a production Vercel deployment workflow for the standalone `site` package
- run deployments on `main` changes under `site/` and allow manual dispatch
- use the existing `site/vercel.json` build configuration

## Configuration

Requires repository variables `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`, plus repository secret `VERCEL_TOKEN`.

## Verification

- `git diff --check`
- Build not run locally because Node.js, Corepack, and pnpm are unavailable in the runtime

Closes [MAC-8584](https://multica.macaron.xin/issues/9a914c21-c155-4dbe-b17f-b10711fe8c16 "为 macaron artifacts 创建 Vercel 部署 workflow")