### PR TITLE
Embed the file editor as a canvas tile with markdown preview modes

### DIFF
--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -33,7 +33,7 @@ function basenameOf(path: string): string {
 export function FileTile({
   project,
   path,
-  focused: _focused,
+  focused,
   refreshKey,
 }: {
   project: string;
@@ -46,7 +46,7 @@ export function FileTile({
   const [original, setOriginal] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(true);
-  const [mode, setMode] = useState<'preview' | 'edit'>('preview');
+  const [mode, setMode] = useState<'preview' | 'split' | 'edit'>('preview');
   const [saving, setSaving] = useState(false);
   const dirty = content !== original;
 
@@ -92,12 +92,12 @@ export function FileTile({
     }
   }, [project, path, content, dirty, saving, toast]);
 
-  // Cmd/Ctrl+S — only when this tile has focus. Simple hook: bind while
-  // in edit mode and dirty.
+  // Cmd/Ctrl+S — only the focused tile handles it. Split mode is editable,
+  // so it shares the same save shortcut as the full editor.
   const saveRef = useRef(save);
   saveRef.current = save;
   useEffect(() => {
-    if (mode !== 'edit') return;
+    if (!focused || mode === 'preview') return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
         e.preventDefault();
@@ -106,7 +106,7 @@ export function FileTile({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [mode]);
+  }, [focused, mode]);
 
   const tooBig = content.length > MAX_INLINE_PREVIEW_BYTES;
 
@@ -139,6 +139,18 @@ export function FileTile({
     return <pre className="ft-preview code">{content}</pre>;
   }, [isImage, isBinary, isMarkdown, error, loading, tooBig, content, project, path]);
 
+  const editorNode = error ? (
+    <div className="ft-placeholder err">Can't read: {error}</div>
+  ) : (
+    <Suspense fallback={<div className="ft-placeholder">Loading editor…</div>}>
+      <CodeEditor
+        path={path}
+        value={content}
+        onChange={setContent}
+      />
+    </Suspense>
+  );
+
   return (
     <div className="ft-root">
       {/* Redundant tile-header replaced by a compact floating action strip
@@ -157,6 +169,17 @@ export function FileTile({
               >
                 Preview
               </button>
+              {isMarkdown && (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === 'split'}
+                  className={'ft-mode-btn' + (mode === 'split' ? ' active' : '')}
+                  onClick={() => setMode('split')}
+                >
+                  Split
+                </button>
+              )}
               <button
                 type="button"
                 role="tab"
@@ -168,7 +191,7 @@ export function FileTile({
                 {dirty && <span className="ft-dirty" title="Unsaved changes">●</span>}
               </button>
             </div>
-            {mode === 'edit' && (
+            {mode !== 'preview' && (
               <button
                 type="button"
                 className="ft-save"
@@ -183,18 +206,13 @@ export function FileTile({
         )}
         {mode === 'preview' && previewNode}
         {mode === 'edit' && (
-          <>
-            {error && <div className="ft-placeholder err">Can't read: {error}</div>}
-            {!error && (
-              <Suspense fallback={<div className="ft-placeholder">Loading editor…</div>}>
-                <CodeEditor
-                  path={path}
-                  value={content}
-                  onChange={setContent}
-                />
-              </Suspense>
-            )}
-          </>
+          <div className="ft-editor-pane">{editorNode}</div>
+        )}
+        {mode === 'split' && (
+          <div className="ft-split">
+            <div className="ft-editor-pane">{editorNode}</div>
+            {previewNode}
+          </div>
         )}
       </div>
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5110,6 +5110,25 @@ textarea:focus, select:focus, input:focus {
   /* Anchor for .ft-actions (absolute inside this body). */
   position: relative;
 }
+.ft-editor-pane {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.ft-split {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+.ft-split > .ft-editor-pane,
+.ft-split > .ft-preview {
+  flex: 1 1 50%;
+  min-width: 0;
+}
+.ft-split > .ft-preview { border-left: 1px solid var(--border); }
 .ft-placeholder {
   padding: 24px;
   color: var(--muted);

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -76,6 +76,7 @@ export function Workspace() {
       .then((d) => {
         setWorkspace(d.workspace);
         setSessions(d.sessions);
+        setError('');
       })
       .catch((e) => setError((e as Error).message));
   }, [project]);


### PR DESCRIPTION
Implements [MAC-8680](https://multica.macaron.xin/issues/b46180b7-fab6-49a6-a7a4-0e63fc05ea9d "为编辑器添加 Markdown 预览、分屏与窗口缩放"): the file editor used to be a full-page route that covered the whole workspace, and markdown could only be viewed as source.

## What changed

- **Files as a canvas tile.** `+ Files` in the workspace header now pins an embedded file explorer/editor tile (sentinel sid `files:<uuid>`) instead of navigating away. It inherits everything session tiles already have — drag reorder, SE-corner resize, focus, per-project localStorage persistence — so editing a file no longer hides your sessions, and you get VS Code-style split/zoom for free from the existing 12-col grid. Multiple Files tiles can coexist.

https://github.com/mindverse-ltd/macaron-artifacts/blob/98f7c8c30389feb0e36ebd06606a745d8988c8b7/web/src/lib/canvas.ts#L31-L44

- **Markdown preview.** Opening a `.md`/`.markdown` file shows an Edit / Split / Preview segmented switch (VS Code-style). Split renders the editor and a live `react-markdown` + `remark-gfm` preview side by side; the preview re-renders as you type.

https://github.com/mindverse-ltd/macaron-artifacts/blob/98f7c8c30389feb0e36ebd06606a745d8988c8b7/web/src/views/FileExplorer.tsx#L212-L218

- **Collapsible file tree** to reclaim width inside a small tile.
- The old `/w/:project/files` route still works — `FileExplorer` is now a thin wrapper around the extracted `FilesPane` (`embedded` prop switches viewport-fill vs tile-fill and scopes Cmd/Ctrl+S to the focused pane).
- Drive-by fix: a transient failed workspace poll used to pin the canvas on the error screen forever; `load()` now clears the stale error on the next successful poll.

## Verification

- `pnpm --filter @macaron/web typecheck`: no new errors (the 73 pre-existing macaron-vendor errors are unchanged, checked against a stashed baseline)
- Browser smoke (Chromium, 1600×900): pin/unpin Files tile, tree lazy-load, open `CLAUDE.md`, Edit/Split/Preview switching with live re-render, tree collapse, Cmd/Ctrl+S save scoping, drag-resize the tile (colSpan 8→6 / rowSpan 14→12 persisted to localStorage), reload persistence, Files tile + session tile coexisting