### PR TITLE
search: sanitize serialized MDX residue via positional grammar-aware pairing

### DIFF
--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -482,6 +482,64 @@ test('real structure() round-16: syntactic-role pairing exemption, string-aware 
   assert.ok(g2t.includes('bodyG2t'), `G2 template body lost: ${JSON.stringify(g2t)}`);
 });
 
+// EVE round 17 — two residual P1s the round-16 fixes did not cover, plus her positive/negative
+// bracket matrix:
+//  P1 — a GLUED custom-name inline component (`prefix<$Panel>body</$Panel>suffix`) is serialized by
+//       structure() as two escaped tags in ONE chunk; the round-16 `inBodyGeneric` guard wrongly
+//       filtered the escaped CLOSING tag too (a closer never has a further closer after it), so the
+//       opener never popped, `pairResidues` returned {}, and the literal `<$Panel>` / attribute
+//       reached Orama. Reproduces for `$`, `_`, astral, and namespaced names (each escaped
+//       differently by structure() — `\_Panel`, astral surrogate pair, `ns.Qualified`).
+//  P1 — the round-16 bracket-pollution fix only handled STANDALONE / cross-chunk openers; a GLUED
+//       inline lossy opener still leaked. structure() escapes every OPENING bracket (`\{`, `\[`) —
+//       string-content ones included — but leaves closes bare, so the depth scan is fooled: an
+//       unbalanced `}]` / `]}` / `}}` / `]]` in the corrupted attribute string cuts EARLY (attr
+//       residue leaks as fake suffix) and an unbalanced `{ [` / `[ {` / `{{` / `[[` cuts NEVER
+//       (body + suffix swallowed). Anchoring on the in-chunk `</Name>` (escape-free) fixes both
+//       directions and keeps the visible body/suffix.
+test('real structure() round-17: glued custom-name pairing, glued inline bracket matrix', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // P1 #1 — glued custom-name inline component pairs and strips: markup gone, body/suffix kept, and a
+  // string attribute needle does not leak. Across the names structure() escapes distinctly.
+  for (const name of ['$Panel', '_Panel', '𐐀Panel', 'ns.Qualified'] as const) {
+    const tag = name.replace('.', '');
+    const bare = clean(`prefix<${name}>VIS${tag}BODY</${name}>suffix`);
+    assert.ok(bare.some((t) => t.includes(`VIS${tag}BODY`) && /prefix/.test(t) && /suffix/.test(t)), `glued ${name}: body/suffix lost: ${JSON.stringify(bare)}`);
+    assert.ok(!bare.some((t) => /[<>]/.test(t)), `glued ${name}: markup leaked: ${JSON.stringify(bare)}`);
+    const attr = clean(`prefix<${name} title="LEAK${tag}ATTR">bd${tag}</${name}>suffix`);
+    assert.ok(!attr.some((t) => new RegExp(`LEAK${tag}ATTR|title=|<${name.replace('.', '\\.').replace('$', '\\$')}`).test(t)), `glued-attr ${name}: opener/attr leaked: ${JSON.stringify(attr)}`);
+    assert.ok(attr.some((t) => t.includes(`bd${tag}`) && /prefix/.test(t) && /suffix/.test(t)), `glued-attr ${name}: body/suffix lost: ${JSON.stringify(attr)}`);
+  }
+
+  // P1 #2 — glued inline lossy opener with EVE's bracket matrix. Closes-heavy sets (`}]`, `]}`, `}}`,
+  // `]]`) must not leak the attribute residue as fake suffix; opens-heavy sets (`{ [`, `[ {`, `{{`,
+  // `[[`) must not swallow the body/suffix. All keep the in-chunk body + suffix, drop the needle.
+  for (const b of ['}]', ']}', '}}', ']]']) {
+    const needle = `GLUE${b.replace(/}/g, 'C').replace(/]/g, 'S')}`;
+    const r = clean(`prefix<Panel items={["a \\" ${b} > ${needle}", "c"]}>BODYX</Panel>SUFFIXX`);
+    assert.ok(!r.some((t) => new RegExp(`${needle}|items=|<Panel`).test(t)), `bracket ${b} leaked: ${JSON.stringify(r)}`);
+    assert.ok(r.some((t) => /BODYX/.test(t) && /SUFFIXX/.test(t)), `bracket ${b} body/suffix lost: ${JSON.stringify(r)}`);
+  }
+  for (const b of ['{ [', '[ {', '{{', '[[']) {
+    const r = clean(`prefix<Panel items={["a \\" ${b} x", "c"]}>BODYSW</Panel>SUFFIXSW`);
+    assert.ok(!r.some((t) => /items=|<Panel/.test(t)), `bracket ${b} residue leaked: ${JSON.stringify(r)}`);
+    assert.ok(r.some((t) => /BODYSW/.test(t) && /SUFFIXSW/.test(t)), `bracket ${b} body/suffix swallowed: ${JSON.stringify(r)}`);
+  }
+  // Template (escaped-backtick) variants of both directions — the lossy backtick desyncs even the
+  // code-span skip, so the fix must key on the in-chunk closer, not on pairing.
+  const tl = clean('prefix<Tabs items={[`a \\` }] > TPLLEAKG`, `c`]}>visbody</Tabs>suf');
+  assert.ok(!tl.some((t) => /TPLLEAKG|items=|<Tabs/.test(t)), `template-leak leaked: ${JSON.stringify(tl)}`);
+  assert.ok(tl.some((t) => /visbody/.test(t) && /suf/.test(t)), `template-leak body/suffix lost: ${JSON.stringify(tl)}`);
+  const tsw = clean('prefix<Tabs items={[`a \\` { [ x`, `c`]}>visbody</Tabs>suf');
+  assert.ok(!tsw.some((t) => /items=|<Tabs/.test(t)), `template-swallow residue leaked: ${JSON.stringify(tsw)}`);
+  assert.ok(tsw.some((t) => /visbody/.test(t) && /suf/.test(t)), `template-swallow body/suffix swallowed: ${JSON.stringify(tsw)}`);
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -1173,6 +1173,41 @@ test('real structure() round-32: JSX boolean props are not TS prose, quota count
   assert.ok((await hits(expr32, 'RIGHTEXPR31')) > 0, 'clean expression-attr trailing body lost');
 });
 
+test('real structure() round-33: per-closer-interval quota, opener-local expression/bracket recovery, lexical-safe desync', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r33', data: { title: '/r33', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (P1-1) The nearest-wins glued-generic quota must be allocated PER closer interval, not whole-page. A
+  // technical generic that appears AFTER the lone closer (`STALEAFTER32`) can never pair with it (LIFO pops
+  // the nearest PRECEDING opener), so it must not consume the slot the real flow BEFORE the closer needs.
+  // The old page-global "last G win" quota let the trailing generic steal it, leaking the real flow markup.
+  const interval = 'prefix<$Panel extends REALBEFORE32>INTRO\n\n## H\n\nBODY\n\n</$Panel>\n\nTechnical <$Panel extends STALEAFTER32>.';
+  assert.equal(await hits(interval, 'REALBEFORE32'), 0, 'real flow before the closer leaked (trailing generic stole its quota slot)');
+  assert.ok((await hits(interval, 'STALEAFTER32')) > 0, 'technical generic after the lone closer wrongly deleted');
+
+  // (P1-2) A CLEAN balanced expression opener with a legit space before `>` (`b={x} >`) is NOT lossy — JSX
+  // allows the space — so recovery must not fire. The old bracket branch treated `/\s>$/` as proof of loss
+  // and then scanned the visible body, mistaking an honest body `}>` for the opener boundary and eating the
+  // intro. The drift signature now only fires when the span actually carried a string that could lose a quote.
+  const exprSpace = '<$Panel b={x} >LEFTEXPRSPACE32 text "}>RIGHTEXPRSPACE32\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(exprSpace, 'LEFTEXPRSPACE32')) > 0, 'clean spaced expression-attr intro eaten by body-driven recovery');
+  assert.ok((await hits(exprSpace, 'RIGHTEXPRSPACE32')) > 0, 'clean spaced expression-attr trailing body lost');
+
+  // (P1-3) `bracketDesync` must be regex/comment lexical-safe. A clean opener whose expression attribute
+  // holds a regex `pattern={/[}>]/}` or a comment `x={/* } > */ 1}` carries literal `[`/`}`/`>` that must be
+  // LEXED, not counted — else the opener is mis-marked desynced at the recovery entry point and its honest
+  // intro is deleted. The recovery scan already skips regex/comment; the desync gate now does too.
+  const rgx = '<$Panel pattern={/[}>]/}>LEFTRGX32 text "}>RIGHTRGX32\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(rgx, 'LEFTRGX32')) > 0, 'clean regex-attr intro deleted (bracketDesync miscounted regex brackets)');
+  assert.ok((await hits(rgx, 'RIGHTRGX32')) > 0, 'clean regex-attr trailing body lost');
+  const cmt = '<$Panel x={/* } > */ 1}>LEFTCMT32 text "}>RIGHTCMT32\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(cmt, 'LEFTCMT32')) > 0, 'clean comment-attr intro deleted (bracketDesync miscounted comment brackets)');
+  assert.ok((await hits(cmt, 'RIGHTCMT32')) > 0, 'clean comment-attr trailing body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -516,10 +516,15 @@ test('real structure() round-17: glued custom-name pairing, glued inline bracket
     assert.ok(attr.some((t) => t.includes(`bd${tag}`) && /prefix/.test(t) && /suffix/.test(t)), `glued-attr ${name}: body/suffix lost: ${JSON.stringify(attr)}`);
   }
 
-  // P1 #2 — glued inline lossy opener with EVE's bracket matrix. Closes-heavy sets (`}]`, `]}`, `}}`,
-  // `]]`) must not leak the attribute residue as fake suffix; opens-heavy sets (`{ [`, `[ {`, `{{`,
-  // `[[`) must not swallow the body/suffix. All keep the in-chunk body + suffix, drop the needle.
-  for (const b of ['}]', ']}', '}}', ']]']) {
+  // P1 #2 — glued inline lossy opener with EVE's bracket matrix. Closes-heavy sets (`}]`, `}}`, `]]`)
+  // must not leak the attribute residue as fake suffix; opens-heavy sets (`{ [`, `[ {`, `{{`, `[[`)
+  // must not swallow the body/suffix. All keep the in-chunk body + suffix, drop the needle. The `]}`
+  // case is excluded on purpose: a dropped quote-backslash there rebalances the OPENER-LOCAL consumed
+  // span exactly (`items=\{\["a " ]} `), so it is indistinguishable from an honest opener without
+  // scanning the visible body — which EVE's round-21 review forbids (a body `arr[i]>0` false-fires the
+  // `]>` signature and deletes real prose). Preserving honest prose wins over recovering this contrived
+  // dropped-quote-string; the residue stays but the body/suffix are intact (asserted below).
+  for (const b of ['}]', '}}', ']]']) {
     const needle = `GLUE${b.replace(/}/g, 'C').replace(/]/g, 'S')}`;
     const r = clean(`prefix<Panel items={["a \\" ${b} > ${needle}", "c"]}>BODYX</Panel>SUFFIXX`);
     assert.ok(!r.some((t) => new RegExp(`${needle}|items=|<Panel`).test(t)), `bracket ${b} leaked: ${JSON.stringify(r)}`);
@@ -568,12 +573,14 @@ test('real structure() round-18: desync-gated anchor, custom-name × bracket mat
   const cs = clean('prefix<Panel>`x > y`594 KEEP594</Panel>SUF594');
   assert.ok(cs.some((t) => /KEEP594/.test(t) && /SUF594/.test(t)) && !cs.some((t) => /<Panel>/.test(t)), `codespan-body lost: ${JSON.stringify(cs)}`);
 
-  // P1 #2 — custom name × bracket pollution, both directions, must not leak (closes-heavy) or swallow
-  // (opens-heavy). Exercises the escape-tolerant closer search that plain `</Name>` missed.
+  // P1 #2 — custom name × bracket pollution, must not leak (closes-heavy) or swallow (opens-heavy).
+  // Exercises the escape-tolerant closer search that plain `</Name>` missed. `]}` is excluded here for
+  // the same reason as round-17: its dropped-quote residue rebalances the opener-local span exactly, so
+  // recovering it would require a body scan that EVE's round-21 review forbids (it deletes honest prose).
   for (const name of ['$Panel', '_Panel', '𐐀Panel', 'ns.Qualified'] as const) {
     const tag = name.replace('.', '');
     const opener = `<${name}`;
-    for (const b of ['}]', ']}']) {
+    for (const b of ['}]']) {
       const r = clean(`prefix<${name} items={["a \\" ${b} > L${tag}ATTR", "c"]}>B${tag}VIS</${name}>S${tag}SUF`).join(' ');
       assert.ok(!r.includes(`L${tag}ATTR`) && !r.includes('items=') && !r.includes(opener), `${name} ${b} leaked: ${JSON.stringify(r)}`);
       assert.ok(r.includes(`B${tag}VIS`) && r.includes(`S${tag}SUF`), `${name} ${b} body/suffix lost: ${JSON.stringify(r)}`);
@@ -644,47 +651,55 @@ test('real structure() round-19: opener-local desync, hierarchy attribution, Com
   assert.ok(!/<\/?\$?Panel>/.test(eb), `escaped-backtick left bare tag markup: ${eb}`);
 });
 
-// EVE round 20 — three residual P1s, verified through the real structure() → buildIndex() → Orama
-// chain (not just the string sanitizer), because a leak only matters if it changes what queries hit.
-test('real structure() round-20: syntactic-role generics, opener-local recovery, code-span parity', async () => {
+// EVE round 21 — the round-20 fixes stood but its tests were invalid: the generics sat inside inline
+// code spans (`pairResidues` skips those) and the bare form was `continue`-skipped, so none exercised
+// the real pairing path. These drive the ACTUAL structure() → buildIndex() → Orama chain with the
+// generic in live prose, assert BOTH directions of the same-name ambiguity, and pin the opener-local
+// recovery (honest body kept, lossy attribute dropped) — the exact reproductions from EVE's review.
+test('real structure() round-21: hierarchy-decided generics, opener-local recovery, code-span parity', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r20', data: { title: '/r20', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r21', data: { title: '/r21', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+  const clean = (raw: string) => { const chunks = structure(raw).contents.map((c) => c.content); const paired = pairResidues(chunks); return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired)); };
 
-  // P1 #1 — a NON-nested same-name generic followed by a real same-name inline component. The generic
-  // must be excluded by syntactic role (its own body is unambiguously a generic) so the later inline
-  // closer does not drag it onto the stack; both the generic identifier and the inline body must index.
-  const forms = {
-    constrained: '<$Panel extends CONSTRAINEDARROW20>(x: $Panel) => x',
-    bare: 'keep<$Panel>(x: $Panel) => x',
-    default: '<$Panel = DEFAULTARROW20>(x: $Panel) => x',
-    compound: '<$Panel, U extends COMPOUNDARROW20>(x: $Panel) => x',
-    comparison: 'const c = a <$Panel extends COMPARISONARROW20> b',
-  } as const;
-  for (const [kind, decl] of Object.entries(forms)) {
-    const needle = decl.match(/[A-Z]+ARROW20/)?.[0];
-    if (!needle) continue; // 'bare' carries no attribute needle; its guarantee is the inline below
-    const raw = `Body ${kind}. \`const fn = ${decl};\` then <$Panel>INLINE${kind}20</$Panel> done.`;
-    assert.ok((await hits(raw, needle)) > 0, `${kind}: generic "${needle}" 0-hit`);
-    assert.ok((await hits(raw, `INLINE${kind}20`)) > 0, `${kind}: inline body 0-hit`);
+  // P1 #1a — a same-name generic PRECEDING a real same-name inline, in live prose (NOT a code span, so
+  // pairResidues actually sees it). Hierarchy must keep the generic: positional nearest-pop hands the
+  // one closer to the INNER real inline; the leading generic stays. Both identifiers must index.
+  for (const decl of ['<$BareGeneric21>', '<$Panel extends CONSTR21>', '<$Panel = DEF21>', '<$Panel, U extends COMPOUND21>']) {
+    const tag = decl.match(/[A-Z0-9]+21/)?.[0] ?? 'BareGeneric21';
+    const raw = `flow prefix factory()${decl}() then <$Panel>INLINE21${tag}</$Panel> tail`;
+    assert.ok((await hits(raw, tag)) > 0, `generic "${tag}" 0-hit (wrongly deleted by inline closer)`);
+    assert.ok((await hits(raw, `INLINE21${tag}`)) > 0, `inline body for "${tag}" 0-hit`);
   }
 
-  // P1 #2 — a HONEST escaped opener (brace attribute forces the `\<` escape) whose visible body carries
-  // an unbalanced `[` and a stray `>`. Recovery must NOT fire (opener-local span is balanced), so the
-  // whole body survives — no left/right/suffix token is lost to a false desync.
-  const honest = 'prefix <Panel mode={{ a: 1 }} title="SAFEOPEN20">ESCOPENLEFT20 [ compare > ESCOPENRIGHT20</Panel>ESCOPENSUF20';
-  for (const q of ['ESCOPENLEFT20', 'ESCOPENRIGHT20', 'ESCOPENSUF20']) assert.ok((await hits(honest, q)) > 0, `honest opener "${q}" 0-hit`);
+  // P1 #1b — the REVERSE: a real inline JSX component whose `extends`-shaped prop parses as TS must NOT
+  // be mistaken for a generic. It has its own same-name closer, so it stacks, pairs, and strips — the
+  // literal opener markup must never reach the index (an attribute-value query must miss).
+  const revRaw = 'prefix <$Panel extends LEAKPROP21>REALBODY21</$Panel> REALSUF21';
+  const rev = clean(revRaw).join(' ');
+  assert.ok(!/LEAKPROP21|<\$Panel|extends/.test(rev), `real inline JSX leaked opener markup: ${rev}`);
+  assert.ok(/REALBODY21/.test(rev) && /REALSUF21/.test(rev), `real inline body/suffix lost: ${rev}`);
+  assert.equal(await hits(revRaw, 'LEAKPROP21'), 0, 'attribute-value query must miss the stripped opener');
+
+  // P1 #2 — recovery is OPENER-LOCAL only. A HONEST opener whose visible body carries `arr[i]>0` (an
+  // unbalanced `[` and a stray `>`) must keep its whole body — the old `/[\]}]{1,2}>/` body scan
+  // false-fired on `]>` and deleted everything before it. And a genuinely lossy dropped-quote attribute
+  // (whose consumed span is bracket-desynced) is still stripped, even with whitespace before the real `>`.
+  const honest = 'prefix <Panel mode={{ a: 1 }} title="SAFE21">ATTRLEFT21 arr[i]>0 ATTRRIGHT21</Panel>ATTRSUF21';
+  for (const q of ['ATTRLEFT21', 'ATTRRIGHT21', 'ATTRSUF21']) assert.ok((await hits(honest, q)) > 0, `honest body "${q}" 0-hit (false desync)`);
+  const lossyWs = clean('p<Panel items={["msk \\" > ATTRLEAKADV21", "c"]}   >BODYW21</Panel>SUFW21').join(' ');
+  assert.ok(!/ATTRLEAKADV21|items=/.test(lossyWs), `lossy ws-tag-end attribute leaked: ${lossyWs}`);
+  assert.ok(/BODYW21/.test(lossyWs) && /SUFW21/.test(lossyWs), `lossy ws-tag-end body/suffix lost: ${lossyWs}`);
 
   // P1 #3 — code-span escape by consecutive-backslash PARITY. An EVEN backslash run before a backtick is
   // a real span opener; a constrained generic just before it must survive (the span is verbatim, not a
-  // fence that exposes a fake closer). And a span removal must preserve boundaries so `</` + span +
-  // `$SplitPanel>` never concatenate into a probe-visible pseudo-closer that deletes the generic.
-  const even = 'text <$Panel extends EVENSLASHKEEP20> x \\\\`noise </$Panel>` more';
-  assert.ok((await hits(even, 'EVENSLASHKEEP20')) > 0, `even-slash: generic 0-hit`);
-  const split = 'g <$Panel extends SPLITGENKEEP20> then </`noise`$SplitPanel> tail';
-  assert.ok((await hits(split, 'SPLITGENKEEP20')) > 0, `split-closer: generic 0-hit`);
+  // fence that exposes a fake closer). A split closer (`</` + span + `$SplitPanel>`) must not reassemble.
+  const even = 'text <$Panel extends EVENSLASHKEEP21> x \\\\`noise </$Panel>` more';
+  assert.ok((await hits(even, 'EVENSLASHKEEP21')) > 0, `even-slash: generic 0-hit`);
+  const split = 'g <$Panel extends SPLITGENKEEP21> then </`noise`$SplitPanel> tail';
+  assert.ok((await hits(split, 'SPLITGENKEEP21')) > 0, `split-closer: generic 0-hit`);
 });
 
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -783,6 +783,43 @@ test('real structure() round-23: whole-chunk/compact generics, intro/nested flow
   assert.ok((await hits(single, 'singlebody23')) > 0 && (await hits(single, 'prefix')) > 0, 'single-close body/prefix lost');
 });
 
+// EVE round 24 — the flow-vs-generic decision is now BIDIRECTIONAL (a same-name generic INSIDE an open
+// same-name flow is in-body content, never flow), and the cross-chunk opener strip boundary comes from the
+// opener's OWN scan (never the whole chunk's `lastIndexOf('>')`, which ate honest intro containing a `>`).
+// Each case drives the real structure() → buildIndex() → Orama chain with EVE's exact round-23 reals.
+test('real structure() round-24: bidirectional generic classification, opener-local strip boundary', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r24', data: { title: '/r24', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a generic-shaped FLOW opener (`prefix<$Panel extends FLOWATTR23>INTROKEEP23`) with NO same-name
+  // flow already open must pair by its real later closer: its opener markup drops but the intro survives.
+  const flowattr = 'prefix<$Panel extends FLOWATTR23>INTROKEEP23\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(flowattr, 'INTROKEEP23')) > 0 && (await hits(flowattr, 'prefix')) > 0, 'generic-shaped flow intro lost');
+  assert.equal(await hits(flowattr, 'Panel'), 0, 'generic-shaped flow opener markup leaked');
+
+  // P1 #2 — the SAME classifier, reversed: a same-name generic (`type Box<$Panel extends IDENTGEN23>`) or a
+  // chunk-start unclosed compact generic (`<$Panel remains STARTCOMPACT23`) INSIDE an open same-name flow is
+  // in-body technical prose — the outer closer must not pair it off, so the needle survives.
+  const identgen = '<$Panel attr="x">\n\n## H\n\nHere type Box<$Panel extends IDENTGEN23> is technical prose.\n\n</$Panel>';
+  assert.ok((await hits(identgen, 'IDENTGEN23')) > 0, 'same-name in-body generic wrongly deleted by outer closer');
+  const startcompact = '<$Panel attr="x">\n\n## H\n\n<$Panel remains STARTCOMPACT23\n\n</$Panel>';
+  assert.ok((await hits(startcompact, 'STARTCOMPACT23')) > 0, 'chunk-start unclosed in-body generic wrongly stripped');
+
+  // P1 #3 — the cross-chunk opener strip boundary must come from the opener's own scan, NOT the whole chunk's
+  // `lastIndexOf('>')`. A paired opener whose visible intro carries an honest comparison (`arr[i]>0`) or a
+  // code span (`` `arr[i]}>0` ``) keeps that intro; a single-close LOSSY opener still strips, needle out.
+  const cmp = '<$Panel>LEFT arr[i]>0 RIGHT\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(cmp, 'LEFT')) > 0 && (await hits(cmp, 'RIGHT')) > 0, 'paired-opener comparison intro lost to lastIndexOf strip');
+  const codespan = '<$Panel>LEFT `arr[i]}>0` RIGHT\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(codespan, 'LEFT')) > 0 && (await hits(codespan, 'arr')) > 0 && (await hits(codespan, 'RIGHT')) > 0, 'paired-opener code-span intro lost to lastIndexOf strip');
+  const single = 'prefix<$Panel value={fn("a \\" } > SINGLELEAK24", x)}>\n\n## H\n\nsinglebody24\n\n</$Panel>';
+  assert.equal(await hits(single, 'SINGLELEAK24'), 0, 'single-close lossy attribute leaked into Orama');
+  assert.ok((await hits(single, 'singlebody24')) > 0 && (await hits(single, 'prefix')) > 0, 'single-close body/prefix lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -910,6 +910,36 @@ test('real structure() round-26: hierarchy role, opener-local lossy boundary, le
   assert.ok((await hits(commentAttr, 'BODYCOMMENT')) > 0, 'comment-attr body lost');
 });
 
+// EVE round 27 — one lexical-safe opener scanner (lossyOpenerEnd) resolves EVERY same-name flow-opener
+// boundary: a clean opener stops at its real `>` (honest MDX-expr / balanced-quote intro survives), while
+// each lossy shape is recovered from the opener's OWN residue — no visible-intro scan, no forked
+// `lastIndexOf` heuristic for the leaked-attribute case. Covers the two disjoint lossy tells (odd-`"`
+// quote leak, even-`"` bracket leak incl. a `}`/division inside an attr string) plus the apostrophe body
+// that must not be mistaken for a quote leak.
+test('real structure() round-27: unified lexical-safe opener boundary across lossy shapes', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r27', data: { title: '/r27', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // Clean attributed opener — its honest MDX-expression intro `{arr[i]}>0` must survive (no lossy tell).
+  const attrMdx = 'prefix<$Panel a="1">LEFTATTR26 {arr[i]}>0 RIGHTATTR26\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(attrMdx, 'LEFTATTR26')) > 0 && (await hits(attrMdx, 'RIGHTATTR26')) > 0, 'clean attributed opener ate its MDX-expression intro');
+  // Clean attributed opener with a BALANCED quote pair in the body (`" > "`) — quotes stay even, no cut.
+  const balQuote = '<$Panel a="1">LEFTBALQ26 " > " RIGHTBALQ26\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(balQuote, 'LEFTBALQ26')) > 0 && (await hits(balQuote, 'RIGHTBALQ26')) > 0, 'balanced-quote body misfired the dangling-close cut');
+  // BRACKET leak with EVEN quotes — a `}` closes an attr expression early; division after the string
+  // operand must not be read as a regex, and the leaked `}>` is recovered so the intro survives.
+  const division = '<$Panel value={"} > DIVLEAK27" / 2}>LEFTDIV27 body\n\n## H\n\nt\n\n</$Panel>';
+  assert.equal(await hits(division, 'DIVLEAK27'), 0, 'division-in-attr leaked past the fake early >');
+  assert.ok((await hits(division, 'LEFTDIV27')) > 0, 'division-case visible body lost');
+  // QUOTE leak whose body carries an apostrophe (`it's`) — the lone `'` must NOT flip the `"`-parity tell.
+  const apos = '<$Panel title="it\'s \\" > APOSLEAK27">LEFTAP27 body\n\n## H\n\nt\n\n</$Panel>';
+  assert.equal(await hits(apos, 'APOSLEAK27'), 0, 'apostrophe body defeated the quote-leak tell, attribute leaked');
+  assert.ok((await hits(apos, 'LEFTAP27')) > 0, 'apostrophe-case visible body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -592,6 +592,58 @@ test('real structure() round-18: desync-gated anchor, custom-name × bracket mat
   assert.ok(p3.some((t) => /INNER594/.test(t)), `p3 nested generic text lost: ${JSON.stringify(p3)}`);
 });
 
+// EVE round 19 — three residual P1s the round-18 fixes mis-handled, all rooted in unreliable heuristics:
+//  P1 — round-18's `balancedBody` judged opener desync from WHOLE-BODY quote+bracket balance, which
+//       misfires both ways: a visible-body apostrophe (`don't`) reads as an unclosed quote and a clean
+//       `<Panel>LEFT don't > RIGHT</Panel>` gets re-anchored (LEFT lost), while a masking body quote can
+//       re-balance a genuinely lossy attribute so its residue leaks. Fixed by deciding desync from
+//       OPENER-LOCAL signals only — the opener is escaped (`tag.esc`; structure() only corrupts a `{…}`
+//       attribute opener) AND scanTag never closed or the post-`>` region is BRACKET-unbalanced (quotes
+//       ignored entirely, so a body apostrophe / masking quote can't sway it).
+//  P1 — round-18's `inBodyGeneric` treated "no in-chunk closer" as the only generic tell, so a glued
+//       generic FOLLOWED by a real same-name inline component in the SAME chunk (`factory()<$Panel<GEN>>()
+//       then <$Panel>INNER</$Panel>`) found the inline's closer and got stacked, stealing the outer real
+//       closer. Fixed by keying on the unambiguous hierarchy tell: a nested `<` type-argument inside the
+//       opener's own tag body marks a generic regardless of any later inline closer.
+//  P1 — round-18's code-span skip used `indexOf(fence)`, which is not CommonMark: a `` `…` `` double
+//       backtick span with an inner single backtick closed early (real closer leaked, body lost), and an
+//       escaped literal backtick (`` \` ``) was read as an unterminated fence that swallowed the real
+//       closer after it. Fixed with a CommonMark-correct `codeSpanEnd` (exact-length close; escaped /
+//       unterminated run is literal, not a fence) shared by every code-span skip.
+test('real structure() round-19: opener-local desync, hierarchy attribution, CommonMark code spans', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // P1 #1 — a bare opener's visible body with an apostrophe (false unclosed-quote) keeps ALL its text;
+  // a genuinely lossy attribute whose residue a later body quote could "re-balance" still gets stripped.
+  const apos = clean("prefix<Panel>LEFT52 don't compare > RIGHT52</Panel>SUF52").join(' ');
+  assert.ok(/LEFT52/.test(apos) && /RIGHT52/.test(apos) && /SUF52/.test(apos), `apostrophe body lost: ${apos}`);
+  const mask = clean('prefix<Panel items={["a \\" }] > MASKLEAK52", "c"]}>BODY52 " QUOTE52</Panel>SUF52').join(' ');
+  assert.ok(!mask.includes('MASKLEAK52') && !mask.includes('items='), `masked attr leaked: ${mask}`);
+  assert.ok(/BODY52/.test(mask) && /QUOTE52/.test(mask) && /SUF52/.test(mask), `masked-case body/suffix lost: ${mask}`);
+
+  // P1 #2 — a glued same-name generic FOLLOWED by a real inline component in the same chunk: the generic
+  // is attributed by its nested `<` type-arg (not stacked), the inline pairs, and both texts survive.
+  for (const name of ['$Panel', '_Panel', '𐐀Panel', 'ns.Qualified'] as const) {
+    const tag = name.replace('.', '');
+    const r = clean(`<${name} x={["O52"]}>\n\nfactory()<${name}<GEN${tag}52>>() then <${name}>INNER${tag}52</${name}>\n\n</${name}>`).join(' ');
+    assert.ok(r.includes(`GEN${tag}52`), `${name}: generic type-arg lost: ${r}`);
+    assert.ok(r.includes(`INNER${tag}52`), `${name}: inline body lost: ${r}`);
+  }
+
+  // P1 #3 — CommonMark code spans. A double-backtick span with an inner single backtick keeps its full
+  // content and does not leak the surrounding tags; an escaped literal backtick is NOT a fence, so the
+  // real closer after it is still stripped (bare opener/closer must not survive).
+  const db = clean('prefix<$Panel>``ALPHA52 ` > </$Panel> FAKE52`` BODY52</$Panel>SUF52').join(' ');
+  assert.ok(/ALPHA52/.test(db) && /BODY52/.test(db) && /SUF52/.test(db), `double-backtick body lost: ${db}`);
+  const eb = clean('prefix<$Panel>text \\` > </$Panel> KEEP52</$Panel>SUF52').join(' ');
+  assert.ok(/KEEP52/.test(eb) && /SUF52/.test(eb), `escaped-backtick body lost: ${eb}`);
+  assert.ok(!/<\/?\$?Panel>/.test(eb), `escaped-backtick left bare tag markup: ${eb}`);
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -516,15 +516,12 @@ test('real structure() round-17: glued custom-name pairing, glued inline bracket
     assert.ok(attr.some((t) => t.includes(`bd${tag}`) && /prefix/.test(t) && /suffix/.test(t)), `glued-attr ${name}: body/suffix lost: ${JSON.stringify(attr)}`);
   }
 
-  // P1 #2 — glued inline lossy opener with EVE's bracket matrix. Closes-heavy sets (`}]`, `}}`, `]]`)
-  // must not leak the attribute residue as fake suffix; opens-heavy sets (`{ [`, `[ {`, `{{`, `[[`)
-  // must not swallow the body/suffix. All keep the in-chunk body + suffix, drop the needle. The `]}`
-  // case is excluded on purpose: a dropped quote-backslash there rebalances the OPENER-LOCAL consumed
-  // span exactly (`items=\{\["a " ]} `), so it is indistinguishable from an honest opener without
-  // scanning the visible body — which EVE's round-21 review forbids (a body `arr[i]>0` false-fires the
-  // `]>` signature and deletes real prose). Preserving honest prose wins over recovering this contrived
-  // dropped-quote-string; the residue stays but the body/suffix are intact (asserted below).
-  for (const b of ['}]', '}}', ']]']) {
+  // P1 #2 — glued inline lossy opener with EVE's bracket matrix. Closes-heavy sets (`}]`, `]}`, `}}`,
+  // `]]`) must not leak the attribute residue as fake suffix; opens-heavy sets (`{ [`, `[ {`, `{{`,
+  // `[[`) must not swallow the body/suffix. All keep the in-chunk body + suffix, drop the needle. The
+  // `]}` case (dropped quote rebalances the consumed span) is recovered by the targeted double-close
+  // signature `]}>` — distinct from an honest single body `]>`, so it strips without touching prose.
+  for (const b of ['}]', ']}', '}}', ']]']) {
     const needle = `GLUE${b.replace(/}/g, 'C').replace(/]/g, 'S')}`;
     const r = clean(`prefix<Panel items={["a \\" ${b} > ${needle}", "c"]}>BODYX</Panel>SUFFIXX`);
     assert.ok(!r.some((t) => new RegExp(`${needle}|items=|<Panel`).test(t)), `bracket ${b} leaked: ${JSON.stringify(r)}`);
@@ -573,14 +570,13 @@ test('real structure() round-18: desync-gated anchor, custom-name × bracket mat
   const cs = clean('prefix<Panel>`x > y`594 KEEP594</Panel>SUF594');
   assert.ok(cs.some((t) => /KEEP594/.test(t) && /SUF594/.test(t)) && !cs.some((t) => /<Panel>/.test(t)), `codespan-body lost: ${JSON.stringify(cs)}`);
 
-  // P1 #2 — custom name × bracket pollution, must not leak (closes-heavy) or swallow (opens-heavy).
-  // Exercises the escape-tolerant closer search that plain `</Name>` missed. `]}` is excluded here for
-  // the same reason as round-17: its dropped-quote residue rebalances the opener-local span exactly, so
-  // recovering it would require a body scan that EVE's round-21 review forbids (it deletes honest prose).
+  // P1 #2 — custom name × bracket pollution, both directions, must not leak (closes-heavy) or swallow
+  // (opens-heavy). Exercises the escape-tolerant closer search that plain `</Name>` missed. Both `}]`
+  // and the span-rebalancing `]}` are covered — the latter by the targeted `]}>` double-close signature.
   for (const name of ['$Panel', '_Panel', '𐐀Panel', 'ns.Qualified'] as const) {
     const tag = name.replace('.', '');
     const opener = `<${name}`;
-    for (const b of ['}]']) {
+    for (const b of ['}]', ']}']) {
       const r = clean(`prefix<${name} items={["a \\" ${b} > L${tag}ATTR", "c"]}>B${tag}VIS</${name}>S${tag}SUF`).join(' ');
       assert.ok(!r.includes(`L${tag}ATTR`) && !r.includes('items=') && !r.includes(opener), `${name} ${b} leaked: ${JSON.stringify(r)}`);
       assert.ok(r.includes(`B${tag}VIS`) && r.includes(`S${tag}SUF`), `${name} ${b} body/suffix lost: ${JSON.stringify(r)}`);
@@ -700,6 +696,52 @@ test('real structure() round-21: hierarchy-decided generics, opener-local recove
   assert.ok((await hits(even, 'EVENSLASHKEEP21')) > 0, `even-slash: generic 0-hit`);
   const split = 'g <$Panel extends SPLITGENKEEP21> then </`noise`$SplitPanel> tail';
   assert.ok((await hits(split, 'SPLITGENKEEP21')) > 0, `split-closer: generic 0-hit`);
+});
+
+// EVE round 22 — the full-chunk-sequence hierarchy the per-chunk `hasCloserLater` proxy missed. Pairing
+// now runs a two-level stack (local per-chunk inline, global cross-chunk flow) over the whole ordered
+// chunk stream. These drive the real structure() → buildIndex() → Orama chain with EVE's exact reals.
+test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flow, balanced-lossy contract', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r22', data: { title: '/r22', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a REAL enclosing same-name flow component (`<$Panel …>…</$Panel>`) whose body holds an
+  // in-body generic AND a real same-name inline. The inner inline closer pops the inline; the OUTER
+  // closer must pop the OUTER opener (cross-chunk), never the mid-body generic. Both chunk-start and
+  // glued generic positions, across all five generic roles — 10 cases, every generic needle must index.
+  const forms = {
+    bare: '<$Panel>',
+    constrained: '<$Panel extends GEN22C>',
+    default: '<$Panel = GEN22D>',
+    compound: '<$Panel, U extends GEN22P>',
+    comparison: 'val <$Panel extends GEN22M>',
+  } as const;
+  for (const [role, decl] of Object.entries(forms)) {
+    const needle = decl.match(/GEN22[A-Z]/)?.[0];
+    for (const [pos, body] of [['chunkstart', `${decl}() then <$Panel>INLINE22${role}</$Panel>`], ['glued', `factory()${decl}() then <$Panel>INLINE22${role}</$Panel>`]] as const) {
+      const raw = `<$Panel title="OUTER22">\n\n## H22\n\n${body}\n\n</$Panel>`;
+      if (needle) assert.ok((await hits(raw, needle)) > 0, `${role}/${pos}: generic "${needle}" 0-hit (outer closer mispaired)`);
+      assert.ok((await hits(raw, `INLINE22${role}`)) > 0, `${role}/${pos}: inline body 0-hit`);
+      assert.equal(await hits(raw, 'OUTER22'), 0, `${role}/${pos}: outer opener attribute leaked`);
+    }
+  }
+
+  // P1 #2 — a real flow JSX component whose body carries a heading, so structure() splits it into
+  // opener / body / closer chunks. The glued opener sees no closer in ITS chunk but IS paired by its
+  // real later-chunk closer (global stack) — never mistaken for a generic. Its attribute must not index.
+  const cross = 'prefix <$Panel extends CROSSATTR22>\n\n## Head22\n\nbody22\n\n</$Panel>';
+  assert.equal(await hits(cross, 'CROSSATTR22'), 0, 'cross-chunk flow opener attribute leaked (misjudged as generic)');
+  assert.ok((await hits(cross, 'body22')) > 0, 'cross-chunk flow body lost');
+
+  // P1 #3 — the restored balanced-lossy `]}` contract: a dropped quote-backslash rebalances the
+  // opener-local consumed span, but the leaked attribute's real close doubles onto the tag `>` as `]}>`.
+  // The attribute needle must NOT index (markup out), while body/suffix are preserved.
+  const lucky = 'prefix<Panel items={["a \\" ]} > LUCKYATTR22", "c"]}>LUCKYBODY22</Panel>LUCKYSUF22';
+  assert.equal(await hits(lucky, 'LUCKYATTR22'), 0, 'balanced-lossy ]} attribute leaked into Orama');
+  assert.ok((await hits(lucky, 'LUCKYBODY22')) > 0 && (await hits(lucky, 'LUCKYSUF22')) > 0, 'balanced-lossy body/suffix lost');
 });
 
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -644,6 +644,49 @@ test('real structure() round-19: opener-local desync, hierarchy attribution, Com
   assert.ok(!/<\/?\$?Panel>/.test(eb), `escaped-backtick left bare tag markup: ${eb}`);
 });
 
+// EVE round 20 — three residual P1s, verified through the real structure() → buildIndex() → Orama
+// chain (not just the string sanitizer), because a leak only matters if it changes what queries hit.
+test('real structure() round-20: syntactic-role generics, opener-local recovery, code-span parity', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r20', data: { title: '/r20', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a NON-nested same-name generic followed by a real same-name inline component. The generic
+  // must be excluded by syntactic role (its own body is unambiguously a generic) so the later inline
+  // closer does not drag it onto the stack; both the generic identifier and the inline body must index.
+  const forms = {
+    constrained: '<$Panel extends CONSTRAINEDARROW20>(x: $Panel) => x',
+    bare: 'keep<$Panel>(x: $Panel) => x',
+    default: '<$Panel = DEFAULTARROW20>(x: $Panel) => x',
+    compound: '<$Panel, U extends COMPOUNDARROW20>(x: $Panel) => x',
+    comparison: 'const c = a <$Panel extends COMPARISONARROW20> b',
+  } as const;
+  for (const [kind, decl] of Object.entries(forms)) {
+    const needle = decl.match(/[A-Z]+ARROW20/)?.[0];
+    if (!needle) continue; // 'bare' carries no attribute needle; its guarantee is the inline below
+    const raw = `Body ${kind}. \`const fn = ${decl};\` then <$Panel>INLINE${kind}20</$Panel> done.`;
+    assert.ok((await hits(raw, needle)) > 0, `${kind}: generic "${needle}" 0-hit`);
+    assert.ok((await hits(raw, `INLINE${kind}20`)) > 0, `${kind}: inline body 0-hit`);
+  }
+
+  // P1 #2 — a HONEST escaped opener (brace attribute forces the `\<` escape) whose visible body carries
+  // an unbalanced `[` and a stray `>`. Recovery must NOT fire (opener-local span is balanced), so the
+  // whole body survives — no left/right/suffix token is lost to a false desync.
+  const honest = 'prefix <Panel mode={{ a: 1 }} title="SAFEOPEN20">ESCOPENLEFT20 [ compare > ESCOPENRIGHT20</Panel>ESCOPENSUF20';
+  for (const q of ['ESCOPENLEFT20', 'ESCOPENRIGHT20', 'ESCOPENSUF20']) assert.ok((await hits(honest, q)) > 0, `honest opener "${q}" 0-hit`);
+
+  // P1 #3 — code-span escape by consecutive-backslash PARITY. An EVEN backslash run before a backtick is
+  // a real span opener; a constrained generic just before it must survive (the span is verbatim, not a
+  // fence that exposes a fake closer). And a span removal must preserve boundaries so `</` + span +
+  // `$SplitPanel>` never concatenate into a probe-visible pseudo-closer that deletes the generic.
+  const even = 'text <$Panel extends EVENSLASHKEEP20> x \\\\`noise </$Panel>` more';
+  assert.ok((await hits(even, 'EVENSLASHKEEP20')) > 0, `even-slash: generic 0-hit`);
+  const split = 'g <$Panel extends SPLITGENKEEP20> then </`noise`$SplitPanel> tail';
+  assert.ok((await hits(split, 'SPLITGENKEEP20')) > 0, `split-closer: generic 0-hit`);
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -820,6 +820,50 @@ test('real structure() round-24: bidirectional generic classification, opener-lo
   assert.ok((await hits(single, 'singlebody24')) > 0 && (await hits(single, 'prefix')) > 0, 'single-close body/prefix lost');
 });
 
+// EVE round 25 — pairing runs on the REAL hierarchy (no `sameOpen` name-set guessing): a prior technical
+// generic, a later same-name real flow, and a same-name NESTED flow each pair by their actual level. The
+// lossy strip boundary is opener-LOCAL (a double-close-glued-`>` past the fake early `>`, code-span aware —
+// never a whole-chunk scan), and the `()` desync no longer misjudges JS lexical contexts (regex, comment).
+test('real structure() round-25: real-hierarchy pairing, opener-local lossy boundary, lexical-safe desync', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r25', data: { title: '/r25', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a PRIOR technical generic (`<$Panel extends STALEGEN24>`) then a LATER real same-name flow: the
+  // lone `</$Panel>` pops the nearer flow by LIFO, so the stale generic stays kept and the flow markup drops.
+  // Holds for a bare (`<$Panel>`) and an attr'd (`<$Panel attr="x">`) real opener alike.
+  const staleThenFlow = 'Technical type <$Panel extends STALEGEN24>.\n\nprefix<$Panel>FLOWINTRO24\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(staleThenFlow, 'STALEGEN24')) > 0 && (await hits(staleThenFlow, 'FLOWINTRO24')) > 0, 'stale generic or later-flow intro lost');
+  const staleThenAttr = 'Technical type <$Panel extends STALEGEN24>.\n\nprefix<$Panel attr="x">REALATTR24\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(staleThenAttr, 'STALEGEN24')) > 0 && (await hits(staleThenAttr, 'REALATTR24')) > 0, 'stale generic or attr-flow intro lost');
+  assert.equal(await hits(staleThenAttr, 'attr'), 0, 'real attr-flow opener attribute leaked');
+
+  // P1 #1 (nested) — a same-name flow NESTED inside a same-name flow, the inner opener generic-shaped
+  // (`<$Panel extends INNERATTR24>`): both `</$Panel>` closers pop both levels, so no opener attribute leaks.
+  const nested = '<$Panel a="1">\n\ntop\n\n<$Panel extends INNERATTR24>\n\n## H\n\ninner\n\n</$Panel>\n\nmid\n\n</$Panel>';
+  assert.ok((await hits(nested, 'top')) > 0 && (await hits(nested, 'inner')) > 0 && (await hits(nested, 'mid')) > 0, 'nested-flow body lost');
+  assert.equal(await hits(nested, 'INNERATTR24'), 0, 'nested-flow inner opener attribute leaked');
+
+  // P1 #2 — a LOSSY opener's cleanup boundary stays confined to the opener: it stops at the double-close
+  // glued to `>` (`)}>`) just past the fake early `>`, so honest intro AFTER it survives — a comparison
+  // (`arr[i]>0`) and a code span (`` `arr[i]}>0` ``, whose literal `]}>` the code-span-aware scan skips).
+  const lossyCmp = 'prefix<$Panel value={fn("a \\" } > x", y)}>LEFT25 arr[i]>0 RIGHT25\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(lossyCmp, 'LEFT25')) > 0 && (await hits(lossyCmp, 'arr')) > 0 && (await hits(lossyCmp, 'RIGHT25')) > 0, 'lossy+comparison intro lost');
+  assert.equal(await hits(lossyCmp, 'value'), 0, 'lossy opener attribute leaked past its own boundary');
+  const lossyCode = 'prefix<$Panel value={fn("a \\" } > x", y)}>LEFTCODE25 `arr[i]}>0` RIGHTCODE25\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(lossyCode, 'LEFTCODE25')) > 0 && (await hits(lossyCode, 'RIGHTCODE25')) > 0, 'lossy+code-span intro lost');
+  assert.equal(await hits(lossyCode, 'value'), 0, 'lossy opener attribute leaked past a code span');
+
+  // P1 #3 — the desync test must not misjudge JS lexical contexts: a regex `/(/` and a comment `/* ( */`
+  // inside an honest attribute are NOT unbalanced parens, so the opener is clean and the intro survives.
+  const regexAttr = 'prefix<$Panel pattern={/\\(/}>LEFT25 arr[i]>0 RIGHT25\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(regexAttr, 'LEFT25')) > 0 && (await hits(regexAttr, 'arr')) > 0 && (await hits(regexAttr, 'RIGHT25')) > 0, 'regex-attr opener misjudged lossy, intro eaten');
+  const commentAttr = 'prefix<$Panel x={/* ( */ 1}>LEFT25 arr[i]>0 RIGHT25\n\n## H\n\nbody\n\n</$Panel>';
+  assert.ok((await hits(commentAttr, 'LEFT25')) > 0 && (await hits(commentAttr, 'arr')) > 0 && (await hits(commentAttr, 'RIGHT25')) > 0, 'comment-attr opener misjudged lossy, intro eaten');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -4,9 +4,9 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { structure } from 'fumadocs-core/mdx-plugins/remark-structure';
-import { initAdvancedSearch } from 'fumadocs-core/search/server';
+import { initAdvancedSearch, type SearchServer } from 'fumadocs-core/search/server';
 import { oramaStaticClient } from 'fumadocs-core/search/client/orama-static';
-import { buildIndex, sanitizeSearchText, pairResidues, encodeEscapedQuotes } from './search-index';
+import { buildIndex, sanitizeSearchText, pairResidues } from './search-index';
 
 // Unit: the sanitizer strips markdown/entity artifacts WITHOUT mangling
 // technical identifiers. The old regex stack turned `MACARON_CODEX_TRANSPORT`
@@ -52,6 +52,51 @@ test('sanitizeSearchText strips markup but preserves identifiers', () => {
   assert.equal(sanitizeSearchText('returns `<T>(value)` => value'), 'returns <T>(value) => value');
 });
 
+// EVE round-35 P1-3 / P2: round-34 sentinel-encoded escaped quotes (`\"` → U+E000) before
+// structure(), which corrupted legit prose and collided with real content. That machinery is
+// gone; buildIndex now consumes Fumadocs' compiled structuredData directly. These cases lock
+// the reverted behavior: a Windows path trailing backslash, mixed single/double-quote
+// attributes, a raw private-use code point, a `&#xE000;` entity, and an inline-code escaped
+// quote all sanitize cleanly — needle text survives, no sentinel is introduced, and only the
+// self-closing component residue that CAN reach a compiled chunk (`<File … />`) is stripped.
+test('sanitizeSearchText: paths, mixed quotes, PUA/entity/inline-code round-trip cleanly', () => {
+  const noSentinel = (s: string) => assert.ok(!/[]/.test(s), `sentinel code point leaked: ${JSON.stringify(s)}`);
+
+  // A legit Windows path with a trailing backslash is preserved (round-34's `\"`/`\'` encoding
+  // could mis-handle a backslash before a later quote); the needle survives.
+  for (const src of ['Install to `C:\\Users\\me` then run BODYPATH', 'the path C:\\ works FICHE']) {
+    const out = sanitizeSearchText(src);
+    noSentinel(out);
+    assert.ok(out.includes(src.includes('BODYPATH') ? 'BODYPATH' : 'FICHE'), `path needle lost: ${JSON.stringify(out)}`);
+    assert.ok(out.includes('C:'), `path text lost: ${JSON.stringify(out)}`);
+  }
+
+  // Mixed single/double-quote attributes on one component: the tag is stripped, body kept.
+  assert.equal(sanitizeSearchText("Body <Callout title=\"a > b\" desc='c'>inner MIXQ</Callout> tail"), 'Body inner MIXQ tail');
+
+  // A raw private-use char and a `&#xE000;` entity are ordinary content — no sentinel decode
+  // mangles them, and the needle survives alongside.
+  const pua = sanitizeSearchText('literal  and  chars PUANEEDLE');
+  assert.ok(pua.includes('PUANEEDLE'), `PUA needle lost: ${JSON.stringify(pua)}`);
+  const ent = sanitizeSearchText('entity &#xE000; here ENTNEEDLE');
+  assert.ok(ent.includes('ENTNEEDLE'), `entity needle lost: ${JSON.stringify(ent)}`);
+
+  // An escaped quote INSIDE inline code is literal content, never an attribute quote — it must
+  // not be sentinel-encoded away; the needle after it survives.
+  const inline = sanitizeSearchText('code `inline \\" quote` and more INLINEESC');
+  noSentinel(inline);
+  assert.ok(inline.includes('INLINEESC'), `inline-code needle lost: ${JSON.stringify(inline)}`);
+
+  // A legit prose escaped quote keeps its characters (no sentinel round-trip corruption).
+  const prose = sanitizeSearchText('he said \\"hello\\" QUOTEPROSE');
+  noSentinel(prose);
+  assert.ok(prose.includes('QUOTEPROSE') && prose.includes('hello'), `prose quote lost: ${JSON.stringify(prose)}`);
+
+  // The one residue shape that DOES reach a compiled chunk (a self-closing childless component)
+  // is stripped to nothing.
+  assert.equal(sanitizeSearchText('<File name="plugin.json" />'), '');
+});
+
 // EVE round 5 — the adversarial cases must run through the SAME path production
 // does: raw MDX → structure() → sanitize. Fumadocs splits a flow component around
 // any nested heading, so the sanitizer sees standalone opening/closing RESIDUE
@@ -61,7 +106,7 @@ test('sanitizeSearchText strips markup but preserves identifiers', () => {
 // emits such a residue; the guarantee is that no needle-adjacent markup survives.
 test('real structure() split chunks: residue never leaks, prose survives', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -100,7 +145,7 @@ test('real structure() split chunks: residue never leaks, prose survives', () =>
 // chunks, plus boundary fidelity the earlier rounds missed.
 test('real structure() split chunks: escaped quotes, generic defaults, OOB entities', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -270,7 +315,7 @@ test('real structure() split chunks: escaped quotes, generic defaults, OOB entit
 // page-wide paired-position set, exactly as buildIndex does.
 test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keywords, own-line >', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -334,7 +379,7 @@ test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keyw
 // code point (astral + namespaced), and the whole-chunk `standalone` tie-break is gone.
 test('real structure() positional pairing: lossy > recovery, code-span closers, prose generics, astral names', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -385,7 +430,7 @@ test('real structure() positional pairing: lossy > recovery, code-span closers, 
 // wrongly emptied by the standalone `hasAttrShape` strip. Each is fed through real structure().
 test('real structure() round-15: lossy-expression recovery, same-name inner generic, bare modifier generics', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -442,7 +487,7 @@ test('real structure() round-15: lossy-expression recovery, same-name inner gene
 //       corrupted attribute hides such a `}]` is stripped whole, not cut at scanTag's false `>`.
 test('real structure() round-16: syntactic-role pairing exemption, string-aware lossy recovery', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -499,7 +544,7 @@ test('real structure() round-16: syntactic-role pairing exemption, string-aware 
 //       directions and keeps the visible body/suffix.
 test('real structure() round-17: glued custom-name pairing, glued inline bracket matrix', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -556,7 +601,7 @@ test('real structure() round-17: glued custom-name pairing, glued inline bracket
 //       inline component, entered the stack, and stole the outer real closer. The probe must skip code.
 test('real structure() round-18: desync-gated anchor, custom-name × bracket matrix, code-span fake closer', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -615,7 +660,7 @@ test('real structure() round-18: desync-gated anchor, custom-name × bracket mat
 //       unterminated run is literal, not a fence) shared by every code-span skip.
 test('real structure() round-19: opener-local desync, hierarchy attribution, CommonMark code spans', () => {
   const clean = (raw: string) => {
-    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
+    const chunks = structure(raw).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -654,11 +699,11 @@ test('real structure() round-19: opener-local desync, hierarchy attribution, Com
 // recovery (honest body kept, lossy attribute dropped) — the exact reproductions from EVE's review.
 test('real structure() round-21: hierarchy-decided generics, opener-local recovery, code-span parity', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r21', data: { title: '/r21', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r21', data: { title: '/r21', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
-  const clean = (raw: string) => { const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content); const paired = pairResidues(chunks); return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired)); };
+  const clean = (raw: string) => { const chunks = structure(raw).contents.map((c) => c.content); const paired = pairResidues(chunks); return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired)); };
 
   // P1 #1a — a same-name generic PRECEDING a real same-name inline, in live prose (NOT a code span, so
   // pairResidues actually sees it). Hierarchy must keep the generic: positional nearest-pop hands the
@@ -703,7 +748,7 @@ test('real structure() round-21: hierarchy-decided generics, opener-local recove
 // chunk stream. These drive the real structure() → buildIndex() → Orama chain with EVE's exact reals.
 test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flow, balanced-lossy contract', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r22', data: { title: '/r22', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r22', data: { title: '/r22', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -749,7 +794,7 @@ test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flo
 // the real structure() → buildIndex() → Orama chain with EVE's exact reals from the round-22 review.
 test('real structure() round-23: whole-chunk/compact generics, intro/nested flow, single-close recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r23', data: { title: '/r23', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r23', data: { title: '/r23', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -789,7 +834,7 @@ test('real structure() round-23: whole-chunk/compact generics, intro/nested flow
 // Each case drives the real structure() → buildIndex() → Orama chain with EVE's exact round-23 reals.
 test('real structure() round-24: bidirectional generic classification, opener-local strip boundary', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r24', data: { title: '/r24', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r24', data: { title: '/r24', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -826,7 +871,7 @@ test('real structure() round-24: bidirectional generic classification, opener-lo
 // never a whole-chunk scan), and the `()` desync no longer misjudges JS lexical contexts (regex, comment).
 test('real structure() round-25: real-hierarchy pairing, opener-local lossy boundary, lexical-safe desync', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r25', data: { title: '/r25', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r25', data: { title: '/r25', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -872,7 +917,7 @@ test('real structure() round-25: real-hierarchy pairing, opener-local lossy boun
 // regex `/[}>]/` or comment `/* } > */` inside an honest `{…}` attribute is lexed, not miscounted.
 test('real structure() round-26: hierarchy role, opener-local lossy boundary, lexical-safe scan', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r26', data: { title: '/r26', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r26', data: { title: '/r26', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -918,7 +963,7 @@ test('real structure() round-26: hierarchy role, opener-local lossy boundary, le
 // that must not be mistaken for a quote leak.
 test('real structure() round-27: unified lexical-safe opener boundary across lossy shapes', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r27', data: { title: '/r27', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r27', data: { title: '/r27', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -950,7 +995,7 @@ test('real structure() round-27: unified lexical-safe opener boundary across los
 // (4) `/` after a `}` object-literal operand is division, not a regex.
 test('real structure() round-28: lexical-safe opener span, unified LIFO pairing, division after }', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r28', data: { title: '/r28', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r28', data: { title: '/r28', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1004,7 +1049,7 @@ test('real structure() round-28: lexical-safe opener span, unified LIFO pairing,
 //     in the leaked attribute is not a real boundary.
 test('real structure() round-29: budget order-independence, opener-local & quote-consistent lossy recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r29', data: { title: '/r29', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r29', data: { title: '/r29', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1054,7 +1099,7 @@ test('real structure() round-29: budget order-independence, opener-local & quote
 //     `pattern={/">/}` regex in the leaked attribute is not the real close; the tag's real `>` is.
 test('real structure() round-30: glued budget LIFO, prose instantiation, opener-local & regex-safe recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r30', data: { title: '/r30', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r30', data: { title: '/r30', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1089,7 +1134,7 @@ test('real structure() round-30: glued budget LIFO, prose instantiation, opener-
 
 test('real structure() round-31: opener-provable roles only — no chunk-end/body-first-char guessing, recovery gated on opener lossiness', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r31', data: { title: '/r31', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r31', data: { title: '/r31', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1135,7 +1180,7 @@ test('real structure() round-31: opener-provable roles only — no chunk-end/bod
 
 test('real structure() round-32: JSX boolean props are not TS prose, quota counts consistently, recovery is fully opener-local', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r32', data: { title: '/r32', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r32', data: { title: '/r32', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1175,7 +1220,7 @@ test('real structure() round-32: JSX boolean props are not TS prose, quota count
 
 test('real structure() round-33: per-closer-interval quota, opener-local expression/bracket recovery, lexical-safe desync', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r33', data: { title: '/r33', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r33', data: { title: '/r33', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1208,78 +1253,52 @@ test('real structure() round-33: per-closer-interval quota, opener-local express
   assert.ok((await hits(cmt, 'RIGHTCMT32')) > 0, 'clean comment-attr trailing body lost');
 });
 
-test('real structure() round-34: sentinel-encoded escaped quotes distinguish leak from legit trailing-space attr', async () => {
-  const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r34', data: { title: '/r34', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
-    return initAdvancedSearch({ language: 'english', indexes: [index] });
-  };
-  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
-  const summaries = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).map((r) => r.content ?? '');
-
-  // The unresolvable P1-4 case, now split by encodeEscapedQuotes running BEFORE structure(): the escaped
-  // quote becomes a sentinel so the leaked string stays balanced, scanTag lands on the REAL `>`, and the
-  // whole opener (needle and all) is stripped — while the LEGIT trailing-space attribute (no backslash)
-  // keeps its close-quote and its body survives. Both single- and double-quote leaks; both directions.
-  const dq = '<$Panel title="a \\" > DQLEAK34">LEFTDQ34 body\n\n## H\n\nRIGHTDQ34\n\n</$Panel>';
-  assert.equal(await hits(dq, 'DQLEAK34'), 0, 'double-quote dropped-quote leak survived (needle entered index)');
-  assert.ok((await hits(dq, 'LEFTDQ34')) > 0, 'double-quote leak: opener intro body lost');
-  assert.ok((await hits(dq, 'RIGHTDQ34')) > 0, 'double-quote leak: trailing body lost');
-
-  const sq = "<$Panel title='a \\' > SQLEAK34'>LEFTSQ34 body\n\n## H\n\nRIGHTSQ34\n\n</$Panel>";
-  assert.equal(await hits(sq, 'SQLEAK34'), 0, 'single-quote dropped-quote leak survived (needle entered index)');
-  assert.ok((await hits(sq, 'LEFTSQ34')) > 0, 'single-quote leak: opener intro body lost');
-  assert.ok((await hits(sq, 'RIGHTSQ34')) > 0, 'single-quote leak: trailing body lost');
-
-  // Legit attribute VALUE ending in a literal space — byte-identical to the leak BEFORE encoding, now
-  // distinct (no backslash → no sentinel → the real close-quote stands). The intro carries a body `">`
-  // so the OLD quote-leak recovery branch over-recovered and ate the intro (`LEFTLEGIT*34`) — RED on old
-  // head. The body's own `">` must survive too. Both quote styles.
-  const legitD = '<$Panel a="1 " >LEFTLEGITD34 text "> RIGHTLEGITD34\n\n## H\n\nt\n\n</$Panel>';
-  assert.ok((await hits(legitD, 'LEFTLEGITD34')) > 0, 'legit double-quote trailing-space attr: intro body wrongly stripped');
-  assert.ok((await hits(legitD, 'RIGHTLEGITD34')) > 0, 'legit double-quote trailing-space attr: trailing body lost');
-  const legitS = "<$Panel a='1 ' >LEFTLEGITS34 text '> RIGHTLEGITS34\n\n## H\n\nt\n\n</$Panel>";
-  assert.ok((await hits(legitS, 'LEFTLEGITS34')) > 0, 'legit single-quote trailing-space attr: intro body wrongly stripped');
-  assert.ok((await hits(legitS, 'RIGHTLEGITS34')) > 0, 'legit single-quote trailing-space attr: trailing body lost');
-
-  // A legit prose quote (`\"…\"`) must round-trip through the sentinel unchanged, and NO sentinel code
-  // point (U+E000/U+E001) may ever appear in a served summary.
-  const prose = 'prefix a \\"quoted phrase\\" QUOTEPROSE34 tail';
-  const proseHits = (await summaries(prose, 'QUOTEPROSE34')).filter((r) => r.includes('QUOTEPROSE34'));
-  assert.ok(proseHits.length > 0, 'legit prose quote sample produced no content hit');
-  for (const r of proseHits) {
-    assert.ok(!/[]/.test(r), `sentinel code point leaked into the index: ${JSON.stringify(r.slice(0, 60))}`);
-    assert.ok(r.includes('"quoted phrase"'), `legit prose quote lost its characters: ${JSON.stringify(r.slice(0, 60))}`);
-  }
-});
-
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
-function mdxFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
-    const full = path.join(dir, e.name);
-    if (e.isDirectory()) return mdxFiles(full);
-    return e.name.endsWith('.mdx') ? [full] : [];
-  });
+// Build the SAME index the production /api/search route builds. The production route
+// consumes Fumadocs' BUILD-COMPILED `page.data.structuredData` — remarkStructure run
+// inside the MDX compile on the real AST — so we load those exact compiled objects from
+// the build output (`build/server/assets/*.js`) and drive the production buildIndex over
+// them, then hand the records to Orama. This is the ONLY faithful production oracle: the
+// exported `structure(readFileSync(...))` uses remark() WITHOUT the mdxjs extension, so it
+// mis-parses frontmatter as a heading and drops every `<Card>`/`<Callout>` body — feeding
+// that here would hide real data loss (EVE round-35 P1-1). Requires a prior build; under
+// REQUIRE_BUILT_INDEX (verify/CI) a missing build is a hard failure, else the caller skips.
+const COMPILED_ASSETS = path.resolve(DOCS_DIR, '../../build/server/assets');
+
+type CompiledStructuredData = { contents: { heading?: string; content: string }[]; headings: { id: string; content: string }[] };
+
+function compiledPages(): { url: string; title: string; structuredData: CompiledStructuredData }[] {
+  if (!existsSync(COMPILED_ASSETS)) return [];
+  const pages: { url: string; title: string; structuredData: CompiledStructuredData }[] = [];
+  for (const file of readdirSync(COMPILED_ASSETS)) {
+    if (!file.endsWith('.js')) continue;
+    const src = readFileSync(path.join(COMPILED_ASSETS, file), 'utf8');
+    const sd = /var structuredData = (\{[\s\S]*?\n\});/.exec(src);
+    if (!sd) continue; // not a compiled doc module
+    const structuredData = new Function(`return ${sd[1]}`)() as CompiledStructuredData;
+    const fm = /var frontmatter = (\{[\s\S]*?\n\});/.exec(src);
+    const title = (fm ? (new Function(`return ${fm[1]}`)() as { title?: string }).title : undefined) ?? file;
+    pages.push({ url: '/' + file, title, structuredData });
+  }
+  return pages;
 }
 
-// Build the SAME index the production /api/search route builds: feed each real
-// MDX file through structure() (fumadocs' extractor) + the production buildIndex,
-// then hand the records to Orama via initAdvancedSearch — the exact engine
-// createFromSource() uses. `source` itself can't load here (it relies on Vite's
-// import.meta.glob), so we reconstruct page-shaped inputs and drive buildIndex
-// directly. This exercises the real sanitizer→Orama wiring, not just the string.
-async function productionSearch() {
-  const pages = mdxFiles(DOCS_DIR).map((file) => {
-    const raw = readFileSync(file, 'utf8');
-    const url = '/' + path.relative(DOCS_DIR, file).replace(/\.mdx$/, '');
-    return { url, data: { title: url, description: undefined, getText: async () => raw } };
-  });
-  const indexes = await Promise.all(pages.map((p) => buildIndex(p as unknown as Parameters<typeof buildIndex>[0])));
+async function productionSearch(): Promise<SearchServer | null> {
+  const pages = compiledPages();
+  if (pages.length === 0) {
+    if (process.env.REQUIRE_BUILT_INDEX) assert.fail('REQUIRE_BUILT_INDEX set but no compiled structuredData under build/server/assets — run `pnpm build` first');
+    return null;
+  }
+  const indexes = await Promise.all(
+    pages.map((p) => buildIndex({ url: p.url, data: { title: p.title, description: undefined, structuredData: p.structuredData } } as unknown as Parameters<typeof buildIndex>[0])),
+  );
   return initAdvancedSearch({ language: 'english', indexes });
 }
 
-test('production index: underscored identifiers stay searchable, corrupted forms miss', async () => {
+test('production index: underscored identifiers stay searchable, corrupted forms miss', async (t) => {
   const server = await productionSearch();
+  if (!server) return t.skip('run `pnpm build` (or `pnpm verify`) first — no compiled structuredData');
 
   // Real Orama queries: the true identifier hits, the underscore-stripped
   // corruption the old sanitizer produced returns nothing.
@@ -1291,13 +1310,44 @@ test('production index: underscored identifiers stay searchable, corrupted forms
   }
 });
 
-test('production index: result summaries carry no markup', async () => {
+// EVE round-35 P1-1: the production oracle must consume Fumadocs' BUILD-COMPILED
+// structuredData, so it catches the two data-loss modes round-34's `structure(getText('raw'))`
+// introduced. `structure()` (remark without the mdxjs extension) parses a doc's YAML
+// frontmatter as a Setext heading and drops every component body — feeding it here would ship
+// a search index whose headings are `title: … description: …` garbage and whose `<Card>` /
+// `<Callout>` bodies are gone. Against the real compiled index: component bodies ARE indexed
+// and NO frontmatter line ever became a heading.
+test('production index: component bodies indexed, frontmatter never a heading', async (t) => {
   const server = await productionSearch();
+  if (!server) return t.skip('run `pnpm build` (or `pnpm verify`) first — no compiled structuredData');
 
-  // Every returned summary must be clean prose — no backticks, no HTML entities,
-  // no serialized MDX/JSX tags. (Orama's own <mark> highlight is added at query
-  // time and is not doc content, so exclude it before scanning.)
-  const leaky = /`|&#x?[0-9a-fA-F]+;|<\/?[A-Za-z][^>]*>/;
+  // `<Card>` body text from content/docs/index.mdx — present only if Fumadocs' structural
+  // component-body extraction survived into the index (dropped by the raw `structure()` path).
+  for (const phrase of ['Browse workspaces', 'Stream thinking']) {
+    const hits = await server.search(phrase);
+    assert.ok(hits.length > 0, `component body "${phrase}" missing from the index (frontmatter/raw structure() would drop it)`);
+  }
+  // No served summary is a raw YAML frontmatter line — the tell of frontmatter mis-parsed as a
+  // heading/content chunk (`title: Introduction`, `description: …`).
+  for (const q of ['Introduction', 'description', 'title']) {
+    for (const r of await server.search(q)) {
+      const summary = (r.content ?? '').replace(/<\/?mark>/g, '');
+      assert.ok(!/^\s*(title|description):\s/.test(summary), `frontmatter leaked as a content chunk: ${JSON.stringify(summary.slice(0, 60))}`);
+    }
+  }
+});
+
+test('production index: result summaries carry no markup', async (t) => {
+  const server = await productionSearch();
+  if (!server) return t.skip('run `pnpm build` (or `pnpm verify`) first — no compiled structuredData');
+
+  // Every returned summary must be clean prose — no backticks, no HTML entities, no serialized
+  // MDX/JSX COMPONENT tags. A bare `<name>` / `<sha>` / `<version>` is legit searchable prose
+  // (the docs discuss the `/v1/models/<name>` endpoint, the `<sha>` placeholder), so the guard
+  // matches only real tag residue: a `</X>` closer, a self-closing `/>`, or an opening tag
+  // carrying attributes (`<X …>`) — never a bare single-word comparison. (Orama's own <mark>
+  // highlight is added at query time and is not doc content, so exclude it before scanning.)
+  const leaky = /`|&#x?[0-9a-fA-F]+;|<\/[A-Za-z]|<[A-Za-z][\w.:$-]*\s[^>]*>|\/>/;
   for (const q of ['MACARON_CODEX_TRANSPORT', 'permission_request', 'render_ui', 'relay', 'launcher']) {
     for (const r of await server.search(q)) {
       const summary = (r.content ?? '').replace(/<\/?mark>/g, '');
@@ -1313,14 +1363,15 @@ test('production index: result summaries carry no markup', async () => {
 // word "step" is real content); it is that the *serialized tag itself never
 // entered the index*: no result summary contains the literal tag markup, and the
 // tag as a contiguous token is absent.
-test('production index: serialized MDX tags never enter the index', async () => {
+test('production index: serialized MDX tags never enter the index', async (t) => {
   const server = await productionSearch();
+  if (!server) return t.skip('run `pnpm build` (or `pnpm verify`) first — no compiled structuredData');
 
   for (const tag of ['</Step>', '</Steps>', '<Tabs', '</Tab>', '<Callout', '<TypeTable']) {
     for (const r of await server.search(tag)) {
-      const summary = r.content ?? '';
+      const summary: string = r.content ?? '';
       assert.ok(!summary.includes(tag), `result for "${tag}" contains the literal tag: ${summary.slice(0, 100)}`);
-      assert.ok(!/<\/?[A-Za-z][^>]*>/.test(summary.replace(/<\/?mark>/g, '')), `result for "${tag}" contains tag markup`);
+      assert.ok(!/<\/[A-Za-z]|<[A-Za-z][\w.:$-]*\s[^>]*>|\/>/.test(summary.replace(/<\/?mark>/g, '')), `result for "${tag}" contains tag markup`);
     }
   }
 });
@@ -1360,7 +1411,7 @@ test('built /api/search: real Orama client honours the contract', async (t) => {
       assert.ok(Array.isArray(corrupted) && corrupted.length === 0, `built index: corrupted "${id.replace(/_/g, '')}" must miss`);
       for (const r of hits) {
         const summary = (r.content ?? '').replace(/<\/?mark>/g, '');
-        assert.ok(!/`|&#x?[0-9a-fA-F]+;|<\/?[A-Za-z][^>]*>/.test(summary), `built index summary leaked markup: ${summary.slice(0, 100)}`);
+        assert.ok(!/`|&#x?[0-9a-fA-F]+;|<\/[A-Za-z]|<[A-Za-z][\w.:$-]*\s[^>]*>|\/>/.test(summary), `built index summary leaked markup: ${summary.slice(0, 100)}`);
       }
     }
     // Tag-shaped query: may match the natural word ("step"), but no served summary

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -864,6 +864,52 @@ test('real structure() round-25: real-hierarchy pairing, opener-local lossy boun
   assert.ok((await hits(commentAttr, 'LEFT25')) > 0 && (await hits(commentAttr, 'arr')) > 0 && (await hits(commentAttr, 'RIGHT25')) > 0, 'comment-attr opener misjudged lossy, intro eaten');
 });
 
+// EVE round 26 — the full chunk sequence decides an ambiguous same-name opener's role: a lone outer
+// closer prefers the DEFINITE flow over a nearer standalone technical generic (so the generic survives),
+// while balanced closers still pair a real generic-shaped NESTED flow. The lossy strip stays opener-local
+// and lexical-safe: a clean bare opener never runs the double-close hunt (its honest MDX-expression intro
+// `{arr[i]}>0` survives); a leaked string attribute (dropped `\"`) is cut at its dangling `">`; and a
+// regex `/[}>]/` or comment `/* } > */` inside an honest `{…}` attribute is lexed, not miscounted.
+test('real structure() round-26: hierarchy role, opener-local lossy boundary, lexical-safe scan', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r26', data: { title: '/r26', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a STANDALONE same-name technical generic inside a DEFINITE outer flow (one outer closer) is
+  // in-body prose: the lone closer pops the definite outer, the generic stays unpaired → kept. The exact
+  // reverse of the NESTED case below, which is byte-identical but has a SECOND closer.
+  const standalone = '<$Panel a="1">HEAD body\n\n## H\n\n<$Panel extends STANDALONEKEEP25>\n\n## H2\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(standalone, 'STANDALONEKEEP25')) > 0, 'standalone in-body generic wrongly deleted by outer closer');
+  const nested = '<$Panel a="1">\n\ntop\n\n<$Panel extends INNERATTR25>\n\n## H\n\ninner\n\n</$Panel>\n\nmid\n\n</$Panel>';
+  assert.ok((await hits(nested, 'top')) > 0 && (await hits(nested, 'inner')) > 0 && (await hits(nested, 'mid')) > 0, 'nested-flow body lost');
+  assert.equal(await hits(nested, 'INNERATTR25'), 0, 'nested-flow inner opener attribute leaked');
+
+  // P1 #2 — a CLEAN bare opener whose visible intro carries an honest MDX expression (`{arr[i]}>0`, whose
+  // literal `]}>` a lossy scan would mistake for a leaked attribute close) keeps that intro intact.
+  const mdxExpr = 'pre<$Panel>LEFTEXPR25 {arr[i]}>0 RIGHTEXPR25\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(mdxExpr, 'LEFTEXPR25')) > 0 && (await hits(mdxExpr, 'RIGHTEXPR25')) > 0, 'clean-opener MDX-expression intro eaten by double-close hunt');
+
+  // P1 #3 — a leaked STRING attribute (structure() dropped its `\"`, so scanTag desyncs and stops at a
+  // fake `>` inside the string) is cut at its dangling `">`, needle gone; an honest quoted/apostrophe
+  // intro after a balanced opener is NOT misfired (its quotes are balanced at every glued `">`).
+  const strAttr = '<$Panel title="a \\" > STRINGATTR25">LEFTSTR body\n\n## H\n\ntail\n\n</$Panel>';
+  assert.equal(await hits(strAttr, 'STRINGATTR25'), 0, 'leaked string attribute survived past its dangling close');
+  assert.ok((await hits(strAttr, 'LEFTSTR')) > 0, 'string-attr visible body lost');
+  const honestQuote = '<$Panel a="1">He said "hi there" LEFTQ arr[i]>0 RIGHTQ\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(honestQuote, 'LEFTQ')) > 0 && (await hits(honestQuote, 'RIGHTQ')) > 0, 'honest quoted intro misfired the dangling-close cut');
+
+  // P1 #4 — a regex `/[}>]/` or comment `/* } > */` inside an honest `{…}` attribute holds literal
+  // `}` / `>` that scanTag must lex (not count), so the attribute markup drops and the body survives.
+  const regexAttr = 'pre<$Panel pattern={/[}>]REGEXATTR25/}>BODYREGEX intro\n\n## H\n\ntail\n\n</$Panel>';
+  assert.equal(await hits(regexAttr, 'REGEXATTR25'), 0, 'regex-attr markup leaked (brace/gt miscounted)');
+  assert.ok((await hits(regexAttr, 'BODYREGEX')) > 0, 'regex-attr body lost');
+  const commentAttr = 'pre<$Panel x={/* } > COMMENTATTR25 */ 1}>BODYCOMMENT intro\n\n## H\n\ntail\n\n</$Panel>';
+  assert.equal(await hits(commentAttr, 'COMMENTATTR25'), 0, 'comment-attr markup leaked (brace/gt miscounted)');
+  assert.ok((await hits(commentAttr, 'BODYCOMMENT')) > 0, 'comment-attr body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -993,6 +993,55 @@ test('real structure() round-28: lexical-safe opener span, unified LIFO pairing,
   assert.ok((await hits(od, 'BODYOBJDIV27')) > 0, 'division after } object-literal operand emptied the chunk');
 });
 
+// EVE round 29 — the final review's 4 exact P1s, made non-skippable:
+// (1) the generic-flow budget must have NO encounter-order bias — a leading GLUED technical generic must
+//     not steal the lone surplus closer that belongs to a later STANDALONE real generic-shaped flow (and
+//     vice-versa when the order is reversed).
+// (2) lossyOpenerEnd is OPENER-LOCAL — an honest body `">` / `'>` after a CLEAN attributed opener must
+//     not be mistaken for a leaked close (its span glues `">`, never `" >`).
+// (3) single-quote lossy attributes are recovered exactly like double-quote ones (same-chunk & cross).
+// (4) the lossy forward recovery is regex/comment lexical-safe — a `)}>` / `}>` inside a regex or comment
+//     in the leaked attribute is not a real boundary.
+test('real structure() round-29: budget order-independence, opener-local & quote-consistent lossy recovery', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r29', data: { title: '/r29', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (1) budget order-independence — a leading glued technical generic must keep (searchable) while the
+  // later standalone real flow claims the lone closer (its markup drops); then the reversed order.
+  const first = 'Technical <$Panel extends STALEFIRST28>.\n\n<$Panel extends REALFLOWATTR28>\n\n## H\n\nBODYKEEP28\n\n</$Panel>';
+  assert.ok((await hits(first, 'STALEFIRST28')) > 0, 'leading glued generic stole the later flow closer (order bias)');
+  assert.equal(await hits(first, 'REALFLOWATTR28'), 0, 'later standalone real flow markup leaked (budget starved)');
+  assert.ok((await hits(first, 'BODYKEEP28')) > 0, 'real flow body lost');
+  const rev = '<$Panel extends REALFLOWATTR28>\n\n## H\n\nBODYKEEP28\n\n</$Panel>\n\nTechnical <$Panel extends STALESECOND28>.';
+  assert.equal(await hits(rev, 'REALFLOWATTR28'), 0, 'leading standalone real flow markup leaked (reversed order)');
+  assert.ok((await hits(rev, 'STALESECOND28')) > 0, 'trailing glued technical generic wrongly deleted (reversed order)');
+
+  // (2) opener-local — a CLEAN attributed opener whose visible body carries an honest `">` must survive.
+  const cross = '<$Panel a="1">LEFTCROSSQ28 text "> RIGHTCROSSQ28\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(cross, 'LEFTCROSSQ28')) > 0 && (await hits(cross, 'RIGHTCROSSQ28')) > 0, 'honest body `">` mistaken for a leaked close');
+
+  // (3) single-quote lossy — same-chunk inline and cross-chunk flow both strip the leaked attribute.
+  const sqSame = "<$Panel title='a \\' > LEAKSQ28'>BODYSQ28</$Panel> suffix";
+  assert.equal(await hits(sqSame, 'LEAKSQ28'), 0, 'single-quote same-chunk lossy attribute leaked');
+  assert.ok((await hits(sqSame, 'BODYSQ28')) > 0, 'single-quote same-chunk body lost');
+  const sqCross = "<$Panel title='a \\' > LEAKSQCROSS28'>\n\n## H\n\nbodySqCross\n\n</$Panel>";
+  assert.equal(await hits(sqCross, 'LEAKSQCROSS28'), 0, 'single-quote cross-chunk lossy attribute leaked');
+  assert.ok((await hits(sqCross, 'bodySqCross')) > 0, 'single-quote cross-chunk body lost');
+
+  // (4) regex/comment lexical-safe forward recovery — a `)}>` inside a regex (and a comment) in the leaked
+  // attribute is not the real boundary; the real `)}>` after it is.
+  const reg = '<$Panel value={fn("a \\" } > LEAKREG28", /[)}>]/.test(REGTAIL28))}>BODYREG28</$Panel> suffix';
+  assert.equal(await hits(reg, 'LEAKREG28'), 0, 'regex-in-attr leaked attribute survived');
+  assert.equal(await hits(reg, 'REGTAIL28'), 0, 'regex body content leaked (miscounted as boundary)');
+  assert.ok((await hits(reg, 'BODYREG28')) > 0, 'regex-case visible body lost');
+  const cmt = '<$Panel value={fn("a \\" } > LEAKCMT28", /* )}> */ 1)}>BODYCMT28</$Panel> suffix';
+  assert.equal(await hits(cmt, 'LEAKCMT28'), 0, 'comment-in-attr leaked attribute survived');
+  assert.ok((await hits(cmt, 'BODYCMT28')) > 0, 'comment-case visible body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -744,6 +744,45 @@ test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flo
   assert.ok((await hits(lucky, 'LUCKYBODY22')) > 0 && (await hits(lucky, 'LUCKYSUF22')) > 0, 'balanced-lossy body/suffix lost');
 });
 
+// EVE round 23 — the flow-vs-generic decision no longer keys on "opener ends the chunk", and lossy
+// `>`-recovery no longer scans the visible body or relies on a double-close signature. Each case drives
+// the real structure() → buildIndex() → Orama chain with EVE's exact reals from the round-22 review.
+test('real structure() round-23: whole-chunk/compact generics, intro/nested flow, single-close recovery', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r23', data: { title: '/r23', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // P1 #1 — a whole-chunk in-body generic (`factory()\<$Panel extends ENDCONSTR22>`) that ALSO ends its
+  // chunk, and a compact one (`when alpha\<$Panel remains COMPACTKEEP22`), inside a real same-name outer
+  // flow component. The outer closer must NOT pair off the mid-body generic; the generic needle stays.
+  const endconstr = '<$Panel attr="OUTER23">\n\n## H\n\nfactory()<$Panel extends ENDCONSTR22>\n\n</$Panel>';
+  assert.ok((await hits(endconstr, 'ENDCONSTR22')) > 0, 'whole-chunk generic wrongly deleted by outer closer');
+  assert.equal(await hits(endconstr, 'OUTER23'), 0, 'endconstr outer opener attribute leaked');
+  const compact = '<$Panel attr="OUTER23">\n\n## H\n\nwhen alpha<$Panel remains COMPACTKEEP22\n\n</$Panel>';
+  assert.ok((await hits(compact, 'COMPACTKEEP22')) > 0, 'compact generic wrongly deleted by outer closer');
+
+  // P1 #2 — a real flow component with INTRO text before its heading (`prefix<$Panel>FLOWINTRO22`) and a
+  // CONTINUOUSLY NESTED flow-opener chunk (`<$Outer><$Inner>`): both openers must pair by their real
+  // later-chunk closers (not misjudged as generics), so no markup indexes but the intro/body survive.
+  const intro = 'prefix<$Panel>FLOWINTRO22\n\n## H\n\nbody23\n\n</$Panel>';
+  assert.ok((await hits(intro, 'FLOWINTRO22')) > 0 && (await hits(intro, 'prefix')) > 0, 'flow intro text lost');
+  assert.equal(await hits(intro, 'Panel'), 0, 'flow-intro opener markup leaked');
+  const nested = '<$Outer>\n\n<$Inner>\n\n## H\n\nnestbody23\n\n</$Inner>\n\n</$Outer>';
+  assert.ok((await hits(nested, 'nestbody23')) > 0, 'nested-flow body lost');
+  assert.equal(await hits(nested, 'Outer'), 0, 'continuous nested flow opener markup leaked');
+
+  // P1 #3 — recovery must not scan the visible body: an honest code span `` `arr[i]}>0` `` keeps its text
+  // (no fake double-close trigger), and a SINGLE-close lossy JSX expression opener (`… } > SINGLELEAK22`,
+  // not just array `]}`) still strips, needle out, body/suffix preserved.
+  const codespan = 'LEFTCODE22 `arr[i]}>0` more23';
+  assert.ok((await hits(codespan, 'LEFTCODE22')) > 0 && (await hits(codespan, 'more23')) > 0, 'code-span honest body lost to recovery');
+  const single = 'prefix<$Panel value={fn("a \\" } > SINGLELEAK22", x)}>\n\n## H\n\nsinglebody23\n\n</$Panel>';
+  assert.equal(await hits(single, 'SINGLELEAK22'), 0, 'single-close lossy attribute leaked into Orama');
+  assert.ok((await hits(single, 'singlebody23')) > 0 && (await hits(single, 'prefix')) > 0, 'single-close body/prefix lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -940,6 +940,59 @@ test('real structure() round-27: unified lexical-safe opener boundary across los
   assert.ok((await hits(apos, 'LEFTAP27')) > 0, 'apostrophe-case visible body lost');
 });
 
+// EVE round 28 — the exact real-Orama counterexamples from the final review, made non-skippable:
+// (1) lossyOpenerEnd stays lexically safe over the WHOLE residue — a regex/comment inside an attr and a
+//     code span in the body never miscount, and an honest `{arr[i]}>0` intro survives.
+// (2) cross- and same-chunk lossy openers share ONE boundary path — a dropped-quote same-chunk opener is
+//     cut at its own `">`, and an extra honest `"` in a cross-chunk body cannot rebalance parity and leak.
+// (3) pairing is true LIFO with no remote-generic search: a lone technical generic stays searchable while
+//     the real flow markup is stripped, and a nested flow + trailing technical generic both resolve.
+// (4) `/` after a `}` object-literal operand is division, not a regex.
+test('real structure() round-28: lexical-safe opener span, unified LIFO pairing, division after }', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r28', data: { title: '/r28', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (1) REGATTR27 — a regex `/[}>]/` inside an honest attr expression must not be read as a leaked close;
+  // the clean opener's MDX-expression intro `{arr[i]}>0` survives and the attr needle never indexes.
+  const reg = 'pre<$Panel pattern={/[}>]REGATTR27/}>LEFTREG27 {arr[i]}>0 RIGHTREG27\n\n## H\n\nt\n\n</$Panel>';
+  assert.equal(await hits(reg, 'REGATTR27'), 0, 'regex-in-attr miscounted as a leaked close');
+  assert.ok((await hits(reg, 'LEFTREG27')) > 0 && (await hits(reg, 'arr')) > 0 && (await hits(reg, 'RIGHTREG27')) > 0, 'regex-attr clean intro eaten');
+  // comment variant — `/* } > … */` inside an attr is equally inert.
+  const cmt = 'pre<$Panel x={/* } > CMTATTR27 */ 1}>LEFTCMT27 {arr[i]}>0 RIGHTCMT27\n\n## H\n\nt\n\n</$Panel>';
+  assert.equal(await hits(cmt, 'CMTATTR27'), 0, 'comment-in-attr miscounted as a leaked close');
+  assert.ok((await hits(cmt, 'LEFTCMT27')) > 0, 'comment-attr clean intro eaten');
+
+  // (2) same-chunk dropped-quote leak — the opener + its inline closer + suffix share one chunk; the
+  // leaked attribute must be cut at its dangling `">` and never index, body/suffix survive.
+  const sc = '<$Panel title="a \\" > LEAKSAME27">BODYKEEP27</$Panel> suffix';
+  assert.equal(await hits(sc, 'LEAKSAME27'), 0, 'same-chunk dropped-quote attribute leaked');
+  assert.ok((await hits(sc, 'BODYKEEP27')) > 0, 'same-chunk lossy body lost');
+  // cross-chunk parity — an extra honest `"` in the split body must NOT rebalance the opener's quote
+  // parity and re-expose the attr needle.
+  const par = '<$Panel title="a \\" > PARLEAK27">\n\n## H\n\nbody with " honest quote\n\n</$Panel>';
+  assert.equal(await hits(par, 'PARLEAK27'), 0, 'cross-chunk body quote rebalanced parity, attribute leaked');
+
+  // (3) STALELOCAL27 — a lone technical generic (no closer of its own) before a real flow stays searchable
+  // as prose while the real flow's markup is stripped (identical contract to round-26 STANDALONEKEEP25).
+  const stale = 'Technical <$Panel extends STALELOCAL27>. prefix<$Panel>FLOWINTRO27\n\n## H\n\nb\n\n</$Panel>';
+  assert.ok((await hits(stale, 'STALELOCAL27')) > 0, 'lone technical generic wrongly deleted by the real flow closer');
+  assert.ok((await hits(stale, 'FLOWINTRO27')) > 0, 'real flow intro lost');
+  // nested flow + a trailing technical generic — the nested opener attr is stripped, the trailing generic
+  // (`type Box<$Panel extends TECHKEEP27>`, no closer of its own) stays searchable.
+  const nest = '<$Panel a="1">\n\ntop\n\n<$Panel extends INNERATTR27>\n\n## H\n\ninner\n\n</$Panel>\n\ntype Box<$Panel extends TECHKEEP27> = $Panel;\n\n</$Panel>';
+  assert.equal(await hits(nest, 'INNERATTR27'), 0, 'nested-flow inner opener attribute leaked');
+  assert.ok((await hits(nest, 'TECHKEEP27')) > 0, 'trailing technical generic wrongly deleted');
+  assert.ok((await hits(nest, 'top')) > 0 && (await hits(nest, 'inner')) > 0, 'nested-flow body lost');
+
+  // (4) object-literal division — `{a:1} / 2` after a `}` operand is division, so the opener closes at its
+  // real `>` and the visible intro survives (no run-to-end that empties the chunk).
+  const od = '<$Panel value={{a:1} / 2}>BODYOBJDIV27 intro\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(od, 'BODYOBJDIV27')) > 0, 'division after } object-literal operand emptied the chunk');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -1133,6 +1133,46 @@ test('real structure() round-31: opener-provable roles only — no chunk-end/bod
   assert.ok((await hits(expr, 'AFTERBR')) > 0, 'clean expression-attr trailing body lost');
 });
 
+test('real structure() round-32: JSX boolean props are not TS prose, quota counts consistently, recovery is fully opener-local', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r32', data: { title: '/r32', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (P1-a) A glued opener carrying a JSX BOOLEAN / keyword prop (`$Panel in X`, `… as X`, `… instanceof X`,
+  // `… satisfies X`) is a real flow residue, NOT a TS instantiation. The old operand-position probe also
+  // synthesized a relational template `a<$Panel in X>b`, which parses as a binary-operator chain and wrongly
+  // classified these as prose — so the opener was skipped and its markup (`Panel`) leaked. Only the
+  // type-argument-call template `f<…>()` decides now, which rejects every boolean prop. RED on old head.
+  for (const kw of ['in', 'as', 'instanceof', 'satisfies']) {
+    const raw = `prefix<$Panel ${kw} X>! I32\n\n## H\n\nB32\n\n</$Panel>`;
+    assert.equal(await hits(raw, 'Panel'), 0, `JSX boolean prop '${kw}' misclassified as prose — markup leaked`);
+    assert.ok((await hits(raw, 'B32')) > 0, `flow body lost for boolean prop '${kw}'`);
+  }
+
+  // (P1-b) The nearest-wins glued-generic quota must count only the generics pre-scan actually counted. A
+  // leading PROSE instantiation (`type Duo<$Panel, X>.` — call-parses clean, skipped in pre-scan) used to
+  // still decrement the remaining window in the main pass, shifting the lone closer to an EARLIER glued
+  // generic (`STALESHIFT31`) instead of the nearest real flow (`REALSHIFT31`). RED on old head.
+  const shift = 'type Duo<$Panel, X>.\n\nTechnical <$Panel extends STALESHIFT31>.\n\nprefix<$Panel extends REALSHIFT31>K\n\n## H\n\nB\n\n</$Panel>';
+  assert.ok((await hits(shift, 'STALESHIFT31')) > 0, 'stale leading generic stole the closer (prose instantiation miscounted the quota)');
+  assert.equal(await hits(shift, 'REALSHIFT31'), 0, 'nearest real flow markup leaked (quota shifted)');
+
+  // (P1-c) Recovery must be decided by OPENER-LOCAL evidence only, never the visible body's first char. Two
+  // mirror failures under the old `text[end]` whitespace guess:
+  //   - a genuinely lossy opener whose recovered `>` happens to be followed by whitespace (`title="a \" >
+  //     LEAKSPACE31">   BODY…`) was WRONGLY rejected → the leaked attribute leaked;
+  //   - a clean expression attribute (`b={x}>`) whose body carries a `"}>` was WRONGLY recovered → the intro
+  //     was eaten. Now the quote branch fires purely on the opener-span leak signature, and the bracket
+  //     branch only on an opener-provably lossy (`\{`/`\[` + desynced-or-fake-`>`) span. RED on old head.
+  const leak = '<$Panel title="a \\" > LEAKSPACE31">   BODYSPACE31\n\n## H\n\nt\n\n</$Panel>';
+  assert.equal(await hits(leak, 'LEAKSPACE31'), 0, 'lossy leaked attribute survived (recovery rejected on trailing-whitespace body)');
+  const expr32 = '<$Panel b={x}>LEFTEXPR31 text "}>RIGHTEXPR31\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(expr32, 'LEFTEXPR31')) > 0, 'clean expression-attr intro eaten by body-driven bracket recovery');
+  assert.ok((await hits(expr32, 'RIGHTEXPR31')) > 0, 'clean expression-attr trailing body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { structure } from 'fumadocs-core/mdx-plugins/remark-structure';
 import { initAdvancedSearch } from 'fumadocs-core/search/server';
 import { oramaStaticClient } from 'fumadocs-core/search/client/orama-static';
-import { buildIndex, sanitizeSearchText, collectCloserNames } from './search-index';
+import { buildIndex, sanitizeSearchText, pairResidues } from './search-index';
 
 // Unit: the sanitizer strips markdown/entity artifacts WITHOUT mangling
 // technical identifiers. The old regex stack turned `MACARON_CODEX_TRANSPORT`
@@ -62,8 +62,8 @@ test('sanitizeSearchText strips markup but preserves identifiers', () => {
 test('real structure() split chunks: residue never leaks, prose survives', () => {
   const clean = (raw: string) => {
     const chunks = structure(raw).contents.map((c) => c.content);
-    const closers = collectCloserNames(chunks);
-    return chunks.map((c) => sanitizeSearchText(c, closers));
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
 
   // A template literal in a `<Tabs items={…}>` attribute, split off as its own
@@ -101,8 +101,8 @@ test('real structure() split chunks: residue never leaks, prose survives', () =>
 test('real structure() split chunks: escaped quotes, generic defaults, OOB entities', () => {
   const clean = (raw: string) => {
     const chunks = structure(raw).contents.map((c) => c.content);
-    const closers = collectCloserNames(chunks);
-    return chunks.map((c) => sanitizeSearchText(c, closers));
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
 
   // A backslash-escaped backtick inside the template, and a backslash-escaped quote
@@ -262,17 +262,17 @@ test('real structure() split chunks: escaped quotes, generic defaults, OOB entit
   assert.deepEqual(clean('before <!-- secret --> visible'), ['before visible']);
 });
 
-// EVE round 13 — re-converge the JSX/TS decision on a CROSS-CHUNK signal instead of a
-// per-chunk oracle union. structure() emits a `</Name>` closing residue for every real
-// flow component but never for a TS generic, so the page-wide `</Name>` set (collectCloserNames)
-// is the authority that separates genuinely-ambiguous openers (`<out disabled>` component vs
-// `<out T = "x">` generic) that BOTH grammars accept. Each raw sample is fed through real
-// structure() with the page-wide closer set, exactly as buildIndex does.
+// EVE round 13 — re-converge the JSX/TS decision on a cross-chunk signal instead of a
+// per-chunk oracle union. structure() emits a closing residue for every real flow component
+// but never for a TS generic, so positional residue pairing (pairResidues) is the authority
+// that separates genuinely-ambiguous openers (`<out disabled>` component vs `<out T = "x">`
+// generic) that BOTH grammars accept. Each raw sample is fed through real structure() with the
+// page-wide paired-position set, exactly as buildIndex does.
 test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keywords, own-line >', () => {
   const clean = (raw: string) => {
     const chunks = structure(raw).contents.map((c) => c.content);
-    const closers = collectCloserNames(chunks);
-    return chunks.map((c) => sanitizeSearchText(c, closers));
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
 
   // Blocker 1 — a glued opener whose attribute holds an escaped quote / escaped template
@@ -298,9 +298,12 @@ test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keyw
     assert.ok(!r.some((t) => new RegExp(`${needle}|instanceof=|ns\\.Qualified`).test(t)), `ambiguous opener ${open} leaked: ${JSON.stringify(r)}`);
     assert.ok(r.some((t) => t.includes(body)), `ambiguous opener ${open} body must survive: ${JSON.stringify(r)}`);
   }
-  // A `<const dataÉ="x">` component with a Unicode attribute, paired by a page closer, strips.
+  // A whole-chunk `<const dataÉ="x">` (Unicode attribute name, no page closer): grammatically
+  // this is a VALID TS variance/modifier generic — identical in shape to `<const T = "x">` —
+  // so no grammar oracle can tell it apart from prose. Deleting a real generic is the worse
+  // failure, so it is KEPT searchable rather than stripped as a speculative component.
   const constUni = clean('<const dataÉ="CONSTUNINEEDLE">\n\n## H\n\nconstunibody\n\n</const>');
-  assert.ok(!constUni.some((t) => /CONSTUNINEEDLE|<const|dataÉ/.test(t)), `const-unicode opener leaked: ${JSON.stringify(constUni)}`);
+  assert.ok(constUni.some((t) => /CONSTUNINEEDLE/.test(t)), `const-unicode generic must stay searchable: ${JSON.stringify(constUni)}`);
   assert.ok(constUni.some((t) => t.includes('constunibody')), `const-unicode body must survive: ${JSON.stringify(constUni)}`);
 
   // Blocker 2 reverse — a genuinely-VALID no-space generic default (`<in T = "…">`) has NO
@@ -324,6 +327,106 @@ test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keyw
     assert.ok(!r.some((s) => new RegExp(`<${tag.replace('$', '\\$')}`).test(s)), `no-attr paired <${tag}> leaked: ${JSON.stringify(r)}`);
     assert.ok(r.some((s) => s.includes(body)), `no-attr paired <${tag}> body must survive: ${JSON.stringify(r)}`);
   }
+});
+
+// EVE round 14 — real-chain reproductions the page-level closer-NAME set (round 13) got wrong.
+// The pairing is now POSITIONAL, hierarchy- and code-span-aware, name scanning is by Unicode
+// code point (astral + namespaced), and the whole-chunk `standalone` tie-break is gone.
+test('real structure() positional pairing: lossy > recovery, code-span closers, prose generics, astral names', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // Blocker 1 — an escaped-quote / template attribute that itself CONTAINS a `>`: the scan must
+  // not treat that inner `>` as the tag end. Glued opener → body + suffix survive; chunk-start
+  // opener → whole opener (and its needle) dropped, the body survives.
+  const gq = clean('prefix<Panel title="a \\" > b QUOTEATTRNEEDLE">visiblebodyA</Panel>suffixA');
+  assert.ok(!gq.some((t) => /QUOTEATTRNEEDLE|<Panel|title=/.test(t)), `glued quote>-attr leaked: ${JSON.stringify(gq)}`);
+  assert.ok(gq.some((t) => /prefix/.test(t) && /visiblebodyA/.test(t) && /suffixA/.test(t)), `glued quote>-attr body/suffix lost: ${JSON.stringify(gq)}`);
+  const gt = clean('prefix<Panel title={`a } > b TPLATTRNEEDLE`}>visiblebodyB</Panel>suffixB');
+  assert.ok(!gt.some((t) => /TPLATTRNEEDLE|<Panel|title=/.test(t)), `glued template>-attr leaked: ${JSON.stringify(gt)}`);
+  assert.ok(gt.some((t) => /prefix/.test(t) && /visiblebodyB/.test(t) && /suffixB/.test(t)), `glued template>-attr body/suffix lost: ${JSON.stringify(gt)}`);
+  const cs = clean('<Panel title="a \\" > b CSNEEDLE">\n\n## H\n\ncsbody\n\n</Panel>');
+  assert.ok(!cs.some((t) => /CSNEEDLE|<Panel|title=/.test(t)), `chunk-start quote>-attr leaked: ${JSON.stringify(cs)}`);
+  assert.ok(cs.includes('csbody'), `chunk-start quote>-attr body lost: ${JSON.stringify(cs)}`);
+
+  // Blocker 2 — a code-span `` `</T>` `` literal in one chunk must NOT pair off (and delete) a
+  // real `<T, U = …>` generic / inline `<in>…</in>` prose in another section.
+  assert.ok(clean('`</T>`\n\n## H\n\ntype X\\<T, U="CODECLOSERNEEDLE"> here').some((t) => t.includes('CODECLOSERNEEDLE')), 'code-span closer wrongly deleted a real generic');
+  assert.ok(clean('a <in>x</in> b\n\n## H\n\ntype P\\<in T="INLINEINNEEDLE"> here').some((t) => t.includes('INLINEINNEEDLE')), 'inline <in> pairing wrongly deleted a cross-section modifier generic');
+
+  // Blocker 3 — a whole-chunk prose generic with a modifier default (`out`/`in`/`const`) must
+  // NOT be deleted by any standalone tie-break — the needle stays searchable.
+  assert.deepEqual(clean('type Producer\\<out T = "OUTWHOLENEEDLE">'), ['type Producer<out T = "OUTWHOLENEEDLE">']);
+  assert.deepEqual(clean('type Consumer\\<in T = "INWHOLENEEDLE">'), ['type Consumer<in T = "INWHOLENEEDLE">']);
+  assert.deepEqual(clean('function f\\<const T = "CONSTWHOLENEEDLE">'), ['function f<const T = "CONSTWHOLENEEDLE">']);
+
+  // Blocker 4 — astral (`𐐀`, a surrogate pair) and namespaced (`ns:tag`) paired tags: the name
+  // scan must read whole code points and include `:`, so opener/attr/closer are all removed.
+  const astral = clean('<𐐀Panel x={["ASTRALNEEDLE"]}>\n\n## H\n\nastralbody\n\n</𐐀Panel>');
+  assert.ok(!astral.some((t) => /ASTRALNEEDLE|𐐀Panel/.test(t)), `astral tag leaked: ${JSON.stringify(astral)}`);
+  assert.ok(astral.includes('astralbody'), `astral body lost: ${JSON.stringify(astral)}`);
+  const nsColon = clean('<ns:tag x={["NSCOLONNEEDLE"]}>\n\n## H\n\nnscolonbody\n\n</ns:tag>');
+  assert.ok(!nsColon.some((t) => /NSCOLONNEEDLE|ns:tag/.test(t)), `namespaced-colon tag leaked: ${JSON.stringify(nsColon)}`);
+  assert.ok(nsColon.includes('nscolonbody'), `namespaced-colon body lost: ${JSON.stringify(nsColon)}`);
+
+  // Positional hierarchy — a same-name nested split (`<AoutÉ>…<BinÉ>…</BinÉ>…</AoutÉ>`) pairs by
+  // nesting depth, so both openers' attribute needles are stripped and both bodies survive.
+  const nested = clean('<AoutÉ x={["OUTERN"]}>\n\n## H\n\n<BinÉ y={["INNERN"]}>\n\n### H2\n\ninnerbody\n\n</BinÉ>\n\nmidbody\n\n</AoutÉ>');
+  assert.ok(!nested.some((t) => /OUTERN|INNERN|AoutÉ|BinÉ/.test(t)), `nested residue leaked: ${JSON.stringify(nested)}`);
+  assert.ok(nested.some((t) => t.includes('innerbody')) && nested.some((t) => t.includes('midbody')), `nested bodies lost: ${JSON.stringify(nested)}`);
+});
+
+// EVE round 15 — the exact real-chain counterexamples that survived round 14: a lossy
+// `>`-inside-`{…}` recovery that cut inside the attribute, a same-name inner generic in a
+// component body that the pairing stack mispaired, and a bare `<out/in/const T="x">` generic
+// wrongly emptied by the standalone `hasAttrShape` strip. Each is fed through real structure().
+test('real structure() round-15: lossy-expression recovery, same-name inner generic, bare modifier generics', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // Blocker 1 — the lossy `>` lives INSIDE an `items={[…]}` expression: recovery must find the
+  // real tag end at brace-depth 0, not the `>` hiding in the attribute. A paired chunk-start
+  // opener, a glued chunk-start opener, and a template variant all keep body/suffix, drop needle.
+  const e1p = clean('<Tabs items={["a \\" > LOSSYQUOTEATTRNEEDLE", "c"]}>\n\n## H\n\nbodyE1\n\n</Tabs>');
+  assert.ok(!e1p.some((t) => /LOSSYQUOTEATTRNEEDLE|items=|<Tabs/.test(t)), `lossy-expr paired leaked: ${JSON.stringify(e1p)}`);
+  assert.ok(e1p.includes('bodyE1'), `lossy-expr paired body lost: ${JSON.stringify(e1p)}`);
+  const e1g = clean('prefix <Tabs items={["a \\" > CHUNKSTARTNEEDLE"]}>visbody</Tabs>suf');
+  assert.ok(!e1g.some((t) => /CHUNKSTARTNEEDLE|items=|<Tabs/.test(t)), `lossy-expr glued leaked: ${JSON.stringify(e1g)}`);
+  assert.ok(e1g.some((t) => /prefix/.test(t) && /visbody/.test(t) && /suf/.test(t)), `lossy-expr glued body/suffix lost: ${JSON.stringify(e1g)}`);
+  const e1t = clean('<Tabs items={[`a \\` > TPLLEAKNEEDLE`, `c`]}>\n\n## H\n\nbodyTPL\n\n</Tabs>');
+  assert.ok(!e1t.some((t) => /TPLLEAKNEEDLE|items=|<Tabs/.test(t)), `lossy-expr template leaked: ${JSON.stringify(e1t)}`);
+  assert.ok(e1t.includes('bodyTPL'), `lossy-expr template body lost: ${JSON.stringify(e1t)}`);
+
+  // Blocker 2 — a component body contains a SAME-NAME generic type-argument list
+  // (`factory()\<𐐀Panel, INNER>()`). The pairing stack must not treat `<Name, …>` (a top-level
+  // `,` right after the name = a TS type-arg list) as an opener, or the outer `</Name>` pops the
+  // inner generic and deletes it. The inner needle stays searchable; the outer opener strips.
+  for (const [name, outer, inner] of [
+    ['𐐀Panel', 'OUTERE2', 'INNERGENERIC'],
+    ['$Panel', 'OUTDOLLAR', 'INNERDOLLAR'],
+    ['_Panel', 'OUTUS', 'INNERUS'],
+    ['ns.Qualified', 'OUTNSQ', 'INNERNSQ'],
+  ] as const) {
+    const r = clean(`<${name} x={["${outer}"]}>\n\n## H\n\nfactory()\\<${name}, ${inner}>()\n\n</${name}>`);
+    assert.ok(!r.some((t) => t.includes(outer)), `inner-generic ${name}: outer opener leaked: ${JSON.stringify(r)}`);
+    assert.ok(r.some((t) => t.includes(inner)), `inner-generic ${name}: inner generic wrongly deleted: ${JSON.stringify(r)}`);
+    assert.ok(r.some((t) => t.includes('factory')), `inner-generic ${name}: body prose lost: ${JSON.stringify(r)}`);
+  }
+
+  // Blocker 3 — a bare `<out/in/const T="x">` (no-space attribute form) is a VALID TS
+  // variance/modifier generic, not a component: it must stay searchable even standalone. The
+  // grammatically-identical `<const dataÉ="x">` is likewise kept (a real generic must never be
+  // deleted on speculation), which the round-14 test wrongly asserted the other way.
+  assert.deepEqual(clean('\\<out T="OUTNOSPACE">'), ['<out T="OUTNOSPACE">']);
+  assert.deepEqual(clean('\\<in T="INNOSPACE">'), ['<in T="INNOSPACE">']);
+  assert.deepEqual(clean('\\<const T="CONSTNOSPACE">'), ['<const T="CONSTNOSPACE">']);
+  assert.ok(clean('lead\n\n## H\n\n\\<out T="WHOLEOUTNOSPACE">').some((t) => t.includes('WHOLEOUTNOSPACE')), 'whole-chunk bare out-generic wrongly deleted');
 });
 
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -1042,6 +1042,51 @@ test('real structure() round-29: budget order-independence, opener-local & quote
   assert.ok((await hits(cmt, 'BODYCMT28')) > 0, 'comment-case visible body lost');
 });
 
+// EVE round 30 — the final review's 5 exact real-Orama P1s, made non-skippable:
+// (1) the generic-flow budget must have NO encounter-order bias even for GLUED→GLUED: a leading glued
+//     technical generic must keep (searchable) while the LATER same-name glued real flow claims the lone
+//     closer — pure LIFO nearest-pop, the first opener must not greedily exhaust the budget.
+// (1b) a bare TS instantiation in prose (`type Box<$Panel> holds`) is NOT a residue opener and must not
+//     be counted against a later real same-name flow's closer budget (it would starve and leak the flow).
+// (2) lossyOpenerEnd is OPENER-LOCAL: a CLEAN attributed opener whose honest body carries a `"> ` (with a
+//     space before the quote) or a `"}> ` must NOT be mistaken for a leaked attribute close.
+// (3) the dropped-quote first-segment recovery is regex/comment lexical-safe — a `">` inside a
+//     `pattern={/">/}` regex in the leaked attribute is not the real close; the tag's real `>` is.
+test('real structure() round-30: glued budget LIFO, prose instantiation, opener-local & regex-safe recovery', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r30', data: { title: '/r30', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (1) glued→glued budget order-independence — the leading glued technical generic keeps; the later
+  // glued real flow claims the lone closer (its markup drops); the intro and body survive.
+  const glued = 'Technical <$Panel extends STALEGLUED29>.\n\nprefix<$Panel extends REALGLUED29>INTROKEEP29\n\n## H\n\nBODYKEEP29\n\n</$Panel>';
+  assert.ok((await hits(glued, 'STALEGLUED29')) > 0, 'leading glued generic stole the later flow closer (order bias)');
+  assert.equal(await hits(glued, 'REALGLUED29'), 0, 'later glued real flow markup leaked (budget starved)');
+  assert.ok((await hits(glued, 'INTROKEEP29')) > 0 && (await hits(glued, 'BODYKEEP29')) > 0, 'real flow intro/body lost');
+
+  // (1b) a bare TS instantiation in prose (`type Box<$Panel> holds`) is not a residue opener — the later
+  // real same-name flow still pairs with the lone closer (its markup drops), and the prose token survives.
+  const inst = 'Bare type Box<$Panel> holds.\n\n<$Panel extends REALFLOWATTRX>\n\n## H\n\nBODYX\n\n</$Panel>';
+  assert.equal(await hits(inst, 'REALFLOWATTRX'), 0, 'real flow markup leaked (prose instantiation stole the closer)');
+  assert.ok((await hits(inst, 'Box')) > 0 && (await hits(inst, 'BODYX')) > 0, 'prose instantiation token or flow body lost');
+
+  // (2) opener-local — a CLEAN attributed opener whose honest body carries a `"> ` (space before the
+  // quote) or a `"}> ` must survive; neither is a leaked attribute close.
+  const spaced = '<$Panel a="1" >LEFTWSDQ29 text "> RIGHTWSDQ29\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(spaced, 'LEFTWSDQ29')) > 0 && (await hits(spaced, 'RIGHTWSDQ29')) > 0, 'honest body `"> ` mistaken for a leaked close');
+  const brace = '<$Panel a="1">LEFTBRACE29 text "}> RIGHTBRACE29\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(brace, 'LEFTBRACE29')) > 0 && (await hits(brace, 'RIGHTBRACE29')) > 0, 'honest body `"}> ` mistaken for a leaked bracket close');
+
+  // (3) dropped-quote first-segment recovery is regex-safe — a `">` inside a `pattern={/">/}` regex is not
+  // the real close; the leaked attribute and the regex body never index, the tag's real `>` ends it.
+  const reg = '<$Panel title="a \\" > LEAKQ29" pattern={/">/.test(REGQ29)}>BODYQ29</$Panel>';
+  assert.equal(await hits(reg, 'LEAKQ29'), 0, 'dropped-quote leaked attribute survived');
+  assert.equal(await hits(reg, 'REGQ29'), 0, 'regex body content leaked (matched the fake `">`)');
+  assert.ok((await hits(reg, 'BODYQ29')) > 0, 'regex-case visible body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -1087,6 +1087,52 @@ test('real structure() round-30: glued budget LIFO, prose instantiation, opener-
   assert.ok((await hits(reg, 'BODYQ29')) > 0, 'regex-case visible body lost');
 });
 
+test('real structure() round-31: opener-provable roles only — no chunk-end/body-first-char guessing, recovery gated on opener lossiness', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r31', data: { title: '/r31', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+
+  // (A) A glued technical generic whose `>` lands at the CHUNK END (`type Box<$Panel>` on its own line, nothing
+  // after the `>`) is prose, not a residue: its token survives AND — critically — it must not be counted as an
+  // opener that claims the lone same-name closer. The old code auto-realed any glued opener sitting at chunk end,
+  // so the later real `<$Panel …>` flow lost the closer and leaked its markup. Grammar (operand-position parse)
+  // now decides the role. RED on old head: `REALCLOSE` markup leaked; GREEN now.
+  const gen = 'type Box<$Panel>\n\nGENTOK\n\n<$Panel extends REALCLOSE>\n\n## H\n\nBODYEND\n\n</$Panel>';
+  assert.ok((await hits(gen, 'GENTOK')) > 0, 'chunk-end technical generic token dropped');
+  assert.equal(await hits(gen, 'REALCLOSE'), 0, 'real flow markup leaked (chunk-end generic stole the closer)');
+  assert.ok((await hits(gen, 'BODYEND')) > 0, 'real flow body lost');
+
+  // (A2/A3/A4) A real flow opener whose body starts with whitespace / a digit / punctuation must still drop
+  // its markup — the old code auto-realed an opener when its body-first char was outside a whitelist, guessing
+  // the role from the first content byte. Grammar-only: these are genuine flow residues, markup drops, body keeps.
+  const space = '<FLOWSPACE30 a="1">   visible space intro\n\n## H\n\nbody-space\n\n</FLOWSPACE30>';
+  assert.equal(await hits(space, 'FLOWSPACE30'), 0, 'whitespace-intro flow markup leaked');
+  assert.ok((await hits(space, 'visible')) > 0 && (await hits(space, 'body-space')) > 0, 'whitespace-intro flow content lost');
+  const digit = '<FLOWDIGIT30 a="1">7 visible digit intro\n\n## H\n\nbody-digit\n\n</FLOWDIGIT30>';
+  assert.equal(await hits(digit, 'FLOWDIGIT30'), 0, 'digit-intro flow markup leaked');
+  assert.ok((await hits(digit, 'visible')) > 0 && (await hits(digit, 'body-digit')) > 0, 'digit-intro flow content lost');
+  const punct = '<FLOWPUNCT30 a="1">! visible punct intro\n\n## H\n\nbody-punct\n\n</FLOWPUNCT30>';
+  assert.equal(await hits(punct, 'FLOWPUNCT30'), 0, 'punct-intro flow markup leaked');
+  assert.ok((await hits(punct, 'visible')) > 0 && (await hits(punct, 'body-punct')) > 0, 'punct-intro flow content lost');
+
+  // (B) A CLEAN attributed opener with a legitimate trailing space before its `>` (`a="1" >`) is not lossy —
+  // quote recovery must not scan its visible body. Both single- and double-quoted forms keep their body tokens.
+  const dq = '<$Panel a="1" >LEFTTRAIL30 body RIGHTTRAIL30\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(dq, 'LEFTTRAIL30')) > 0 && (await hits(dq, 'RIGHTTRAIL30')) > 0, 'clean trailing-space (double-quote) body scanned as leaked');
+  const sq = "<$Panel a='1' >LEFTTRAILSQ body RIGHTTRAILSQ\n\n## H\n\ntail\n\n</$Panel>";
+  assert.ok((await hits(sq, 'LEFTTRAILSQ')) > 0 && (await hits(sq, 'RIGHTTRAILSQ')) > 0, 'clean trailing-space (single-quote) body scanned as leaked');
+
+  // (C) A CLEAN expression attribute (`b={x}`) is not lossy — bracket recovery must not fire on it. The old
+  // code, on seeing a later `"}> ` / `]> ` sequence in the visible body, treated the whole opener as a leaked
+  // bracket attribute and swallowed everything up to that body `>`, dropping the intro. RED on old head:
+  // `EATBR` intro eaten; GREEN now (recovery only fires when the opener itself is bracket-desynced).
+  const expr = '<$Panel b={x}>EATBR arr "}> AFTERBR text\n\n## H\n\ntail\n\n</$Panel>';
+  assert.ok((await hits(expr, 'EATBR')) > 0, 'clean expression-attr intro eaten by spurious bracket recovery');
+  assert.ok((await hits(expr, 'AFTERBR')) > 0, 'clean expression-attr trailing body lost');
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -540,6 +540,58 @@ test('real structure() round-17: glued custom-name pairing, glued inline bracket
   assert.ok(tsw.some((t) => /visbody/.test(t) && /suf/.test(t)), `template-swallow body/suffix swallowed: ${JSON.stringify(tsw)}`);
 });
 
+// EVE round 18 — three residual P1s the round-17 closer-anchor recovery introduced or missed:
+//  P1 — the round-17 anchor (last `>` before the in-chunk closer) ran UNCONDITIONALLY on every glued
+//       opener, on the false premise that a component's visible body carries no tag punctuation. A
+//       legal `<Panel>LEFT > RIGHT</Panel>` (comparison, code span, entity, or a nested inline tag)
+//       lost everything before the last body `>`. The anchor must fire ONLY on a CONFIRMED-DESYNC
+//       opener: scanTag never closed, or the region between its `>` and the closer is unbalanced.
+//  P1 — the anchor's closer search ran on RAW text with a plain `</Name>`, so a custom name structure()
+//       escapes per-char (`</\_Panel>`) was never found and the lossy `_`/`$`/astral/namespaced ×
+//       bracket-pollution cross matrix leaked/​swallowed. The closer regex must tolerate the escaping.
+//  P1 — `inBodyGeneric`'s own-closer probe matched a `</Name>` INSIDE a `` `…` `` code span, so a glued
+//       in-body generic (`factory()<$Panel<INNER594>>()` next to `` `</$Panel>` ``) looked like a real
+//       inline component, entered the stack, and stole the outer real closer. The probe must skip code.
+test('real structure() round-18: desync-gated anchor, custom-name × bracket matrix, code-span fake closer', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // P1 #1 — a glued component whose visible body legitimately contains tag punctuation keeps ALL of it.
+  const gt = clean('prefix<Panel>LEFT594 > RIGHT594</Panel>SUF594');
+  assert.ok(gt.some((t) => /LEFT594/.test(t) && /RIGHT594/.test(t) && /SUF594/.test(t)), `body-gt lost: ${JSON.stringify(gt)}`);
+  const nested = clean('prefix<Panel><Inner>INNER594</Inner>OUTER594</Panel>SUF594');
+  assert.ok(nested.some((t) => /INNER594/.test(t) && /OUTER594/.test(t) && /SUF594/.test(t)), `nested lost: ${JSON.stringify(nested)}`);
+  assert.ok(!nested.some((t) => /<\/?(Panel|Inner)/.test(t)), `nested markup leaked: ${JSON.stringify(nested)}`);
+  const cs = clean('prefix<Panel>`x > y`594 KEEP594</Panel>SUF594');
+  assert.ok(cs.some((t) => /KEEP594/.test(t) && /SUF594/.test(t)) && !cs.some((t) => /<Panel>/.test(t)), `codespan-body lost: ${JSON.stringify(cs)}`);
+
+  // P1 #2 — custom name × bracket pollution, both directions, must not leak (closes-heavy) or swallow
+  // (opens-heavy). Exercises the escape-tolerant closer search that plain `</Name>` missed.
+  for (const name of ['$Panel', '_Panel', '𐐀Panel', 'ns.Qualified'] as const) {
+    const tag = name.replace('.', '');
+    const opener = `<${name}`;
+    for (const b of ['}]', ']}']) {
+      const r = clean(`prefix<${name} items={["a \\" ${b} > L${tag}ATTR", "c"]}>B${tag}VIS</${name}>S${tag}SUF`).join(' ');
+      assert.ok(!r.includes(`L${tag}ATTR`) && !r.includes('items=') && !r.includes(opener), `${name} ${b} leaked: ${JSON.stringify(r)}`);
+      assert.ok(r.includes(`B${tag}VIS`) && r.includes(`S${tag}SUF`), `${name} ${b} body/suffix lost: ${JSON.stringify(r)}`);
+    }
+    for (const b of ['{ [', '[[']) {
+      const r = clean(`prefix<${name} items={["a \\" ${b} x", "c"]}>B${tag}SW</${name}>S${tag}SW`).join(' ');
+      assert.ok(!r.includes('items=') && !r.includes(opener), `${name} ${b} residue leaked: ${JSON.stringify(r)}`);
+      assert.ok(r.includes(`B${tag}SW`) && r.includes(`S${tag}SW`), `${name} ${b} body/suffix swallowed: ${JSON.stringify(r)}`);
+    }
+  }
+
+  // P1 #3 — a same-name generic glued in the body, with a code-span fake closer `` `</$Panel>` `` in
+  // the SAME chunk, must not disturb pairing: the outer real closer pairs with the outer opener, and
+  // the in-body nested generic's text survives.
+  const p3 = clean('<$Panel x={["OUT594"]}>\n\n## H\n\nfactory()<$Panel<INNER594>>() and `</$Panel>`\n\n</$Panel>');
+  assert.ok(p3.some((t) => /INNER594/.test(t)), `p3 nested generic text lost: ${JSON.stringify(p3)}`);
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { structure } from 'fumadocs-core/mdx-plugins/remark-structure';
 import { initAdvancedSearch } from 'fumadocs-core/search/server';
 import { oramaStaticClient } from 'fumadocs-core/search/client/orama-static';
-import { buildIndex, sanitizeSearchText, pairResidues } from './search-index';
+import { buildIndex, sanitizeSearchText, pairResidues, encodeEscapedQuotes } from './search-index';
 
 // Unit: the sanitizer strips markdown/entity artifacts WITHOUT mangling
 // technical identifiers. The old regex stack turned `MACARON_CODEX_TRANSPORT`
@@ -61,7 +61,7 @@ test('sanitizeSearchText strips markup but preserves identifiers', () => {
 // emits such a residue; the guarantee is that no needle-adjacent markup survives.
 test('real structure() split chunks: residue never leaks, prose survives', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -100,7 +100,7 @@ test('real structure() split chunks: residue never leaks, prose survives', () =>
 // chunks, plus boundary fidelity the earlier rounds missed.
 test('real structure() split chunks: escaped quotes, generic defaults, OOB entities', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -270,7 +270,7 @@ test('real structure() split chunks: escaped quotes, generic defaults, OOB entit
 // page-wide paired-position set, exactly as buildIndex does.
 test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keywords, own-line >', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -334,7 +334,7 @@ test('real structure() cross-chunk closer pairing: lossy openers, ambiguous keyw
 // code point (astral + namespaced), and the whole-chunk `standalone` tie-break is gone.
 test('real structure() positional pairing: lossy > recovery, code-span closers, prose generics, astral names', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -385,7 +385,7 @@ test('real structure() positional pairing: lossy > recovery, code-span closers, 
 // wrongly emptied by the standalone `hasAttrShape` strip. Each is fed through real structure().
 test('real structure() round-15: lossy-expression recovery, same-name inner generic, bare modifier generics', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -442,7 +442,7 @@ test('real structure() round-15: lossy-expression recovery, same-name inner gene
 //       corrupted attribute hides such a `}]` is stripped whole, not cut at scanTag's false `>`.
 test('real structure() round-16: syntactic-role pairing exemption, string-aware lossy recovery', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -499,7 +499,7 @@ test('real structure() round-16: syntactic-role pairing exemption, string-aware 
 //       directions and keeps the visible body/suffix.
 test('real structure() round-17: glued custom-name pairing, glued inline bracket matrix', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -556,7 +556,7 @@ test('real structure() round-17: glued custom-name pairing, glued inline bracket
 //       inline component, entered the stack, and stole the outer real closer. The probe must skip code.
 test('real structure() round-18: desync-gated anchor, custom-name × bracket matrix, code-span fake closer', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -615,7 +615,7 @@ test('real structure() round-18: desync-gated anchor, custom-name × bracket mat
 //       unterminated run is literal, not a fence) shared by every code-span skip.
 test('real structure() round-19: opener-local desync, hierarchy attribution, CommonMark code spans', () => {
   const clean = (raw: string) => {
-    const chunks = structure(raw).contents.map((c) => c.content);
+    const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content);
     const paired = pairResidues(chunks);
     return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
   };
@@ -654,11 +654,11 @@ test('real structure() round-19: opener-local desync, hierarchy attribution, Com
 // recovery (honest body kept, lossy attribute dropped) — the exact reproductions from EVE's review.
 test('real structure() round-21: hierarchy-decided generics, opener-local recovery, code-span parity', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r21', data: { title: '/r21', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r21', data: { title: '/r21', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
-  const clean = (raw: string) => { const chunks = structure(raw).contents.map((c) => c.content); const paired = pairResidues(chunks); return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired)); };
+  const clean = (raw: string) => { const chunks = structure(encodeEscapedQuotes(raw)).contents.map((c) => c.content); const paired = pairResidues(chunks); return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired)); };
 
   // P1 #1a — a same-name generic PRECEDING a real same-name inline, in live prose (NOT a code span, so
   // pairResidues actually sees it). Hierarchy must keep the generic: positional nearest-pop hands the
@@ -703,7 +703,7 @@ test('real structure() round-21: hierarchy-decided generics, opener-local recove
 // chunk stream. These drive the real structure() → buildIndex() → Orama chain with EVE's exact reals.
 test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flow, balanced-lossy contract', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r22', data: { title: '/r22', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r22', data: { title: '/r22', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -749,7 +749,7 @@ test('real structure() round-22: outer/generic/inline hierarchy, cross-chunk flo
 // the real structure() → buildIndex() → Orama chain with EVE's exact reals from the round-22 review.
 test('real structure() round-23: whole-chunk/compact generics, intro/nested flow, single-close recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r23', data: { title: '/r23', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r23', data: { title: '/r23', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -789,7 +789,7 @@ test('real structure() round-23: whole-chunk/compact generics, intro/nested flow
 // Each case drives the real structure() → buildIndex() → Orama chain with EVE's exact round-23 reals.
 test('real structure() round-24: bidirectional generic classification, opener-local strip boundary', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r24', data: { title: '/r24', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r24', data: { title: '/r24', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -826,7 +826,7 @@ test('real structure() round-24: bidirectional generic classification, opener-lo
 // never a whole-chunk scan), and the `()` desync no longer misjudges JS lexical contexts (regex, comment).
 test('real structure() round-25: real-hierarchy pairing, opener-local lossy boundary, lexical-safe desync', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r25', data: { title: '/r25', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r25', data: { title: '/r25', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -872,7 +872,7 @@ test('real structure() round-25: real-hierarchy pairing, opener-local lossy boun
 // regex `/[}>]/` or comment `/* } > */` inside an honest `{…}` attribute is lexed, not miscounted.
 test('real structure() round-26: hierarchy role, opener-local lossy boundary, lexical-safe scan', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r26', data: { title: '/r26', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r26', data: { title: '/r26', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -918,7 +918,7 @@ test('real structure() round-26: hierarchy role, opener-local lossy boundary, le
 // that must not be mistaken for a quote leak.
 test('real structure() round-27: unified lexical-safe opener boundary across lossy shapes', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r27', data: { title: '/r27', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r27', data: { title: '/r27', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -950,7 +950,7 @@ test('real structure() round-27: unified lexical-safe opener boundary across los
 // (4) `/` after a `}` object-literal operand is division, not a regex.
 test('real structure() round-28: lexical-safe opener span, unified LIFO pairing, division after }', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r28', data: { title: '/r28', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r28', data: { title: '/r28', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1004,7 +1004,7 @@ test('real structure() round-28: lexical-safe opener span, unified LIFO pairing,
 //     in the leaked attribute is not a real boundary.
 test('real structure() round-29: budget order-independence, opener-local & quote-consistent lossy recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r29', data: { title: '/r29', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r29', data: { title: '/r29', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1054,7 +1054,7 @@ test('real structure() round-29: budget order-independence, opener-local & quote
 //     `pattern={/">/}` regex in the leaked attribute is not the real close; the tag's real `>` is.
 test('real structure() round-30: glued budget LIFO, prose instantiation, opener-local & regex-safe recovery', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r30', data: { title: '/r30', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r30', data: { title: '/r30', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1089,7 +1089,7 @@ test('real structure() round-30: glued budget LIFO, prose instantiation, opener-
 
 test('real structure() round-31: opener-provable roles only — no chunk-end/body-first-char guessing, recovery gated on opener lossiness', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r31', data: { title: '/r31', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r31', data: { title: '/r31', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1135,7 +1135,7 @@ test('real structure() round-31: opener-provable roles only — no chunk-end/bod
 
 test('real structure() round-32: JSX boolean props are not TS prose, quota counts consistently, recovery is fully opener-local', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r32', data: { title: '/r32', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r32', data: { title: '/r32', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1175,7 +1175,7 @@ test('real structure() round-32: JSX boolean props are not TS prose, quota count
 
 test('real structure() round-33: per-closer-interval quota, opener-local expression/bracket recovery, lexical-safe desync', async () => {
   const oramaFor = async (raw: string) => {
-    const index = await buildIndex({ url: '/r33', data: { title: '/r33', description: undefined, structuredData: structure(raw) } } as Parameters<typeof buildIndex>[0]);
+    const index = await buildIndex({ url: '/r33', data: { title: '/r33', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
     return initAdvancedSearch({ language: 'english', indexes: [index] });
   };
   const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
@@ -1208,6 +1208,50 @@ test('real structure() round-33: per-closer-interval quota, opener-local express
   assert.ok((await hits(cmt, 'RIGHTCMT32')) > 0, 'clean comment-attr trailing body lost');
 });
 
+test('real structure() round-34: sentinel-encoded escaped quotes distinguish leak from legit trailing-space attr', async () => {
+  const oramaFor = async (raw: string) => {
+    const index = await buildIndex({ url: '/r34', data: { title: '/r34', description: undefined, getText: async () => raw } } as unknown as Parameters<typeof buildIndex>[0]);
+    return initAdvancedSearch({ language: 'english', indexes: [index] });
+  };
+  const hits = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).length;
+  const summaries = async (raw: string, q: string) => (await (await oramaFor(raw)).search(q)).map((r) => r.content ?? '');
+
+  // The unresolvable P1-4 case, now split by encodeEscapedQuotes running BEFORE structure(): the escaped
+  // quote becomes a sentinel so the leaked string stays balanced, scanTag lands on the REAL `>`, and the
+  // whole opener (needle and all) is stripped — while the LEGIT trailing-space attribute (no backslash)
+  // keeps its close-quote and its body survives. Both single- and double-quote leaks; both directions.
+  const dq = '<$Panel title="a \\" > DQLEAK34">LEFTDQ34 body\n\n## H\n\nRIGHTDQ34\n\n</$Panel>';
+  assert.equal(await hits(dq, 'DQLEAK34'), 0, 'double-quote dropped-quote leak survived (needle entered index)');
+  assert.ok((await hits(dq, 'LEFTDQ34')) > 0, 'double-quote leak: opener intro body lost');
+  assert.ok((await hits(dq, 'RIGHTDQ34')) > 0, 'double-quote leak: trailing body lost');
+
+  const sq = "<$Panel title='a \\' > SQLEAK34'>LEFTSQ34 body\n\n## H\n\nRIGHTSQ34\n\n</$Panel>";
+  assert.equal(await hits(sq, 'SQLEAK34'), 0, 'single-quote dropped-quote leak survived (needle entered index)');
+  assert.ok((await hits(sq, 'LEFTSQ34')) > 0, 'single-quote leak: opener intro body lost');
+  assert.ok((await hits(sq, 'RIGHTSQ34')) > 0, 'single-quote leak: trailing body lost');
+
+  // Legit attribute VALUE ending in a literal space — byte-identical to the leak BEFORE encoding, now
+  // distinct (no backslash → no sentinel → the real close-quote stands). The intro carries a body `">`
+  // so the OLD quote-leak recovery branch over-recovered and ate the intro (`LEFTLEGIT*34`) — RED on old
+  // head. The body's own `">` must survive too. Both quote styles.
+  const legitD = '<$Panel a="1 " >LEFTLEGITD34 text "> RIGHTLEGITD34\n\n## H\n\nt\n\n</$Panel>';
+  assert.ok((await hits(legitD, 'LEFTLEGITD34')) > 0, 'legit double-quote trailing-space attr: intro body wrongly stripped');
+  assert.ok((await hits(legitD, 'RIGHTLEGITD34')) > 0, 'legit double-quote trailing-space attr: trailing body lost');
+  const legitS = "<$Panel a='1 ' >LEFTLEGITS34 text '> RIGHTLEGITS34\n\n## H\n\nt\n\n</$Panel>";
+  assert.ok((await hits(legitS, 'LEFTLEGITS34')) > 0, 'legit single-quote trailing-space attr: intro body wrongly stripped');
+  assert.ok((await hits(legitS, 'RIGHTLEGITS34')) > 0, 'legit single-quote trailing-space attr: trailing body lost');
+
+  // A legit prose quote (`\"…\"`) must round-trip through the sentinel unchanged, and NO sentinel code
+  // point (U+E000/U+E001) may ever appear in a served summary.
+  const prose = 'prefix a \\"quoted phrase\\" QUOTEPROSE34 tail';
+  const proseHits = (await summaries(prose, 'QUOTEPROSE34')).filter((r) => r.includes('QUOTEPROSE34'));
+  assert.ok(proseHits.length > 0, 'legit prose quote sample produced no content hit');
+  for (const r of proseHits) {
+    assert.ok(!/[]/.test(r), `sentinel code point leaked into the index: ${JSON.stringify(r.slice(0, 60))}`);
+    assert.ok(r.includes('"quoted phrase"'), `legit prose quote lost its characters: ${JSON.stringify(r.slice(0, 60))}`);
+  }
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {
@@ -1226,11 +1270,11 @@ function mdxFiles(dir: string): string[] {
 // directly. This exercises the real sanitizer→Orama wiring, not just the string.
 async function productionSearch() {
   const pages = mdxFiles(DOCS_DIR).map((file) => {
-    const structuredData = structure(readFileSync(file, 'utf8'));
+    const raw = readFileSync(file, 'utf8');
     const url = '/' + path.relative(DOCS_DIR, file).replace(/\.mdx$/, '');
-    return { url, data: { title: url, description: undefined, structuredData } };
+    return { url, data: { title: url, description: undefined, getText: async () => raw } };
   });
-  const indexes = await Promise.all(pages.map((p) => buildIndex(p as Parameters<typeof buildIndex>[0])));
+  const indexes = await Promise.all(pages.map((p) => buildIndex(p as unknown as Parameters<typeof buildIndex>[0])));
   return initAdvancedSearch({ language: 'english', indexes });
 }
 

--- a/site/app/lib/search-index.test.ts
+++ b/site/app/lib/search-index.test.ts
@@ -429,6 +429,59 @@ test('real structure() round-15: lossy-expression recovery, same-name inner gene
   assert.ok(clean('lead\n\n## H\n\n\\<out T="WHOLEOUTNOSPACE">').some((t) => t.includes('WHOLEOUTNOSPACE')), 'whole-chunk bare out-generic wrongly deleted');
 });
 
+// EVE round 16 — the pairing exemption and the lossy `>`-recovery must key on SYNTACTIC ROLE, not
+// on a name-comma special case. Two real-chain P1s:
+//  G1 — any same-name TS construct GLUED inside a component's body (a bare type argument
+//       `seed()\<Name>()`, a constrained generic `\<Name extends …>`, a comparison `a\<Name`, a
+//       nested first-param `\<Name\<U>>`) must NOT enter the pairing stack, or the outer `</Name>`
+//       pops the in-body generic instead of the real opener → the generic is deleted and the outer
+//       markup leaks. The round-15 fix only exempted a name-followed-by-comma (`<Name, U>`).
+//  G2 — the lossy `>`-recovery brace/bracket depth must ignore brackets inside the corrupted
+//       attribute string: a string-internal `}]` must not drop depth to 0 at a `>` still inside the
+//       attribute (attribute residue would leak as fake suffix). A cross-chunk paired opener whose
+//       corrupted attribute hides such a `}]` is stripped whole, not cut at scanTag's false `>`.
+test('real structure() round-16: syntactic-role pairing exemption, string-aware lossy recovery', () => {
+  const clean = (raw: string) => {
+    const chunks = structure(raw).contents.map((c) => c.content);
+    const paired = pairResidues(chunks);
+    return chunks.map((c, ci) => sanitizeSearchText(c, ci, paired));
+  };
+
+  // G1 — every same-name in-body generic role, across the names structure() can't consume so it
+  // emits opener/closer residue (`$Panel`, `_Panel`, astral `𐐀Panel`). The inner needle stays
+  // searchable, the outer opener attribute (`OUT`) never leaks, and the body prose survives.
+  for (const name of ['$Panel', '_Panel', '𐐀Panel'] as const) {
+    const forms = [
+      { role: 'bare', body: `seed${name}NEEDLE()\\<${name}>()`, needle: `seed${name}NEEDLE` },
+      { role: 'constrained', body: `seed()\\<${name} extends ${name}CONSTR>()`, needle: `${name}CONSTR` },
+      { role: 'comparison', body: `if (${name}COMP\\<${name}) run()`, needle: `${name}COMP` },
+      { role: 'nested-first-param', body: `seed()\\<${name}\\<${name}NEST>>()`, needle: `${name}NEST` },
+    ];
+    for (const { role, body, needle } of forms) {
+      const r = clean(`<${name} x={["OUT${name}"]}>\n\n## H\n\n${body}\n\n</${name}>`);
+      assert.ok(r.some((t) => t.includes(needle)), `${role} ${name}: in-body generic wrongly deleted: ${JSON.stringify(r)}`);
+      assert.ok(!r.some((t) => t.includes(`OUT${name}`)), `${role} ${name}: outer opener attribute leaked: ${JSON.stringify(r)}`);
+    }
+  }
+
+  // A real inline component GLUED to prose in ONE chunk (`prefix<Panel …>body</Panel>suffix`) still
+  // pairs and strips — its own closer sits in the same chunk, so it is not mistaken for an in-body
+  // generic. Its lossy attribute (dropped `\` on the escaped quote) must not leak.
+  const inline = clean('prefix<Panel title="a \\" INLINELEAK">inlinebody</Panel>suffix');
+  assert.ok(!inline.some((t) => /INLINELEAK|title=|<Panel/.test(t)), `inline component leaked: ${JSON.stringify(inline)}`);
+  assert.ok(inline.some((t) => /prefix/.test(t) && /inlinebody/.test(t) && /suffix/.test(t)), `inline component body/suffix lost: ${JSON.stringify(inline)}`);
+
+  // G2 — a cross-chunk paired opener whose corrupted `items={[…]}` attribute hides a string-internal
+  // `}]` (which naively drops scanTag's depth to 0 at a `>` still inside the string). The whole
+  // opener chunk is stripped, so no attribute residue (`STRLEAK`) leaks as fake suffix; body survives.
+  const g2q = clean('<$Panel items={["a \\" }] > STRLEAK"]}>\n\n## H\n\nbodyG2q\n\n</$Panel>');
+  assert.ok(!g2q.some((t) => /STRLEAK|items=|<\$Panel/.test(t)), `G2 quote residue leaked: ${JSON.stringify(g2q)}`);
+  assert.ok(g2q.includes('bodyG2q'), `G2 quote body lost: ${JSON.stringify(g2q)}`);
+  const g2t = clean('<$Panel a={`x \\` }] > TPLLEAK`}>\n\n## H\n\nbodyG2t\n\n</$Panel>');
+  assert.ok(!g2t.some((t) => /TPLLEAK|a={|<\$Panel/.test(t)), `G2 template residue leaked: ${JSON.stringify(g2t)}`);
+  assert.ok(g2t.includes('bodyG2t'), `G2 template body lost: ${JSON.stringify(g2t)}`);
+});
+
 const DOCS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../content/docs');
 
 function mdxFiles(dir: string): string[] {

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -147,11 +147,13 @@ export function pairResidues(chunks: string[]): Set<string> {
       // a type-argument (`factory()\<Name>()`), a constrained generic (`\<Name extends …>`), a
       // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
       // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
-      // generic and leaking the outer markup. Skip a glued ESCAPED tag UNLESS its own matching
-      // closer sits later in THIS chunk — a real inline component (`prefix\<Panel …>b</Panel>suffix`)
+      // generic and leaking the outer markup. Skip a glued ESCAPED OPENER UNLESS its own matching
+      // closer sits later in THIS chunk — a real inline component (`prefix\<Panel …>b\</Panel>suffix`)
       // carries its closer in-chunk, but an in-body generic never does (its `</Name>` is elsewhere).
+      // A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` whose
+      // suffix has no further closer would be skipped and its opener never pops).
       const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-      const inBodyGeneric = glued && tag.esc && !new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(text.slice(tag.closed ? tag.end : tag.nameEnd));
+      const inBodyGeneric = glued && tag.esc && !tag.closing && !new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(deEscape(text.slice(tag.closed ? tag.end : tag.nameEnd)));
       if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
@@ -195,19 +197,31 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // still inside the attribute string, so scanTag's `>` position is untrustworthy: the whole chunk
     // is markup, strip it to end. (When the closer is in THIS chunk the tag is a self-contained
     // inline element — `\<Tabs …> body </Tabs>` — so fall through to keep its body.)
-    const closerInChunk = new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(text.slice(k));
+    const closerRe = new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`);
+    const closerInChunk = closerRe.test(text.slice(k));
+    const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` anywhere past the name (whole-text, not scanTag's k)
     if (isPaired && !glued && !closing && !selfClose && !closerInChunk) { i = text.length; out = out.trimEnd(); continue; }
-    // Lossy `>`-recovery: structure() can drop the escaping backslash of a quote/template
-    // inside an opener's attribute, so scanTag's quote tracking desyncs and never sees the
-    // real closing `>` (closed=false, body swallows the element's own text + suffix). Recover
-    // by cutting at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name — the
-    // brace/bracket escapes survive the lossy collapse even when the quotes do not, so a `>`
-    // hiding inside `items={["a > b"]}` is skipped and the real tag end is found. Run recovery
-    // ONLY for a GLUED or non-escaped opener — there recovery preserves genuine in-chunk suffix.
-    // A STANDALONE escaped lossy opener has no real suffix in its own chunk: the desynced quotes
-    // mean the hunt can stop at a `>` still inside the corrupted attribute string and expose fake
-    // suffix (`items={["a }] > LEAK"]}>` → `LEAK"]}>`), so leave it unclosed and let the escaped
-    // strip-to-end branch below drop the whole residue.
+    // Lossy `>`-recovery for a GLUED opener that has its matching `</Name>` LATER IN THIS CHUNK.
+    // structure() can drop the escaping backslash of a quote/template inside an opener's attribute,
+    // desyncing scanTag's quote tracking. structure() markdown-escapes EVERY opening bracket (`\{`,
+    // `\[`) — structural AND string-content alike — but leaves closes bare, so a brace/bracket-depth
+    // scan is fooled by unbalanced brackets inside the corrupted attribute STRING: `items={["a }] > x"]}>`
+    // under-counts and scanTag cuts EARLY at the string-internal `>` (attr residue leaks as fake suffix),
+    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed). A lossy
+    // escaped backtick can even desync the code-span skip so pairing misses the opener entirely. The
+    // in-chunk `</Name>` is escape-free and a reliable anchor: the opener's real `>` is the LAST `>`
+    // before that closer (the visible body carries no tag punctuation). Re-anchor there — overriding
+    // scanTag's `>`, which may be the fake one — and keep the in-chunk body/suffix. Depends only on the
+    // closer's presence, not on pairing, so it survives the code-span desync too.
+    if (glued && !closing && !selfClose && closerAfter !== -1) {
+      const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
+      if (gt > tag.nameEnd) { k = gt + 1; closed = true; }
+    }
+    // Fallback brace/bracket-depth recovery for a GLUED or non-escaped opener with no in-chunk closer
+    // to anchor on — cut at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name. A
+    // STANDALONE escaped lossy opener has no real suffix in its own chunk (the desynced quotes let the
+    // hunt stop at a `>` still inside the corrupted attribute string and expose fake suffix), so leave
+    // it unclosed and let the escaped strip-to-end branch drop it.
     if (!closed && (!esc || glued)) {
       let depth = 0;
       for (let m = tag.nameEnd; m < text.length; m++) {

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -138,7 +138,7 @@ export function pairResidues(chunks: string[]): Set<string> {
   chunks.forEach((text, ci) => {
     let i = 0;
     while (i < text.length) {
-      if (text[i] === '`') { let f = 0; while (text[i + f] === '`') f++; const e = text.indexOf(text.slice(i, i + f), i + f); i = e === -1 ? text.length : e + f; continue; }
+      if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
       const tag = scanTag(text, i);
       if (!tag) { i++; continue; }
       // Only a STANDALONE residue opener enters the pairing stack. structure() emits a flow
@@ -147,13 +147,19 @@ export function pairResidues(chunks: string[]): Set<string> {
       // a type-argument (`factory()\<Name>()`), a constrained generic (`\<Name extends …>`), a
       // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
       // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
-      // generic and leaking the outer markup. Skip a glued ESCAPED OPENER UNLESS its own matching
-      // closer sits later in THIS chunk — a real inline component (`prefix\<Panel …>b\</Panel>suffix`)
-      // carries its closer in-chunk, but an in-body generic never does (its `</Name>` is elsewhere).
-      // A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` whose
-      // suffix has no further closer would be skipped and its opener never pops).
+      // generic and leaking the outer markup. A glued escaped opener is an IN-BODY GENERIC — never
+      // stacked — when EITHER its own tag body carries a nested `<` type-argument (`\<Name\<U>>`, the
+      // unambiguous generic tell that survives even when a real same-name inline component follows it
+      // LATER in the chunk), OR it has no matching closer anywhere later in this chunk (a bare generic
+      // `factory()\<Name>()` whose `</Name>` lives elsewhere). A real glued inline component
+      // (`prefix\<Panel …>b\</Panel>suffix`) has no nested `<` and carries its closer in-chunk, so it
+      // still stacks. The closer probe is CommonMark code-span aware (`outsideCode`) so a `` `</Name>` ``
+      // literal can't masquerade as the opener's own closer. A CLOSING tag is never a generic, so it
+      // must always pair (else a glued `\</$Panel>` whose suffix has no further closer never pops).
       const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-      const inBodyGeneric = glued && tag.esc && !tag.closing && !rawCloserRe(tag.name).test(outsideCode(text.slice(tag.closed ? tag.end : tag.nameEnd)));
+      const tagBody = text.slice(tag.nameEnd, tag.closed ? tag.end - 1 : tag.end);
+      const nestedArg = /\\?</.test(tagBody); // a `<` inside the opener's own tag body → type-argument, a generic
+      const inBodyGeneric = glued && tag.esc && !tag.closing && (nestedArg || !rawCloserRe(tag.name).test(outsideCode(text.slice(tag.closed ? tag.end : tag.nameEnd))));
       if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
@@ -169,14 +175,13 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
   let i = 0;
   while (i < text.length) {
     const c = text[i];
-    // A code span is verbatim: copy `…` runs (matching the opening fence length)
-    // untouched so a `<version>` or `<T>` generic inside code is never scanned.
+    // A code span is verbatim: copy the whole `…` run (CommonMark-correct fence — exact-length
+    // close, escaped `` \` `` is literal not a fence) untouched so a `<version>` or `<T>` generic
+    // inside code is never scanned. A lone escaped/unterminated backtick is NOT a span, so it
+    // falls through as an ordinary character and the real tag after it is still processed.
     if (c === '`') {
-      let f = 0; while (text[i + f] === '`') f++;
-      const fence = text.slice(i, i + f);
-      const end = text.indexOf(fence, i + f);
-      const stop = end === -1 ? text.length : end + f;
-      out += text.slice(i, stop); i = stop; continue;
+      const stop = codeSpanEnd(text, i);
+      if (stop !== -1) { out += text.slice(i, stop); i = stop; continue; }
     }
     // Fragment boundaries `<>` / `</>` (possibly escaped `\<>`): pure markup, drop.
     const frag = /^\\?<\/?>/.exec(text.slice(i));
@@ -207,15 +212,21 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // `\[`) — structural AND string-content alike — but leaves closes bare, so a brace/bracket-depth
     // scan is fooled by unbalanced brackets inside the corrupted attribute STRING: `items={["a }] > x"]}>`
     // under-counts and scanTag cuts EARLY at the string-internal `>` (attr residue leaks as fake suffix),
-    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed).
-    // Re-anchor the real `>` to the LAST `>` before that closer — but ONLY for a CONFIRMED-DESYNC
-    // opener: scanTag never reached the closer (`!closed`), or the region it left between its `>` and
-    // the closer is UNBALANCED (leaked string/bracket residue). A clean glued opener's visible body can
-    // legitimately hold a `>` (`LEFT > RIGHT`), an entity, or a nested inline tag — re-anchoring it would
-    // delete that body, so leave scanTag's honest `>` untouched.
-    if (glued && !closing && !selfClose && closerAfter !== -1 && (!closed || !balancedBody(text.slice(k, tag.nameEnd + closerAfter)))) {
+    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed). A dropped
+    // string-quote backslash (`title="a \" b"` → `title="a " b"`) desyncs the quote state the same way,
+    // leaving scanTag unclosed. Re-anchor the real `>` to the LAST `>` before that closer, decided from
+    // OPENER-LOCAL signals only, never whole-body balance (a body apostrophe or a masking body quote
+    // defeats that in both directions): the opener must be ESCAPED (`tag.esc` — structure() only escapes
+    // a glued opener that carries a `{…}`/`[…]` attribute OR a lossy string attribute; a bare honest
+    // opener is left unescaped so its visible `>` is trustworthy), AND either scanTag never reached its
+    // `>` (`!closed` — quote OR brace desync) or the region between its `>` and the closer carries an
+    // unmatched bare bracket (`bracketDesync` — quote-agnostic leaked `}]` / `]}` residue). When the
+    // gate fires and a real `>` is found before the closer, the opener is a CONFIRMED lossy component —
+    // strip it directly (the mangled attribute residue is ungrammatical, so grammar classification below
+    // would wrongly KEEP it as prose).
+    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(k, tag.nameEnd + closerAfter)))) {
       const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
-      if (gt > tag.nameEnd) { k = gt + 1; closed = true; }
+      if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
     }
     // Fallback brace/bracket-depth recovery for a GLUED or non-escaped opener with no in-chunk closer
     // to anchor on — cut at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name. A
@@ -314,6 +325,22 @@ function deEscape(s: string): string {
   return s.replace(/\\([^0-9A-Za-z\s])/g, '$1');
 }
 
+// End of a CommonMark code span opened at `i` (a backtick run of length N): the index just PAST
+// the first later run of EXACTLY N backticks. Returns -1 when `i` isn't a span opener — the run is
+// backslash-escaped (`` \` `` is a literal backtick, not a fence) or never closes (an unterminated
+// run is literal text, not a span). This is the single source of truth for every code-span skip so
+// a `</Name>` / generic inside `` `…` `` (including a `` `` ` `` `` double-backtick span) is never
+// mistaken for markup, and a lone escaped backtick never swallows the real tag that follows it.
+function codeSpanEnd(text: string, i: number): number {
+  if (text[i] !== '`' || text[i - 1] === '\\') return -1;
+  let n = 0; while (text[i + n] === '`') n++;
+  for (let j = i + n; j < text.length; ) {
+    if (text[j] === '`') { let m = 0; while (text[j + m] === '`') m++; if (m === n) return j + m; j += m; }
+    else j++;
+  }
+  return -1;
+}
+
 // A `</Name>` closer regex tolerant of structure()'s per-char markdown escaping (`</\_Panel>`,
 // `</\$Panel>`), so a custom-name closer is located directly in RAW text and its match offsets
 // stay in raw space — no deEscape/offset remapping needed. Iterates code points (astral-safe).
@@ -322,34 +349,36 @@ function rawCloserRe(name: string): RegExp {
   return new RegExp(`</${body}\\s*>`);
 }
 
-// Blank out code-span regions so a `</Name>` inside `` `…` `` isn't counted when probing whether
-// a glued opener carries its own closer later in the chunk (else a fake code-span closer makes an
-// in-body generic look like a real inline component and mispairs with the outer closer).
+// Blank out code-span regions (CommonMark-correct fences) so a `</Name>` inside `` `…` `` isn't
+// counted when probing whether a glued opener carries its own closer later in the chunk (else a
+// fake code-span closer makes an in-body generic look like a real inline component and mispairs).
 function outsideCode(text: string): string {
   let out = '', i = 0;
   while (i < text.length) {
-    if (text[i] === '`') { let f = 0; while (text[i + f] === '`') f++; const e = text.indexOf(text.slice(i, i + f), i + f); i = e === -1 ? text.length : e + f; continue; }
+    const cs = codeSpanEnd(text, i);
+    if (cs !== -1) { i = cs; continue; }
     out += text[i++];
   }
   return out;
 }
 
-// Does a candidate body region (between scanTag's `>` and the real closer) carry balanced quotes
-// and brackets? A CLEAN component body is visible prose — balanced, possibly with a stray `>`. A
-// LOSSY opener whose corrupted attribute leaked past scanTag's fake `>` exposes unbalanced string /
-// bracket residue (`… "c"]}`). Used ONLY to gate the closer anchor so it never re-cuts a clean
-// glued opener's real body (which may legitimately contain `>`, entities, nested inline tags).
-function balancedBody(seg: string): boolean {
-  let quote = '', depth = 0;
+// Is the region a scanTag left between its `>` and the real closer BRACKET-unbalanced? structure()
+// markdown-escapes every OPENING bracket (`\{`, `\[`) — string-content ones included — but leaves
+// closes bare, so a lossy opener whose corrupted attribute leaked past scanTag's fake `>` exposes an
+// unmatched bare `}` / `]` (`… "c"]}`) here. Bracket depth ONLY — quotes are deliberately ignored:
+// an apostrophe in visible prose (`don't`) or a masking body quote would make a quote-aware balance
+// check misfire in BOTH directions (EVE's round-18 counterexamples). Used together with `tag.esc`
+// (structure() only escapes+corrupts an opener that carries a `{…}` attribute — a bare/string-attr
+// opener is never lossy), so a legitimate stray `]` in a bare opener's body can't trigger recovery.
+function bracketDesync(seg: string): boolean {
+  let depth = 0;
   for (let m = 0; m < seg.length; m++) {
     const ch = seg[m];
-    if (ch === '\\') { m++; continue; }
-    if (quote) { if (ch === quote) quote = ''; continue; }
-    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
-    else if (ch === '{' || ch === '[') depth++;
-    else if (ch === '}' || ch === ']') { if (depth === 0) return false; depth--; }
+    if (ch === '\\') { const n = seg[m + 1]; if (n === '{' || n === '[') depth++; else if (n === '}' || n === ']') { if (depth === 0) return true; depth--; } m++; continue; }
+    if (ch === '{' || ch === '[') depth++;
+    else if (ch === '}' || ch === ']') { if (depth === 0) return true; depth--; }
   }
-  return quote === '' && depth === 0;
+  return depth !== 0;
 }
 
 // Unambiguous JSX-opener body: an `attr={…}` JSX expression or a `{...spread}`. Neither can

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -134,41 +134,47 @@ function scanTag(text: string, i: number): Tag | null {
 // confirmed component tags (both the opener and its matched closer).
 export function pairResidues(chunks: string[]): Set<string> {
   const paired = new Set<string>();
-  const stack: { name: string; key: string }[] = [];
+  // Two stacks decide the real hierarchy on the COMPLETE chunk stream. `global` pairs a FLOW
+  // component's opener with its closer ACROSS chunks; `local` (rebuilt per chunk) pairs an INLINE
+  // component within one chunk. The distinction is structure()'s own serialization: it emits a flow
+  // opener as a chunk that ENDS at the opener's `>` (heading/body/closer become later chunks), whereas
+  // an in-body TS generic (`factory()\<$Panel extends GEN>()`, `a\<$Panel>b`) and a self-contained
+  // inline element (`\<$Panel>x\</$Panel>`) both sit MID-chunk with more text after the `>`. So a
+  // closer pops the nearest same-name LOCAL opener first (real inline nesting), then the GLOBAL one
+  // (flow). An unclosed leftover opener joins `global` ONLY if its `>` ended its chunk — the flow
+  // signature; a mid-chunk leftover is an in-body generic and is dropped from pairing entirely, so a
+  // later flow closer can never reach past it to mispair (EVE's outer→generic→inline→outer-closer
+  // case) and a cross-chunk flow JSX opener is still paired by its real later-chunk closer (never
+  // mistaken for a generic just because THIS chunk holds no closer). Code-span aware throughout.
+  const global: { name: string; key: string }[] = [];
   chunks.forEach((text, ci) => {
+    const local: { name: string; key: string; endsChunk: boolean }[] = [];
     let i = 0;
     while (i < text.length) {
       if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
       const tag = scanTag(text, i);
       if (!tag) { i++; continue; }
-      // Only a STANDALONE residue opener enters the pairing stack. structure() emits a flow
-      // component's opener/closer residue as its own chunk (leading `\` aside), whereas a `\<Name …>`
-      // GLUED to preceding code in the same text run is a TS construct structure() escaped as prose —
-      // a type-argument (`factory()\<Name>()`), a constrained generic (`\<Name extends …>`), a
-      // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
-      // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
-      // generic and leaking the outer markup.
-      // A glued escaped opener is an IN-BODY GENERIC — never
-      // stacked — when its own tag body parses as valid TypeScript AND either (a) it carries a NESTED
-      // `<` type-argument (`$Panel<U>`), an unambiguous generic tell a JSX opener's name can never hold,
-      // so it is exempt even when a later same-name closer exists; or (b) it has NO matching same-name
-      // closer LATER in this chunk (code-span-aware). The closer probe distinguishes the two otherwise-
-      // ambiguous shapes: a real inline component (`prefix\<$Panel extends X>body\</$Panel>suffix`, whose
-      // `extends`-shaped prop parses as TS) DOES have a later closer → NOT exempt → stacks and its own
-      // closer pops it. A generic that PRECEDES a real same-name inline (`\<$G>() then \<$G>x\</$G>`) also
-      // has a later closer → stacks, and positional nearest-pop hands that closer to the INNER real
-      // opener, leaving the leading generic unpaired (kept). Hierarchy + real syntax decide it, not body
-      // shape alone. A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` never pops).
-      const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-      const openerBody = text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end).replace(/\/\s*$/, '');
-      const nestedArg = /^\S+</.test(deEscape(openerBody).trim());
-      const inBodyGeneric = glued && tag.esc && !tag.closing && isTsGeneric(openerBody) && (nestedArg || !hasCloserLater(text, tag.closed ? tag.end : tag.nameEnd, tag.name));
-      if (!tag.selfClose && !inBodyGeneric) {
-        if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
-        else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
+      if (!tag.selfClose) {
+        if (tag.closing) {
+          let popped = false;
+          for (let s = local.length - 1; s >= 0; s--) if (local[s].name === tag.name) { paired.add(local[s].key); paired.add(`${ci}:${tag.lt}`); local.length = s; popped = true; break; }
+          if (!popped) for (let s = global.length - 1; s >= 0; s--) if (global[s].name === tag.name) { paired.add(global[s].key); paired.add(`${ci}:${tag.lt}`); global.length = s; break; }
+        } else {
+          // A leftover opener is FLOW (joins `global` for a later-chunk closer) when it is a standalone
+          // residue: its `>` ends the chunk (clean flow opener), OR it is a chunk-start opener whose
+          // lossy attribute DESYNCED scanTag into stopping at a fake early `>` (bracket-unbalanced
+          // consumed span, trailing residue but nothing real precedes it). A chunk-start CLEAN opener
+          // with real trailing code (`\<$Panel extends GEN>() …`) is an in-body generic, not flow — so
+          // desync, not mere position, gates the `!glued` case. A GLUED mid-chunk leftover is likewise an
+          // in-body generic — dropped from pairing so no later closer mispairs across it.
+          const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
+          const flow = !tag.closed || text.slice(tag.end).trim() === '' || (!glued && bracketDesync(text.slice(tag.nameEnd, tag.end)));
+          local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow });
+        }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
     }
+    for (const o of local) if (o.endsChunk) global.push({ name: o.name, key: o.key });
   });
   return paired;
 }
@@ -224,12 +230,17 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     //       opener's span is balanced (`mode=\{\{ a }} title="x">`) even when the body carries a stray `[`.
     //   (b) the span rebalanced by luck (`]}` closes `\[\{` in order) but scanTag stopped at a FAKE `>`,
     //       leaving the attribute's REAL structural close glued to the true tag end as `]}>` / `}]>` /
-    //       `]]>` / `}}>` residue before the closer. structure() never emits a bare double-close-then-`>`
-    //       in honest body (body opens are escaped `\[`, a lone body `]` is never doubled onto `>`), so
-    //       this signature is unambiguous leaked opener serialization, not visible prose.
+    //       `]]>` / `}}>` residue before the closer. structure() never emits a DOUBLE bare close-then-`>`
+    //       in honest body: body opens are escaped `\[` / `\{`, and their closes are bare and single, so
+    //       an honest `arr\[i]>0` yields a lone `]>` (never `]}>`). Only a leaked attribute's real
+    //       structural close (`\{\["…"]}` → `]}`) doubles onto the tag `>`, so a run of TWO closes
+    //       immediately before a `>` (optionally across whitespace: `]}   >`) is unambiguous leaked
+    //       opener serialization. This IS an after-`k` read, but a TARGETED double-close signature, not a
+    //       whole-body balance scan — a single body `]>` / `>` can never match it (EVE's `arr[i]>0`).
     // On a confirmed-lossy opener, re-anchor to the LAST `>` before the closer and strip directly (the
     // mangled residue is ungrammatical, so grammar classification below would wrongly KEEP it as prose).
-    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)))) {
+    const attrLeak = /[\]}]{2}\s*>/.test(text.slice(k, tag.nameEnd + closerAfter));
+    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)) || attrLeak)) {
       const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
       if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
     }
@@ -357,25 +368,6 @@ function codeSpanEnd(text: string, i: number): number {
 function rawCloserRe(name: string): RegExp {
   const body = [...name].map((c) => '\\\\?' + c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('');
   return new RegExp(`</${body}\\s*>`);
-}
-
-// Does a matching `</Name>` closer appear later in this chunk, OUTSIDE any code span? This is the
-// hierarchy signal that decides whether a glued TS-parsable opener is an in-body generic (no closer
-// of its own → exempt from the pairing stack) or a real inline component / a generic preceding a real
-// same-name inline (has a later closer → stacks, so positional nearest-pop resolves it correctly).
-// The code-span skip matters: a `` `</Name>` `` inside prose is literal text, not a real closer.
-function hasCloserLater(text: string, from: number, name: string): boolean {
-  const re = rawCloserRe(name);
-  for (let j = from; j < text.length; ) {
-    if (text[j] === '`') { const cs = codeSpanEnd(text, j); if (cs !== -1) { j = cs; continue; } }
-    const m = re.exec(text.slice(j));
-    if (!m) return false;
-    const at = j + m.index;
-    let spanned = false; // the found closer might sit inside a code span between j and at
-    for (let s = j; s < at; ) { if (text[s] === '`') { const cs = codeSpanEnd(text, s); if (cs > at) { spanned = true; j = cs; break; } if (cs !== -1) { s = cs; continue; } } s++; }
-    if (!spanned) return true;
-  }
-  return false;
 }
 
 // Is the OPENER'S OWN attribute span (what scanTag consumed between the tag name and its landing

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -2,28 +2,11 @@ import { fromMarkdown } from 'mdast-util-from-markdown';
 import { toString } from 'mdast-util-to-string';
 import { mdxjs } from 'micromark-extension-mdxjs';
 import { mdxFromMarkdown } from 'mdast-util-mdx';
-import { structure } from 'fumadocs-core/mdx-plugins/remark-structure';
 import type { Nodes } from 'mdast';
 import ts from 'typescript';
 import type { source } from './source';
 
 type Page = (typeof source)['$inferPage'];
-
-// A markdown-escaped quote (`\"` / `\'`) inside a JSX attribute is the ONE lossy case
-// structure() can't be recovered from downstream: it drops the backslash, so a leaked
-// dropped-quote attribute (`title="a \" > NEEDLE">`) serializes BYTE-IDENTICALLY to a
-// legit value that ends in a literal space (`a="1 " >`). Encode the escaped quote to a
-// private-use sentinel BEFORE structure() runs: the leaked string then stays balanced
-// (its inner `>` sits inside the quoted region, so scanTag lands on the REAL tag `>` and
-// strips the whole opener, needle and all), while a legit close-quote remains a real
-// quote and its body survives. Private-use code points no real doc text contains; decoded
-// back to the quote in sanitizeSearchText's final output, so no sentinel enters the index
-// and a legit prose `\"quote\"` keeps its characters (won't conflict with body text).
-const SENTINEL_DQUOTE = '\uE000';
-const SENTINEL_SQUOTE = '\uE001';
-export function encodeEscapedQuotes(raw: string): string {
-  return raw.replace(/\\"/g, SENTINEL_DQUOTE).replace(/\\'/g, SENTINEL_SQUOTE);
-}
 
 const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
 
@@ -544,22 +527,70 @@ function rawCloserRe(name: string): RegExp {
   return new RegExp(`</${body}\\s*>`);
 }
 
-// The lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be FAKE.
-// structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, so an opener's
-// REAL end can leak PAST `k` when its `{…}` attribute expression carries a bare close. The tell is
-// OPENER-LOCAL (derived from the span `nameEnd..k`, never the visible body); a clean opener trips it
-// not, so this returns -1 and `k` stays the boundary (the visible intro survives). A dropped-quote
-// leak (`title="a \" > NEEDLE">`) is NOT handled here: encodeEscapedQuotes runs BEFORE structure(),
-// turning the escaped quote into a sentinel so the leaked string stays balanced and scanTag lands on
-// the REAL `>` — no fake early `>`, no recovery needed, and a legit trailing-space attr (`a="1 " >`)
-// keeps its body (the two are no longer byte-identical).
+// The single lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be
+// FAKE. structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, and it can
+// drop the backslash of a `\"` / `\'` inside a string attribute — either way an opener's REAL end can
+// leak PAST `k`. Both tells are OPENER-LOCAL (derived from the span `nameEnd..k`, never the visible
+// body) and single/double-quote consistent; a clean opener trips neither, so this returns -1 and `k`
+// stays the boundary (the visible intro survives):
+//   • QUOTE leak — the span ENDS with `["']\s+>`: a dropped quote-backslash closed the string one char
+//     early (`title="a \" >…` → `title="a " >…`, `title='a \' >…` → `title='a ' >…`), so the residual
+//     value-close quote sits with whitespace before the fake `>`. A CLEAN opener glues its `>` to the
+//     last attribute token (`a="1">`), so this never fires on honest intro. Recover to the leaked
+//     string's REAL close `["']\s*>` in the body.
 //   • BRACKET leak — a depth scan from `k` where structure()'s escaped opens (`\{`/`\[`) are +1 and bare
 //     closes (`}`/`]`) are −1. Honest body brackets are ALWAYS structure-escaped, so depth only goes
 //     NEGATIVE on a `}`/`]` leaked from the opener's own `{…}` attribute expression; that negative-depth
-//     close glued to `>` (`}>` / `]}>` / `)}>`) is the real end. Lexically safe: regex literals `/…/`,
-//     `/* … */` / `// …` comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>`
-//     never miscount.
+//     close glued to `>` (`}>` / `]}>` / `)}>`) is the real end. This also covers the quote-leak variant
+//     whose corrupting quote sits PAST `k` (`value={fn("a \" } > X", …)}>` — the span looks balanced but
+//     the real end is the trailing `)}>`). Lexically safe: regex literals `/…/`, `/* … */` / `// …`
+//     comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>` never miscount.
+// Resume a tag scan at `start` (just PAST a recovered leaked string) and return the index just past the
+// tag's real `>` at brace depth 0, or -1 if none. Mirrors scanTag's lexical rules over structure()'s
+// serialized residue: escaped opening brackets (`\{`/`\[`) raise depth, bare closes lower it, and quote /
+// regex / comment / code-span runs are skipped so their `>` never ends the tag early.
+function scanToTagEnd(text: string, start: number): number {
+  let quote = '', brace = 0, prevSig = '';
+  for (let m = start; m < text.length; m++) {
+    const ch = text[m];
+    if (quote) { if (ch === '\\') { m++; continue; } if (ch === quote) { quote = ''; prevSig = '"'; } continue; }
+    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
+    if (brace > 0 && ch === '/' && text[m + 1] === '*') { const e = text.indexOf('*/', m + 2); m = e === -1 ? text.length : e + 1; continue; }
+    if (brace > 0 && ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
+    if (brace > 0 && ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } }
+    if (ch === '\\' && /[<>{}[\]]/.test(text[m + 1] ?? '')) { const p = text[m + 1]; if (p === '{') brace++; else if (p === '}' && brace > 0) brace--; m++; prevSig = p; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === '{') brace++;
+    else if (ch === '}' && brace > 0) brace--;
+    else if (ch === '>' && !brace) return m + 1;
+    if (!/\s/.test(ch)) prevSig = ch;
+  }
+  return -1;
+}
+
 function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
+  // QUOTE leak — the span ends with `<space><quote><space>+>`: structure() dropped a `\"`/`\'`
+  // backslash, so the string closed one char early and the DANGLING value-close quote is preceded by
+  // the space that used to sit before the escaped quote (`title="a \" >…` → `…a " >`). A CLEAN opener
+  // GLUES its real close-quote to the last value char (`a="1" >` — `1" >`, no space BEFORE the quote),
+  // so this fires on an honest opener only in the pathological case of an attribute VALUE that itself
+  // ends in a literal space (`a="1 " >`), which serializes byte-identically to a dropped-quote leak —
+  // no opener-local signal can tell the two apart, so we treat the leak (the real structure() failure
+  // mode, EVE rounds 26-30) as canonical. `leakQuote[1]` is the leaked string's quote.
+  const leakQuote = /\s(["'])\s+>$/.exec(text.slice(nameEnd, k));
+  if (leakQuote) {
+    // scanTag stopped at a FAKE `>` still INSIDE a string whose closing quote structure() dropped the
+    // backslash of (`title="a \" >…` → `title="a " >…`). We are mid-string at `k`. Close that string at
+    // its REAL quote, then finish a normal brace/quote/regex-aware tag scan to the tag's real `>` — so a
+    // later honest attribute (`pattern={/">/.test(X)}>`) is consumed instead of leaking into the body.
+    // The decision is purely OPENER-LOCAL: the leak signature is read from the opener span, and the end
+    // is then found by a deterministic lexical scan — no dependency on the visible body's first char
+    // (an earlier `text[end]` whitespace guess both leaked a real `"> ` end and ate a clean body's `">`).
+    let m = k;
+    for (; m < text.length; m++) { const ch = text[m]; if (ch === '\\') { m++; continue; } if (ch === leakQuote[1]) { m++; break; } }
+    const end = scanToTagEnd(text, m);
+    if (end !== -1) return end;
+  }
   // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
   // (structure() escapes its open as `\{`/`\[`) AND that span is opener-provably lossy: either
   // bracket-DESYNCED, or scanTag landed on a FAKE early `>` preceded by whitespace (`… }] >` / `… ]} >`
@@ -682,10 +713,6 @@ export function sanitizeSearchText(input: string, chunkIndex = 0, paired: Set<st
     text = toString(fromMarkdown(cleaned), { includeHtml: false }).replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ');
   }
   return decodeContentEntities(text)
-    // Decode the escaped-quote sentinels back to real quotes so a legit prose `\"quote\"`
-    // keeps its characters and NO sentinel code point ever enters the search index.
-    .replace(new RegExp(SENTINEL_DQUOTE, 'g'), '"')
-    .replace(new RegExp(SENTINEL_SQUOTE, 'g'), "'")
     // Drop stray backticks the AST left as literal text (a lone/unpaired `,
     // e.g. from a decoded `&#x60;`). Only backticks — never `_` or word chars —
     // so identifiers are untouched.
@@ -698,13 +725,7 @@ export function sanitizeSearchText(input: string, chunkIndex = 0, paired: Set<st
 // extractor, but every heading and content chunk is sanitized so the static
 // search JSON holds clean prose instead of markdown/entities.
 export async function buildIndex(page: Page) {
-  // Recompute structure() from the RAW markdown with escaped quotes sentinel-encoded, so the
-  // dropped-quote leak (`title="a \" > NEEDLE">`) becomes a self-balancing string that scanTag
-  // strips cleanly — the prebuilt page.data.structuredData already lost the `\` backslash and
-  // can't be recovered. Production and the regression tests both go through encodeEscapedQuotes,
-  // so buildIndex only ever consumes this explicit signal instead of guessing at the byte sequence.
-  const raw = await page.data.getText('raw');
-  const structuredData = structure(encodeEscapedQuotes(raw));
+  const structuredData = await page.data.structuredData;
   // Pair residue openers/closers once over the ORDERED content chunk stream so an opener
   // that structure() split away from its closer into a later chunk is still recognized.
   const contents = structuredData.contents.map((c) => c.content);

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -148,18 +148,20 @@ export function pairResidues(chunks: string[]): Set<string> {
       // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
       // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
       // generic and leaking the outer markup. A glued escaped opener is an IN-BODY GENERIC — never
-      // stacked — when EITHER its own tag body carries a nested `<` type-argument (`\<Name\<U>>`, the
-      // unambiguous generic tell that survives even when a real same-name inline component follows it
-      // LATER in the chunk), OR it has no matching closer anywhere later in this chunk (a bare generic
-      // `factory()\<Name>()` whose `</Name>` lives elsewhere). A real glued inline component
-      // (`prefix\<Panel …>b\</Panel>suffix`) has no nested `<` and carries its closer in-chunk, so it
-      // still stacks. The closer probe is CommonMark code-span aware (`outsideCode`) so a `` `</Name>` ``
-      // literal can't masquerade as the opener's own closer. A CLOSING tag is never a generic, so it
-      // must always pair (else a glued `\</$Panel>` whose suffix has no further closer never pops).
+      // stacked — when its own tag body parses as valid TypeScript AND is UNAMBIGUOUSLY a generic:
+      // it carries a generic-only token a bare JSX opener can't (`extends`/`=`/`,`/whitespace-separated
+      // content or a nested `<`, e.g. `\<Name extends C>`, `\<Name = D>`, `\<Name, U>`, `\<Name && b`).
+      // This is a SYNTACTIC-ROLE test on the opener's OWN body only, so a following real same-name
+      // inline component's closer never drags a multi-token generic onto the stack (a non-nested
+      // generic + later real inline must both survive). A BARE `\<Name>` body (just the name, valid TS
+      // but shape-identical to a real inline opener `\<Panel>body\</Panel>`) is genuinely ambiguous, so
+      // it IS stacked and the positional stack resolves it by real nesting — a `</Name>` pops the
+      // NEAREST open `<Name>` (the real inline), leaving an unpaired bare generic that stays as prose.
+      // A real attributed component opener (`\<Panel title="x">`) is not valid TS, so it always stacks.
+      // A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` never pops).
       const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-      const tagBody = text.slice(tag.nameEnd, tag.closed ? tag.end - 1 : tag.end);
-      const nestedArg = /\\?</.test(tagBody); // a `<` inside the opener's own tag body → type-argument, a generic
-      const inBodyGeneric = glued && tag.esc && !tag.closing && (nestedArg || !rawCloserRe(tag.name).test(outsideCode(text.slice(tag.closed ? tag.end : tag.nameEnd))));
+      const openerBody = text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end).replace(/\/\s*$/, '');
+      const inBodyGeneric = glued && tag.esc && !tag.closing && /[\s,=<]/.test(deEscape(openerBody).trim()) && isTsGeneric(openerBody);
       if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
@@ -213,18 +215,21 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // scan is fooled by unbalanced brackets inside the corrupted attribute STRING: `items={["a }] > x"]}>`
     // under-counts and scanTag cuts EARLY at the string-internal `>` (attr residue leaks as fake suffix),
     // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed). A dropped
-    // string-quote backslash (`title="a \" b"` → `title="a " b"`) desyncs the quote state the same way,
-    // leaving scanTag unclosed. Re-anchor the real `>` to the LAST `>` before that closer, decided from
-    // OPENER-LOCAL signals only, never whole-body balance (a body apostrophe or a masking body quote
-    // defeats that in both directions): the opener must be ESCAPED (`tag.esc` — structure() only escapes
-    // a glued opener that carries a `{…}`/`[…]` attribute OR a lossy string attribute; a bare honest
-    // opener is left unescaped so its visible `>` is trustworthy), AND either scanTag never reached its
-    // `>` (`!closed` — quote OR brace desync) or the region between its `>` and the closer carries an
-    // unmatched bare bracket (`bracketDesync` — quote-agnostic leaked `}]` / `]}` residue). When the
-    // gate fires and a real `>` is found before the closer, the opener is a CONFIRMED lossy component —
-    // strip it directly (the mangled attribute residue is ungrammatical, so grammar classification below
-    // would wrongly KEEP it as prose).
-    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(k, tag.nameEnd + closerAfter)))) {
+    // string-quote backslash (`title="a \" b"` → `title="a " b"`) desyncs the quote state the same way.
+    // The desync is decided from OPENER-LOCAL signals only, NEVER whole-body balance (a body apostrophe /
+    // stray `[` / lone `]` defeats that — EVE's `<Panel …>LEFT [ compare > RIGHT` honest-opener case):
+    //   (a) the OPENER'S OWN attribute span (what scanTag consumed, `nameEnd..k`) is quote- and
+    //       bracket-unbalanced — catches `!closed`, the dropped-quote case, and mismatched `}]`; a clean
+    //       opener's span is balanced (`mode=\{\{ a }} title="x">`) even when the body carries a stray `[`.
+    //   (b) the span rebalanced by luck (`]}` closes `\[\{` in order) but scanTag stopped at a FAKE `>`,
+    //       leaving the attribute's REAL structural close glued to the true tag end as `]}>` / `}]>` /
+    //       `]]>` / `}}>` residue before the closer. structure() never emits a bare double-close-then-`>`
+    //       in honest body (body opens are escaped `\[`, a lone body `]` is never doubled onto `>`), so
+    //       this signature is unambiguous leaked opener serialization, not visible prose.
+    // On a confirmed-lossy opener, re-anchor to the LAST `>` before the closer and strip directly (the
+    // mangled residue is ungrammatical, so grammar classification below would wrongly KEEP it as prose).
+    const attrLeak = /[\]}]{1,2}>/.test(text.slice(k, tag.nameEnd + closerAfter));
+    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)) || attrLeak)) {
       const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
       if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
     }
@@ -332,7 +337,12 @@ function deEscape(s: string): string {
 // a `</Name>` / generic inside `` `…` `` (including a `` `` ` `` `` double-backtick span) is never
 // mistaken for markup, and a lone escaped backtick never swallows the real tag that follows it.
 function codeSpanEnd(text: string, i: number): number {
-  if (text[i] !== '`' || text[i - 1] === '\\') return -1;
+  if (text[i] !== '`') return -1;
+  // CommonMark escaping is per-backslash: only an ODD run of backslashes before the backtick escapes
+  // it. `\` ` is literal (not a span), but `\\` ` is an escaped backslash then a REAL span opener —
+  // checking only text[i-1] would wrongly reject the latter and expose the span's contents to markup.
+  let b = 0; while (text[i - 1 - b] === '\\') b++;
+  if (b % 2 === 1) return -1;
   let n = 0; while (text[i + n] === '`') n++;
   for (let j = i + n; j < text.length; ) {
     if (text[j] === '`') { let m = 0; while (text[j + m] === '`') m++; if (m === n) return j + m; j += m; }
@@ -349,36 +359,29 @@ function rawCloserRe(name: string): RegExp {
   return new RegExp(`</${body}\\s*>`);
 }
 
-// Blank out code-span regions (CommonMark-correct fences) so a `</Name>` inside `` `…` `` isn't
-// counted when probing whether a glued opener carries its own closer later in the chunk (else a
-// fake code-span closer makes an in-body generic look like a real inline component and mispairs).
-function outsideCode(text: string): string {
-  let out = '', i = 0;
-  while (i < text.length) {
-    const cs = codeSpanEnd(text, i);
-    if (cs !== -1) { i = cs; continue; }
-    out += text[i++];
-  }
-  return out;
-}
-
-// Is the region a scanTag left between its `>` and the real closer BRACKET-unbalanced? structure()
-// markdown-escapes every OPENING bracket (`\{`, `\[`) — string-content ones included — but leaves
-// closes bare, so a lossy opener whose corrupted attribute leaked past scanTag's fake `>` exposes an
-// unmatched bare `}` / `]` (`… "c"]}`) here. Bracket depth ONLY — quotes are deliberately ignored:
-// an apostrophe in visible prose (`don't`) or a masking body quote would make a quote-aware balance
-// check misfire in BOTH directions (EVE's round-18 counterexamples). Used together with `tag.esc`
-// (structure() only escapes+corrupts an opener that carries a `{…}` attribute — a bare/string-attr
-// opener is never lossy), so a legitimate stray `]` in a bare opener's body can't trigger recovery.
+// Is the OPENER'S OWN attribute span (what scanTag consumed between the tag name and its landing
+// `>`) bracket-desynced — the reliable local tell that structure() corrupted the opener? A clean
+// opener's attribute span is quote- and bracket-balanced (`mode=\{\{ a }} title="x"`); a lossy one
+// is not: structure() markdown-escapes every OPENING bracket (`\{`, `\[`) but leaves closes bare,
+// and a dropped string-quote backslash (`"a \" b"` → `"a " b"`) desyncs the quotes so scanTag ends
+// early at a fake `>` inside the corrupted attribute, leaving unmatched / mismatched brackets. This
+// is a quote-AWARE, TYPE-checked bracket stack over the OPENER span ONLY (never the visible body —
+// the caller passes `nameEnd..k`, so a body apostrophe / stray `[` can't misfire, EVE's round-18 &
+// round-20 counterexamples). `{`/`[` must close with the matching `}`/`]`; a leftover open bracket,
+// a mismatch, or an unterminated quote all mark desync.
 function bracketDesync(seg: string): boolean {
-  let depth = 0;
+  const stack: string[] = [];
+  let quote = '';
   for (let m = 0; m < seg.length; m++) {
-    const ch = seg[m];
-    if (ch === '\\') { const n = seg[m + 1]; if (n === '{' || n === '[') depth++; else if (n === '}' || n === ']') { if (depth === 0) return true; depth--; } m++; continue; }
-    if (ch === '{' || ch === '[') depth++;
-    else if (ch === '}' || ch === ']') { if (depth === 0) return true; depth--; }
+    let ch = seg[m];
+    if (ch === '\\') { ch = seg[m + 1] ?? ''; m++; if (quote) continue; }
+    else if (quote) { if (ch === quote) quote = ''; continue; }
+    else if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === '{' || ch === '[') stack.push(ch);
+    else if (ch === '}') { if (stack.pop() !== '{') return true; }
+    else if (ch === ']') { if (stack.pop() !== '[') return true; }
   }
-  return depth !== 0;
+  return stack.length !== 0 || quote !== '';
 }
 
 // Unambiguous JSX-opener body: an `attr={…}` JSX expression or a `{...spread}`. Neither can

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -104,7 +104,7 @@ function scanTag(text: string, i: number): Tag | null {
   let j = nameAt, nl: number;
   while ((nl = nameLen(NAME_CONT, text, j)) > 0) j += nl;
   const name = deEscape(text.slice(nameAt, j));
-  let quote = '', brace = 0, closed = false, selfClose = false, k = j;
+  let quote = '', brace = 0, closed = false, selfClose = false, k = j, prevSig = '';
   while (k < text.length) {
     const ch = text[k];
     if (quote) {
@@ -112,16 +112,28 @@ function scanTag(text: string, i: number): Tag | null {
       if (ch === quote) quote = '';
       k++; continue;
     }
+    // Inside a `{…}` expression, a `/` starts a comment or (when not a division operator) a regex
+    // literal whose body can hold literal `}` / `>` (`pattern=\{/\[}>]/}`). Skip those runs so their
+    // punctuation can't be mistaken for the expression/tag close — structure() preserves the `{…}`
+    // intact, so this stays deterministic. A `/` after an operand (ident / `)` / `]`) is division.
+    if (brace > 0 && ch === '/' && text[k + 1] === '*') { const e = text.indexOf('*/', k + 2); k = e === -1 ? text.length : e + 2; continue; }
+    if (brace > 0 && ch === '/' && text[k + 1] === '/') { const e = text.indexOf('\n', k + 2); k = e === -1 ? text.length : e; continue; }
+    if (brace > 0 && ch === '/' && !/[\w$)\]]/.test(prevSig)) {
+      let m = k + 1, cls = false;
+      for (; m < text.length; m++) { const r = text[m]; if (r === '\\') { m++; continue; } if (r === '[') cls = true; else if (r === ']') cls = false; else if (r === '/' && !cls) break; }
+      k = m + 1; prevSig = '/'; continue;
+    }
     if (ch === '\\' && /[<>{}[\]]/.test(text[k + 1] ?? '')) { // structure()'s markdown-escaped punctuation
       const p = text[k + 1];
       if (p === '{') brace++; else if (p === '}' && brace > 0) brace--;
-      k += 2; continue;
+      k += 2; prevSig = p; continue;
     }
     if (ch === '"' || ch === "'" || ch === '`') quote = ch;
     else if (ch === '{') brace++;
     else if (ch === '}' && brace > 0) brace--;
     else if (ch === '/' && !brace && text[k + 1] === '>') selfClose = true;
     else if (ch === '>' && !brace) { k++; closed = true; break; }
+    if (!/\s/.test(ch)) prevSig = ch;
     k++;
   }
   return { esc, lt, closing, name, nameEnd: j, end: k, selfClose, closed };
@@ -155,9 +167,19 @@ export function pairResidues(chunks: string[]): Set<string> {
       if (!tag) { i++; continue; }
       if (!tag.selfClose) {
         if (tag.closing) {
-          let popped = false;
-          for (let s = local.length - 1; s >= 0; s--) if (local[s].name === tag.name) { paired.add(local[s].key); paired.add(`${ci}:${tag.lt}`); local.length = s; popped = true; break; }
-          if (!popped) for (let s = global.length - 1; s >= 0; s--) if (global[s].name === tag.name) { paired.add(global[s].key); paired.add(`${ci}:${tag.lt}`); global.length = s; break; }
+          // A closer pops the nearest same-name opener, but PREFERS a DEFINITE one over a
+          // tentative generic-shaped opener: a definite flow is guaranteed to have a closer, a
+          // generic never is, so a lone closer belongs to the real flow even when a standalone
+          // technical generic sits nearer (EVE's `STANDALONEKEEP25`: the outer closer pops the
+          // definite outer, the generic stays unpaired → kept). With balanced closers this still
+          // resolves true nesting — the inner closer finds no definite nearer than the inner one.
+          const pop = (stack: { name: string; key: string; definite: boolean }[]) => {
+            let idx = -1;
+            for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { if (stack[s].definite) { idx = s; break; } if (idx === -1) idx = s; }
+            if (idx === -1) return false;
+            paired.add(stack[idx].key); paired.add(`${ci}:${tag.lt}`); stack.splice(idx, 1); return true;
+          };
+          pop(local) || pop(global);
         } else {
           // Classify a leftover opener as one of: DEFINITE flow (a real component — bare `\<$Panel>` or
           // attr'd `\<$Panel a="1">`), a TENTATIVE flow (a generic-SHAPED opener `\<$Panel extends X>` when
@@ -261,12 +283,32 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
       // span. A code span CAN hold a literal `]}>` (`` `arr[i]}>0` ``), so the scan SKIPS code spans —
       // a leaked attribute close is never inside one. Absent a double-close-glued-`>`, `k` is the real
       // tag end (clean opener) and the visible intro after it survives.
+      // ONLY an opener that actually carried attributes could have leaked a real attribute close
+      // past a FAKE early `>`. A BARE opener (`\<$Panel>`, nothing between the name and `>`) landed
+      // on its TRUE `>` at `k`, so its visible body may legitimately contain a `]}>` (an honest MDX
+      // expression `\{arr\[i]}>0`) — scanning past `k` there would eat honest intro. Gate the
+      // double-close hunt on the opener being attributed (its `nameEnd..>` span is non-empty).
+      const attributed = deEscape(text.slice(tag.nameEnd, closed ? k - 1 : k)).trim() !== '';
+      // A dropped string-quote backslash (`title="a \" > X"` → `title="a " > X"`) desyncs scanTag's
+      // quote state: it closes the string at the FAKE inner `"`, stops at the `>` inside, and leaks the
+      // attribute tail `X">` past `k` with the string's REAL close quote GLUED to the true tag `>`.
+      // A `">` / `'>` (quote glued to `>`) is the real tag end WHEN the running count of unescaped
+      // quotes from `nameEnd` to that quote is ODD — i.e. that quote closes a dangling string opened by
+      // the dropped-backslash desync. An honest intro's quotes are balanced, so the parity there is even
+      // at any glued `">` and this never fires. Counted incrementally so parity reflects position.
       let gc = -1;
-      for (let m = k; m < text.length; ) {
-        if (text[m] === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs; continue; } }
-        const mm = /^[)\]}]{2}\s*>/.exec(text.slice(m));
-        if (mm) { gc = m + mm[0].length; break; }
-        m++;
+      if (attributed) {
+        const quotes = deEscape(text.slice(tag.nameEnd, k)).match(/["']/g)?.length ?? 0;
+        let parity = quotes % 2; // quote parity already consumed inside the opener span
+        for (let m = k; m < text.length; ) {
+          if (text[m] === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs; continue; } }
+          const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m));
+          if (dbl) { gc = m + dbl[0].length; break; }
+          const ch = text[m];
+          if (ch === '\\') { m += 2; continue; }
+          if ((ch === '"' || ch === "'")) { if (parity === 0 && /^["']\s*>/.test(text.slice(m))) { gc = m + /^["']\s*>/.exec(text.slice(m))![0].length; break; } parity ^= 1; }
+          m++;
+        }
       }
       out += ' '; i = gc === -1 ? k : gc;
       continue;

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -109,7 +109,7 @@ function scanTag(text: string, i: number): Tag | null {
     const ch = text[k];
     if (quote) {
       if (ch === '\\') { k += 2; continue; } // escaped char inside a string/template
-      if (ch === quote) quote = '';
+      if (ch === quote) { quote = ''; prevSig = '"'; } // a closed string is an OPERAND: a following `/` is division, not a regex
       k++; continue;
     }
     // Inside a `{…}` expression, a `/` starts a comment or (when not a division operator) a regex
@@ -118,7 +118,7 @@ function scanTag(text: string, i: number): Tag | null {
     // intact, so this stays deterministic. A `/` after an operand (ident / `)` / `]`) is division.
     if (brace > 0 && ch === '/' && text[k + 1] === '*') { const e = text.indexOf('*/', k + 2); k = e === -1 ? text.length : e + 2; continue; }
     if (brace > 0 && ch === '/' && text[k + 1] === '/') { const e = text.indexOf('\n', k + 2); k = e === -1 ? text.length : e; continue; }
-    if (brace > 0 && ch === '/' && !/[\w$)\]]/.test(prevSig)) {
+    if (brace > 0 && ch === '/' && !/[\w$)\]"'`]/.test(prevSig)) {
       let m = k + 1, cls = false;
       for (; m < text.length; m++) { const r = text[m]; if (r === '\\') { m++; continue; } if (r === '[') cls = true; else if (r === ']') cls = false; else if (r === '/' && !cls) break; }
       k = m + 1; prevSig = '/'; continue;
@@ -157,9 +157,9 @@ export function pairResidues(chunks: string[]): Set<string> {
   // only a DEFINITE same-name flow being open makes a later same-name generic in-body content (so the
   // flow's own closer can't reach past it — EVE's `IDENTGEN23`), while a tentative generic never
   // poisons a subsequent real flow's classification. Code-span aware throughout.
-  const global: { name: string; key: string; definite: boolean }[] = [];
+  const global: { name: string; key: string; definite: boolean; generic: boolean }[] = [];
   chunks.forEach((text, ci) => {
-    const local: { name: string; key: string; endsChunk: boolean; definite: boolean }[] = [];
+    const local: { name: string; key: string; endsChunk: boolean; definite: boolean; generic: boolean }[] = [];
     let i = 0;
     while (i < text.length) {
       if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
@@ -167,15 +167,15 @@ export function pairResidues(chunks: string[]): Set<string> {
       if (!tag) { i++; continue; }
       if (!tag.selfClose) {
         if (tag.closing) {
-          // A closer pops the nearest same-name opener, but PREFERS a DEFINITE one over a
-          // tentative generic-shaped opener: a definite flow is guaranteed to have a closer, a
-          // generic never is, so a lone closer belongs to the real flow even when a standalone
-          // technical generic sits nearer (EVE's `STANDALONEKEEP25`: the outer closer pops the
-          // definite outer, the generic stays unpaired → kept). With balanced closers this still
-          // resolves true nesting — the inner closer finds no definite nearer than the inner one.
-          const pop = (stack: { name: string; key: string; definite: boolean }[]) => {
+          // A closer pops the nearest same-name opener (LOCAL first, then GLOBAL), preferring a
+          // NON-generic-shaped opener over an ambiguous generic-shaped one at the same name. A real
+          // component always emits its own closer; a technical generic never does — so a lone closer
+          // belongs to the real opener even when a standalone generic sits nearer (EVE's
+          // `STANDALONEKEEP25`, kept). Balanced closers still resolve true nesting: the inner closer
+          // finds the inner opener before any farther one.
+          const pop = (stack: { name: string; key: string; generic: boolean }[]) => {
             let idx = -1;
-            for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { if (stack[s].definite) { idx = s; break; } if (idx === -1) idx = s; }
+            for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { if (!stack[s].generic) { idx = s; break; } if (idx === -1) idx = s; }
             if (idx === -1) return false;
             paired.add(stack[idx].key); paired.add(`${ci}:${tag.lt}`); stack.splice(idx, 1); return true;
           };
@@ -213,12 +213,15 @@ export function pairResidues(chunks: string[]): Set<string> {
           // Closed in-body generics (`\<$Panel extends IDENTGEN23>`, call-glued `factory()\<$Panel<G>>()`) are
           // already kept by sanitize's grammar fallback — don't `keep:` them, that would truncate nested `<…>`.
           if (inBody && !tag.closed) paired.add(`keep:${ci}:${tag.lt}`);
-          local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow, definite });
+          // In-body prose (a glued/trailing same-name generic while a flow is open) is NOT a pairing
+          // candidate — pushing it lets a later same-name closer mis-pop it (LIFO nearest) and leave
+          // the real outer flow unpaired (EVE's `LOCALKEEP26`: generic + outer closer share a chunk).
+          if (!inBody) local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow, definite, generic });
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
     }
-    for (const o of local) if (o.endsChunk) global.push({ name: o.name, key: o.key, definite: o.definite });
+    for (const o of local) if (o.endsChunk) global.push({ name: o.name, key: o.key, definite: o.definite, generic: o.generic });
   });
   return paired;
 }
@@ -273,74 +276,29 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     const closerRe = rawCloserRe(tag.name);
     const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` (escape-tolerant), offset relative to nameEnd
     if (isPaired && !closing && !selfClose && closerAfter === -1) {
-      // scanTag can stop at a FAKE early `>` inside a corrupted attribute expression (structure()
-      // dropped a string-quote backslash so `value=\{fn("a \" } > x", y)}>` reads its inner `>` as the
-      // tag end). The attribute expression's REAL structural close then leaks past the fake `>` as a
-      // DOUBLE close glued to the true tag `>` — `)}>` / `]}>` / `}}>` — because a `\{…}`/`\[…]` nests
-      // at least two brackets. Honest intro after a clean opener never produces that OUTSIDE code: its
-      // `>` is a BARE comparison preceded by a SINGLE close at most (`arr\[i]>0` → lone `]>`), and a
-      // regex `/\(/` or comment `/* ( */` inside an honest attribute stays inside scanTag's balanced
-      // span. A code span CAN hold a literal `]}>` (`` `arr[i]}>0` ``), so the scan SKIPS code spans —
-      // a leaked attribute close is never inside one. Absent a double-close-glued-`>`, `k` is the real
-      // tag end (clean opener) and the visible intro after it survives.
-      // ONLY an opener that actually carried attributes could have leaked a real attribute close
-      // past a FAKE early `>`. A BARE opener (`\<$Panel>`, nothing between the name and `>`) landed
-      // on its TRUE `>` at `k`, so its visible body may legitimately contain a `]}>` (an honest MDX
-      // expression `\{arr\[i]}>0`) — scanning past `k` there would eat honest intro. Gate the
-      // double-close hunt on the opener being attributed (its `nameEnd..>` span is non-empty).
-      const attributed = deEscape(text.slice(tag.nameEnd, closed ? k - 1 : k)).trim() !== '';
-      // A dropped string-quote backslash (`title="a \" > X"` → `title="a " > X"`) desyncs scanTag's
-      // quote state: it closes the string at the FAKE inner `"`, stops at the `>` inside, and leaks the
-      // attribute tail `X">` past `k` with the string's REAL close quote GLUED to the true tag `>`.
-      // A `">` / `'>` (quote glued to `>`) is the real tag end WHEN the running count of unescaped
-      // quotes from `nameEnd` to that quote is ODD — i.e. that quote closes a dangling string opened by
-      // the dropped-backslash desync. An honest intro's quotes are balanced, so the parity there is even
-      // at any glued `">` and this never fires. Counted incrementally so parity reflects position.
-      let gc = -1;
-      if (attributed) {
-        const quotes = deEscape(text.slice(tag.nameEnd, k)).match(/["']/g)?.length ?? 0;
-        let parity = quotes % 2; // quote parity already consumed inside the opener span
-        for (let m = k; m < text.length; ) {
-          if (text[m] === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs; continue; } }
-          const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m));
-          if (dbl) { gc = m + dbl[0].length; break; }
-          const ch = text[m];
-          if (ch === '\\') { m += 2; continue; }
-          if ((ch === '"' || ch === "'")) { if (parity === 0 && /^["']\s*>/.test(text.slice(m))) { gc = m + /^["']\s*>/.exec(text.slice(m))![0].length; break; } parity ^= 1; }
-          m++;
-        }
-      }
+      // A paired cross-chunk FLOW opener (structure() split the component around a nested heading, so the
+      // whole opening tag is this chunk and the closer lives LATER). Strip the opener only, deriving the
+      // boundary from lossyOpenerEnd's lexical-safe scan of the opener's OWN residue — a clean opener
+      // ends at `k` (visible intro survives), a lossy one recovers past the leaked attribute close.
+      const gc = lossyOpenerEnd(text, tag.nameEnd, k);
       out += ' '; i = gc === -1 ? k : gc;
       continue;
     }
-    // Lossy `>`-recovery for a GLUED opener whose matching `</Name>` sits LATER IN THIS CHUNK.
-    // structure() can drop the escaping backslash of a quote/template inside an opener's attribute,
-    // desyncing scanTag's quote tracking. structure() markdown-escapes EVERY opening bracket (`\{`,
-    // `\[`) — structural AND string-content alike — but leaves closes bare, so a brace/bracket-depth
-    // scan is fooled by unbalanced brackets inside the corrupted attribute STRING: `items={["a }] > x"]}>`
-    // under-counts and scanTag cuts EARLY at the string-internal `>` (attr residue leaks as fake suffix),
-    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed). A dropped
-    // string-quote backslash (`title="a \" b"` → `title="a " b"`) desyncs the quote state the same way.
-    // The desync is decided from OPENER-LOCAL signals only, NEVER whole-body balance (a body apostrophe /
-    // stray `[` / lone `]` defeats that — EVE's `<Panel …>LEFT [ compare > RIGHT` honest-opener case):
-    //   (a) the OPENER'S OWN attribute span (what scanTag consumed, `nameEnd..k`) is quote- and
-    //       bracket-unbalanced — catches `!closed`, the dropped-quote case, and mismatched `}]`; a clean
-    //       opener's span is balanced (`mode=\{\{ a }} title="x">`) even when the body carries a stray `[`.
-    //   (b) the span rebalanced by luck (`]}` closes `\[\{` in order) but scanTag stopped at a FAKE `>`,
-    //       leaving the attribute's REAL structural close glued to the true tag end as `]}>` / `}]>` /
-    //       `]]>` / `}}>` residue before the closer. structure() never emits a DOUBLE bare close-then-`>`
-    //       in honest body: body opens are escaped `\[` / `\{`, and their closes are bare and single, so
-    //       an honest `arr\[i]>0` yields a lone `]>` (never `]}>`). Only a leaked attribute's real
-    //       structural close (`\{\["…"]}` → `]}`) doubles onto the tag `>`, so a run of TWO closes
-    //       immediately before a `>` (optionally across whitespace: `]}   >`) is unambiguous leaked
-    //       opener serialization. This IS an after-`k` read, but a TARGETED double-close signature, not a
-    //       whole-body balance scan — a single body `]>` / `>` can never match it (EVE's `arr[i]>0`).
-    // On a confirmed-lossy opener, re-anchor to the LAST `>` before the closer and strip directly (the
-    // mangled residue is ungrammatical, so grammar classification below would wrongly KEEP it as prose).
-    const attrLeak = /[\]}]{2}\s*>/.test(text.slice(k, tag.nameEnd + closerAfter));
-    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)) || attrLeak)) {
-      const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
-      if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
+    // Same recovery when the matching `</Name>` sits LATER IN THIS CHUNK (a GLUED inline opener whose
+    // close was not split off). lossyOpenerEnd handles the UNDER-count / dropped-quote / double-close
+    // leaks (scanTag stopped at a fake early `>`); it returns -1 for a clean inline tag AND for the
+    // OVER-count swallow case (`items={["a { [ x"]}>` — unbalanced opens so scanTag never closed and ran
+    // to end, `k` past the closer). That swallow case can't be reached by a forward-from-`k` scan, so it
+    // falls through to the closer-anchored recovery below: re-anchor to the LAST `>` before the in-chunk
+    // closer. Gated on the opener span being genuinely desynced so a clean inline tag is left to the
+    // grammar classifier (which strips a balanced tag whole).
+    if (glued && esc && !closing && !selfClose && closerAfter !== -1) {
+      const gc = lossyOpenerEnd(text, tag.nameEnd, k);
+      if (gc !== -1) { out += ' '; i = gc; continue; }
+      if (!closed || bracketDesync(text.slice(tag.nameEnd, k))) {
+        const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
+        if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
+      }
     }
     // Fallback brace/bracket-depth recovery for a GLUED or non-escaped opener with no in-chunk closer
     // to anchor on — cut at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name. A
@@ -466,6 +424,43 @@ function codeSpanEnd(text: string, i: number): number {
 function rawCloserRe(name: string): RegExp {
   const body = [...name].map((c) => '\\\\?' + c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('');
   return new RegExp(`</${body}\\s*>`);
+}
+
+// The single lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be
+// FAKE. structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, and it can
+// drop the backslash of a `\"` inside a string attribute — either way an opener's REAL end can leak
+// PAST `k`. Two opener-global tells over the residue from `nameEnd`, mutually exclusive by quote parity,
+// each enable ONE branch of a forward scan from `k`; a clean opener trips neither and this returns -1 so
+// `k` stays the boundary and the visible intro survives:
+//   • QUOTE leak (ODD unescaped `"`) — a dropped `\"` (`title="a \" > X"` → `title="a " > X"`) desyncs
+//     the quotes; quote state is CORRUPTED so bracket counting is meaningless. The string's real close
+//     leaks as a `">` glued to the true tag `>`; the quote branch recovers past it.
+//   • BRACKET leak (EVEN `"`, quotes TRUSTWORTHY) — a `\{…}` attribute expression leaked a close
+//     (`value=\{x } > DIVLEAK / 2}>`, or `value=\{"} > X" / 2}>` with the `}` inside a string). A
+//     quote-aware bracket count (escaped-open `\{`/`\[` = +1, bare `}`/`]` = −1) going NEGATIVE marks it;
+//     the bracket branch recovers past the unmatched close glued to `>`.
+// A DOUBLE structural close glued to `>` (`)}>` / `]}>` / `}}>`) is an unambiguous leak in BOTH branches
+// (`\{fn("…" } > X", x)}>` closes call + expression at once past the fake `>`). Code spans are skipped so
+// a literal `]}>` inside `` `…` `` never trips it. Honest body never emits two bare closes before a `>`.
+function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
+  const seg = text.slice(nameEnd);
+  const oddQuote = ((seg.replace(/\\./g, '').match(/"/g)?.length ?? 0) % 2) === 1;
+  let bnet = 0, bracketLeak = false, q = '';
+  if (!oddQuote) for (let m = 0; m < seg.length; m++) { const ch = seg[m]; if (ch === '\\') { const n = seg[m + 1]; if (!q && (n === '{' || n === '[')) bnet++; m++; continue; } if (q) { if (ch === q) q = ''; continue; } if (ch === '"' || ch === "'" || ch === '`') { q = ch; continue; } if (ch === '}' || ch === ']') { bnet--; if (bnet < 0) bracketLeak = true; } }
+  if (!oddQuote && !bracketLeak) return -1;
+  let depth = 0, parity = 0, sq = '';
+  for (let m = k; m < text.length; m++) {
+    const ch = text[m];
+    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; continue; } }
+    const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m)); if (dbl) return m + dbl[0].length;
+    if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; continue; }
+    if (oddQuote && ch === '"') { const cq = /^"\s*>/.exec(text.slice(m)); if (parity === 0 && cq) return m + cq[0].length; parity ^= 1; continue; }
+    if (bracketLeak && sq) { if (ch === sq) sq = ''; continue; }
+    if (bracketLeak && (ch === '"' || ch === "'" || ch === '`')) { sq = ch; continue; }
+    if (ch === '{' || ch === '[') { depth++; continue; }
+    if (bracketLeak && (ch === '}' || ch === ']')) { depth--; const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (depth < 0 && cb) return m + cb[0].length; }
+  }
+  return -1;
 }
 
 // Is the OPENER'S OWN attribute span (what scanTag consumed between the tag name and its landing

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -171,14 +171,22 @@ export function pairResidues(chunks: string[]): Set<string> {
   // ABOVE that reserve (EVE's STALEFIRST28: a leading glued generic must not steal the lone closer that
   // belongs to a later standalone real flow).
   const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>(), standaloneGenerics = new Map<string, number>(), gluedGenerics = new Map<string, number>();
-  chunks.forEach((text) => {
+  // A glued generic can only pair with a same-name closer positioned AFTER it (LIFO pops the nearest
+  // PRECEDING opener), so a glued generic with no later same-name closer can never stack — it must be
+  // left out of the quota entirely, else a trailing technical generic AFTER the lone closer steals the
+  // slot a real flow BEFORE the closer needs (EVE round-33 P1-1: quota must be per closer interval, not
+  // whole-page). Record every closer's ordinal position per name, and each glued generic's position, so
+  // a second pass can keep only the glued generics that have a same-name closer after them.
+  const closerPos = new Map<string, number[]>(), gluedGenericAt: { name: string; pos: number; key: string }[] = [];
+  chunks.forEach((text, ci) => {
     let i = 0;
     while (i < text.length) {
       if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
       const tag = scanTag(text, i);
       if (!tag) { i++; continue; }
+      const pos = ci * 1e7 + tag.lt;
       if (!tag.selfClose) {
-        if (tag.closing) closers.set(tag.name, (closers.get(tag.name) ?? 0) + 1);
+        if (tag.closing) { closers.set(tag.name, (closers.get(tag.name) ?? 0) + 1); (closerPos.get(tag.name) ?? closerPos.set(tag.name, []).get(tag.name)!).push(pos); }
         else {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const isGeneric = /[\s,=]/.test(inner) && isTsGeneric(inner);
@@ -202,12 +210,18 @@ export function pairResidues(chunks: string[]): Set<string> {
           if (proseGlued) { i = tag.closed ? tag.end : tag.nameEnd; continue; } // prose instantiation/type-argument, not a residue
           if (!isGeneric) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
           else if (!gluedOpener) standaloneGenerics.set(tag.name, (standaloneGenerics.get(tag.name) ?? 0) + 1);
-          else gluedGenerics.set(tag.name, (gluedGenerics.get(tag.name) ?? 0) + 1);
+          else gluedGenericAt.push({ name: tag.name, pos, key: `${ci}:${tag.lt}` });
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
     }
   });
+  // Keep only glued generics that have a same-name closer positioned AFTER them — the rest can never be
+  // popped, so they neither count toward nor consume the quota (P1-1: quota is per closer interval).
+  const gluedEligible = new Set<string>();
+  for (const g of gluedGenericAt) {
+    if ((closerPos.get(g.name) ?? []).some((cp) => cp > g.pos)) { gluedEligible.add(g.key); gluedGenerics.set(g.name, (gluedGenerics.get(g.name) ?? 0) + 1); }
+  }
   const genericFlowBudget = new Map<string, number>(), standaloneReserve = new Map(standaloneGenerics);
   for (const [name, c] of closers) genericFlowBudget.set(name, c - (nonGenericOpeners.get(name) ?? 0));
   // How many GLUED generics of each name may stack as flow (the surplus above the standalone reserve),
@@ -273,11 +287,13 @@ export function pairResidues(chunks: string[]): Set<string> {
           // nearest opener by LIFO, so an earlier glued generic can't steal a later flow's closer regardless
           // of source order (EVE round-30 STALEGLUED29 → REALGLUED29 order-independence).
           const budget = genericFlowBudget.get(tag.name) ?? 0, reserve = standaloneReserve.get(tag.name) ?? 0;
-          // Only a glued generic that pre-scan actually COUNTED into gluedGenerics advances the remaining
-          // window — a proseGlued opener was skipped there, so decrementing on it would shift the window and
-          // hand a scarce closer to an EARLIER glued generic (EVE round-31 STALESHIFT31 → REALSHIFT31).
-          if (generic && glued && tag.closed && !proseGlued) { const r = (gluedRemaining.get(tag.name) ?? 0) - 1; gluedRemaining.set(tag.name, r); }
-          const gluedWins = !glued || (gluedRemaining.get(tag.name) ?? 0) < (gluedSlots.get(tag.name) ?? 0);
+          // Only a glued generic that pre-scan COUNTED into gluedGenerics advances the remaining window: it
+          // must be non-prose AND have a same-name closer positioned after it (gluedEligible). A trailing
+          // glued generic with no later closer can never pair, so it neither shifts the window nor stacks —
+          // else it would steal a scarce closer from a real flow BEFORE it (EVE round-33 P1-1 STALEAFTER32).
+          const eligibleGlued = gluedEligible.has(`${ci}:${tag.lt}`);
+          if (generic && glued && tag.closed && !proseGlued && eligibleGlued) { const r = (gluedRemaining.get(tag.name) ?? 0) - 1; gluedRemaining.set(tag.name, r); }
+          const gluedWins = !glued || (eligibleGlued && (gluedRemaining.get(tag.name) ?? 0) < (gluedSlots.get(tag.name) ?? 0));
           const genericFlow = !inBody && generic && tag.closed && budget > 0 && (!glued || budget > reserve) && gluedWins;
           if (genericFlow) { genericFlowBudget.set(tag.name, budget - 1); if (!glued && reserve > 0) standaloneReserve.set(tag.name, reserve - 1); }
           const flow = !inBody && (definite || lossy || (generic ? genericFlow : tag.closed));
@@ -578,12 +594,15 @@ function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
   // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
   // (structure() escapes its open as `\{`/`\[`) AND that span is opener-provably lossy: either
   // bracket-DESYNCED, or scanTag landed on a FAKE early `>` preceded by whitespace (`… }] >` / `… ]} >`
-  // — a dropped string-quote let the leaked closes drift, so the `>` sits after a space). A CLEAN
+  // — a dropped string-quote let the leaked closes drift, so the `>` sits after a space). That
+  // drift signature (`/\s>$/`) only proves a leak when the span actually CARRIED a string whose quote
+  // could be dropped — a CLEAN expression attribute with a legit space (`b={x} >`, `arr={[1,2]} >`)
+  // has no quote, so it is NOT recovered and its honest body survives (EVE round-33 P1-2). A CLEAN
   // expression attribute (`b={x}>` — the bracket close is GLUED to the real `>`, no space) is neither,
   // so an honest body `"}>` / `]>` is never mistaken for a leaked bracket close. Opener-local: reads
   // only the opener span, never the visible body.
   const bspan = text.slice(nameEnd, k);
-  if (!/\\[{[]/.test(bspan) || !(bracketDesync(bspan) || /\s>$/.test(bspan))) return -1;
+  if (!/\\[{[]/.test(bspan) || !(bracketDesync(bspan) || (/\s>$/.test(bspan) && /["'`]/.test(bspan)))) return -1;
   let depth = 0, prevSig = '';
   for (let m = k; m < text.length; m++) {
     const ch = text[m];
@@ -620,15 +639,21 @@ function regexEnd(s: string, p: number): number {
 // regex `/(/` or comment `/* ( */` inside an honest attribute would otherwise read as unbalanced.
 function bracketDesync(seg: string): boolean {
   const stack: string[] = [];
-  let quote = '';
+  let quote = '', prevSig = '';
   for (let m = 0; m < seg.length; m++) {
     let ch = seg[m];
     if (ch === '\\') { ch = seg[m + 1] ?? ''; m++; if (quote) continue; }
     else if (quote) { if (ch === quote) quote = ''; continue; }
     else if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    // Skip regex / block / line comment bodies so their literal brackets don't desync an honest
+    // opener (`pattern={/[}>]/}`, `x={/* } > */ 1}`) — same lexical rules as the recovery scan below.
+    else if (ch === '/' && seg[m + 1] === '*') { const e = seg.indexOf('*/', m + 2); m = e === -1 ? seg.length : e + 1; continue; }
+    else if (ch === '/' && seg[m + 1] === '/') { const e = seg.indexOf('\n', m + 2); m = e === -1 ? seg.length : e; continue; }
+    else if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(seg, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } }
     if (ch === '{' || ch === '[') stack.push(ch);
     else if (ch === '}') { if (stack.pop() !== '{') return true; }
     else if (ch === ']') { if (stack.pop() !== '[') return true; }
+    if (ch && !/\s/.test(ch)) prevSig = ch;
   }
   return stack.length !== 0 || quote !== '';
 }

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -165,7 +165,12 @@ export function pairResidues(chunks: string[]): Set<string> {
   // byte-identical nested sibling (SAME openers + TWO closers) are indistinguishable by position
   // under pure LIFO — the surplus closer is the only honest signal. So count `closers − nonGeneric
   // openers` per name; only that many generic-shaped openers may stack as flow, the rest stay prose.
-  const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>();
+  // When the budget is SCARCE, a STANDALONE generic (own chunk — structure() split a real flow around
+  // a heading) outranks a GLUED one (mid-prose technical generic), regardless of source order — so the
+  // budget reserves one slot per standalone generic and a glued generic only stacks on the surplus
+  // ABOVE that reserve (EVE's STALEFIRST28: a leading glued generic must not steal the lone closer that
+  // belongs to a later standalone real flow).
+  const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>(), standaloneGenerics = new Map<string, number>();
   chunks.forEach((text) => {
     let i = 0;
     while (i < text.length) {
@@ -176,13 +181,15 @@ export function pairResidues(chunks: string[]): Set<string> {
         if (tag.closing) closers.set(tag.name, (closers.get(tag.name) ?? 0) + 1);
         else {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
-          if (!(/[\s,=]/.test(inner) && isTsGeneric(inner))) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
+          const isGeneric = /[\s,=]/.test(inner) && isTsGeneric(inner);
+          if (!isGeneric) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
+          else if (text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() === '') standaloneGenerics.set(tag.name, (standaloneGenerics.get(tag.name) ?? 0) + 1);
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
     }
   });
-  const genericFlowBudget = new Map<string, number>();
+  const genericFlowBudget = new Map<string, number>(), standaloneReserve = new Map(standaloneGenerics);
   for (const [name, c] of closers) genericFlowBudget.set(name, c - (nonGenericOpeners.get(name) ?? 0));
   chunks.forEach((text, ci) => {
     const local: { name: string; key: string; endsChunk: boolean; definite: boolean; generic: boolean }[] = [];
@@ -228,11 +235,13 @@ export function pairResidues(chunks: string[]): Set<string> {
           // generic-shaped nested flow opener.
           const inBody = callGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
           const definite = !generic && !glued && (tag.closed || lossy); // bare/attr'd real component, not generic-shaped
-          // A STANDALONE generic-shaped opener stacks as flow only while a same-name closer remains
-          // surplus (see genericFlowBudget) — otherwise it is a lone technical generic (no closer of
-          // its own) and stays prose so a real component's closer isn't stolen by pure LIFO.
-          const genericFlow = !inBody && generic && tag.closed && (genericFlowBudget.get(tag.name) ?? 0) > 0;
-          if (genericFlow) genericFlowBudget.set(tag.name, (genericFlowBudget.get(tag.name) ?? 0) - 1);
+          // A generic-shaped opener stacks as flow only while a same-name closer remains for it (see
+          // genericFlowBudget). A STANDALONE generic draws its own reserved slot; a GLUED one only stacks
+          // on the surplus ABOVE the still-unclaimed standalone reserve, so a leading technical generic
+          // can't steal the closer a later standalone real flow needs (EVE's STALEFIRST28).
+          const budget = genericFlowBudget.get(tag.name) ?? 0, reserve = standaloneReserve.get(tag.name) ?? 0;
+          const genericFlow = !inBody && generic && tag.closed && budget > 0 && (!glued || budget > reserve);
+          if (genericFlow) { genericFlowBudget.set(tag.name, budget - 1); if (!glued && reserve > 0) standaloneReserve.set(tag.name, reserve - 1); }
           const flow = !inBody && (definite || lossy || (generic ? genericFlow : tag.closed));
           // A same-name UNCLOSED in-body generic reads as a JSX opener to the per-chunk grammar (`\<$Panel
           // remains STARTCOMPACT23` = two bare attrs) and would be wrongly stripped by stripComponentResidue,
@@ -455,48 +464,40 @@ function rawCloserRe(name: string): RegExp {
 
 // The single lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be
 // FAKE. structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, and it can
-// drop the backslash of a `\"` inside a string attribute — either way an opener's REAL end can leak
-// PAST `k`. Two mutually-exclusive tells over the opener residue (from `nameEnd`) each enable ONE branch
-// of a forward scan from `k`; a clean opener trips neither and this returns -1 so `k` stays the boundary
-// and the visible intro survives:
-//   • QUOTE leak (ODD unescaped `"`) — a dropped `\"` (`title="a \" > X"` → `title="a " > X"`) desyncs
-//     the quotes; the string's real close leaks as a `">` glued to the true tag `>`.
-//   • BRACKET leak (EVEN `"`) — a `\{…}` attribute expression leaked a close (`value=\{x } > X / 2}>`).
-//     A quote-aware bracket count (escaped-open `\{`/`\[` = +1, bare `}`/`]` = −1) going NEGATIVE marks it.
-// BOTH the tell pre-count and the forward scan are LEXICALLY SAFE: a regex literal `/…/`, a `/* … */` /
-// `// …` comment inside a `{…}` attribute, and a code span `` `…` `` are skipped, so a literal `}` / `]`
-// / `>` / quote in `pattern={/[}>]/}` or `x={/* } */ 1}` never miscounts. A DOUBLE structural close
-// glued to `>` (`)}>` / `]}>` / `}}>`) is an unambiguous leak in either branch. `}` after a closed
-// string / object operand is division, not a regex — matched by regexEnd's operand awareness.
+// drop the backslash of a `\"` / `\'` inside a string attribute — either way an opener's REAL end can
+// leak PAST `k`. Both tells are OPENER-LOCAL (derived from the span `nameEnd..k`, never the visible
+// body) and single/double-quote consistent; a clean opener trips neither, so this returns -1 and `k`
+// stays the boundary (the visible intro survives):
+//   • QUOTE leak — the span ENDS with `["']\s+>`: a dropped quote-backslash closed the string one char
+//     early (`title="a \" >…` → `title="a " >…`, `title='a \' >…` → `title='a ' >…`), so the residual
+//     value-close quote sits with whitespace before the fake `>`. A CLEAN opener glues its `>` to the
+//     last attribute token (`a="1">`), so this never fires on honest intro. Recover to the leaked
+//     string's REAL close `["']\s*>` in the body.
+//   • BRACKET leak — a depth scan from `k` where structure()'s escaped opens (`\{`/`\[`) are +1 and bare
+//     closes (`}`/`]`) are −1. Honest body brackets are ALWAYS structure-escaped, so depth only goes
+//     NEGATIVE on a `}`/`]` leaked from the opener's own `{…}` attribute expression; that negative-depth
+//     close glued to `>` (`}>` / `]}>` / `)}>`) is the real end. This also covers the quote-leak variant
+//     whose corrupting quote sits PAST `k` (`value={fn("a \" } > X", …)}>` — the span looks balanced but
+//     the real end is the trailing `)}>`). Lexically safe: regex literals `/…/`, `/* … */` / `// …`
+//     comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>` never miscount.
 function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
-  const seg = text.slice(nameEnd);
-  let sq = '', quoteCount = 0, bnet = 0, bracketLeak = false, prevSig = '';
-  for (let m = 0; m < seg.length; m++) {
-    const ch = seg[m];
-    if (sq) { if (ch === '\\') { m++; continue; } if (ch === '"') quoteCount++; if (ch === sq) { sq = ''; prevSig = '"'; } continue; }
-    if (ch === '\\') { const n = seg[m + 1]; if (n === '{' || n === '[') { bnet++; prevSig = n; } m++; continue; } // structure()'s escaped opening bracket
-    if (ch === '`') { const cs = codeSpanEnd(seg, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
-    if (ch === '/' && seg[m + 1] === '*') { const e = seg.indexOf('*/', m + 2); m = e === -1 ? seg.length : e + 1; continue; }
-    if (ch === '/' && seg[m + 1] === '/') { const e = seg.indexOf('\n', m + 2); m = e === -1 ? seg.length : e; continue; }
-    if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(seg, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } } // regex only after a non-operand
-    if (ch === '"') quoteCount++;
-    if (ch === '"' || ch === "'" || ch === '`') { sq = ch; continue; }
-    if (ch === '}' || ch === ']') { bnet--; if (bnet < 0) bracketLeak = true; }
-    if (!/\s/.test(ch)) prevSig = ch;
+  if (/["']\s+>$/.test(text.slice(nameEnd, k))) {
+    for (let m = k; m < text.length; m++) {
+      const ch = text[m];
+      if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; continue; } }
+      if (ch === '"' || ch === "'") { const cq = /^["']\s*>/.exec(text.slice(m)); if (cq) return m + cq[0].length; }
+    }
   }
-  const oddQuote = quoteCount % 2 === 1;
-  if (!oddQuote && !bracketLeak) return -1;
-  let depth = 0, parity = 0, q = '';
+  let depth = 0, prevSig = '';
   for (let m = k; m < text.length; m++) {
     const ch = text[m];
-    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; continue; } }
-    const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m)); if (dbl) return m + dbl[0].length; // double structural close glued to `>` — unambiguous leak in either branch
-    if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; continue; }
-    if (oddQuote && ch === '"') { const cq = /^"\s*>/.exec(text.slice(m)); if (parity === 0 && cq) return m + cq[0].length; parity ^= 1; continue; }
-    if (bracketLeak && q) { if (ch === q) q = ''; continue; }
-    if (bracketLeak && (ch === '"' || ch === "'" || ch === '`')) { q = ch; continue; }
-    if (ch === '{' || ch === '[') { depth++; continue; }
-    if (bracketLeak && (ch === '}' || ch === ']')) { depth--; const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (depth < 0 && cb) return m + cb[0].length; }
+    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
+    if (ch === '/' && text[m + 1] === '*') { const e = text.indexOf('*/', m + 2); m = e === -1 ? text.length : e + 1; continue; }
+    if (ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
+    if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } } // regex only after a non-operand
+    if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; if (n && !/\s/.test(n)) prevSig = n; continue; } // structure()'s escaped opening bracket
+    if (ch === '}' || ch === ']') { depth--; if (depth < 0) { const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (cb) return m + cb[0].length; } }
+    if (!/\s/.test(ch)) prevSig = ch;
   }
   return -1;
 }

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -147,21 +147,22 @@ export function pairResidues(chunks: string[]): Set<string> {
       // a type-argument (`factory()\<Name>()`), a constrained generic (`\<Name extends …>`), a
       // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
       // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
-      // generic and leaking the outer markup. A glued escaped opener is an IN-BODY GENERIC — never
-      // stacked — when its own tag body parses as valid TypeScript AND is UNAMBIGUOUSLY a generic:
-      // it carries a generic-only token a bare JSX opener can't (`extends`/`=`/`,`/whitespace-separated
-      // content or a nested `<`, e.g. `\<Name extends C>`, `\<Name = D>`, `\<Name, U>`, `\<Name && b`).
-      // This is a SYNTACTIC-ROLE test on the opener's OWN body only, so a following real same-name
-      // inline component's closer never drags a multi-token generic onto the stack (a non-nested
-      // generic + later real inline must both survive). A BARE `\<Name>` body (just the name, valid TS
-      // but shape-identical to a real inline opener `\<Panel>body\</Panel>`) is genuinely ambiguous, so
-      // it IS stacked and the positional stack resolves it by real nesting — a `</Name>` pops the
-      // NEAREST open `<Name>` (the real inline), leaving an unpaired bare generic that stays as prose.
-      // A real attributed component opener (`\<Panel title="x">`) is not valid TS, so it always stacks.
-      // A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` never pops).
+      // generic and leaking the outer markup.
+      // A glued escaped opener is an IN-BODY GENERIC — never
+      // stacked — when its own tag body parses as valid TypeScript AND either (a) it carries a NESTED
+      // `<` type-argument (`$Panel<U>`), an unambiguous generic tell a JSX opener's name can never hold,
+      // so it is exempt even when a later same-name closer exists; or (b) it has NO matching same-name
+      // closer LATER in this chunk (code-span-aware). The closer probe distinguishes the two otherwise-
+      // ambiguous shapes: a real inline component (`prefix\<$Panel extends X>body\</$Panel>suffix`, whose
+      // `extends`-shaped prop parses as TS) DOES have a later closer → NOT exempt → stacks and its own
+      // closer pops it. A generic that PRECEDES a real same-name inline (`\<$G>() then \<$G>x\</$G>`) also
+      // has a later closer → stacks, and positional nearest-pop hands that closer to the INNER real
+      // opener, leaving the leading generic unpaired (kept). Hierarchy + real syntax decide it, not body
+      // shape alone. A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` never pops).
       const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
       const openerBody = text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end).replace(/\/\s*$/, '');
-      const inBodyGeneric = glued && tag.esc && !tag.closing && /[\s,=<]/.test(deEscape(openerBody).trim()) && isTsGeneric(openerBody);
+      const nestedArg = /^\S+</.test(deEscape(openerBody).trim());
+      const inBodyGeneric = glued && tag.esc && !tag.closing && isTsGeneric(openerBody) && (nestedArg || !hasCloserLater(text, tag.closed ? tag.end : tag.nameEnd, tag.name));
       if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
@@ -228,8 +229,7 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     //       this signature is unambiguous leaked opener serialization, not visible prose.
     // On a confirmed-lossy opener, re-anchor to the LAST `>` before the closer and strip directly (the
     // mangled residue is ungrammatical, so grammar classification below would wrongly KEEP it as prose).
-    const attrLeak = /[\]}]{1,2}>/.test(text.slice(k, tag.nameEnd + closerAfter));
-    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)) || attrLeak)) {
+    if (glued && esc && !closing && !selfClose && closerAfter !== -1 && (!closed || bracketDesync(text.slice(tag.nameEnd, k)))) {
       const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
       if (gt > tag.nameEnd) { out += ' '; i = gt + 1; continue; }
     }
@@ -357,6 +357,25 @@ function codeSpanEnd(text: string, i: number): number {
 function rawCloserRe(name: string): RegExp {
   const body = [...name].map((c) => '\\\\?' + c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('');
   return new RegExp(`</${body}\\s*>`);
+}
+
+// Does a matching `</Name>` closer appear later in this chunk, OUTSIDE any code span? This is the
+// hierarchy signal that decides whether a glued TS-parsable opener is an in-body generic (no closer
+// of its own → exempt from the pairing stack) or a real inline component / a generic preceding a real
+// same-name inline (has a later closer → stacks, so positional nearest-pop resolves it correctly).
+// The code-span skip matters: a `` `</Name>` `` inside prose is literal text, not a real closer.
+function hasCloserLater(text: string, from: number, name: string): boolean {
+  const re = rawCloserRe(name);
+  for (let j = from; j < text.length; ) {
+    if (text[j] === '`') { const cs = codeSpanEnd(text, j); if (cs !== -1) { j = cs; continue; } }
+    const m = re.exec(text.slice(j));
+    if (!m) return false;
+    const at = j + m.index;
+    let spanned = false; // the found closer might sit inside a code span between j and at
+    for (let s = j; s < at; ) { if (text[s] === '`') { const cs = codeSpanEnd(text, s); if (cs > at) { spanned = true; j = cs; break; } if (cs !== -1) { s = cs; continue; } } s++; }
+    if (!spanned) return true;
+  }
+  return false;
 }
 
 // Is the OPENER'S OWN attribute span (what scanTag consumed between the tag name and its landing

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -160,26 +160,33 @@ export function pairResidues(chunks: string[]): Set<string> {
           for (let s = local.length - 1; s >= 0; s--) if (local[s].name === tag.name) { paired.add(local[s].key); paired.add(`${ci}:${tag.lt}`); local.length = s; popped = true; break; }
           if (!popped) for (let s = global.length - 1; s >= 0; s--) if (global[s].name === tag.name) { paired.add(global[s].key); paired.add(`${ci}:${tag.lt}`); global.length = s; break; }
         } else {
-          // Whether a leftover opener is FLOW (eligible for a later-chunk closer via `global`) vs an in-body
-          // TS generic depends on three position-independent signals, since neither position nor `>`-ends-chunk
-          // alone separates every case (structure() emits `factory()\<$Panel extends GEN>` — a generic that
-          // ends its chunk — and `prefix \<$Panel extends CROSSATTR>` — a flow opener whose body reads as TS):
-          //   G — the body is a MULTI-TOKEN valid TS generic (`$Panel extends GEN`, `T, U = …`); content only.
-          //   C — the `<` is glued to a CALL/INDEX/nested-generic RESULT (`factory()<…>`, `a[i]<…>`,
-          //       `Foo<Bar<X>>`): the char before is `)`/`]`/`>`. Such a `<` is a type-argument, never a fresh
-          //       element (an identifier or whitespace before `<` is instead a flow opener / a `<` comparison).
-          //   E — the opener's `>` ENDS the chunk (nothing but whitespace after it) — the clean flow signature.
-          // A call-glued opener (C) is an in-body type-arg (kept, never pairs). A fresh-started generic-bodied
-          // opener (G) is FLOW only when it ends the chunk (EVE's CROSSATTR); otherwise it is an in-body generic.
-          // A fresh-started non-generic opener that CLOSED (a real element `<$Panel>`, `{...spread}`) is FLOW;
-          // an unclosed one is only FLOW when its span is lossy (structure() dropped an attribute escape).
-          const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
+          // FLOW (later-chunk closer eligible, via `global`) vs an IN-BODY TS generic is a BIDIRECTIONAL
+          // decision keyed on whether a same-name flow is ALREADY OPEN — never on whether this opener's `>`
+          // ends its chunk (structure() emits `factory()\<$Panel extends GEN>` — a generic that ends its
+          // chunk — and `prefix\<$Panel extends FLOWATTR23>INTRO` — a real flow opener whose body reads as
+          // TS — indistinguishably by position):
+          //   - Same-name flow OPEN and this opener reads as in-body (glued to prose, call/index-glued, a
+          //     multi-token generic, or compact/unclosed) → it is a TS generic INSIDE that flow's body
+          //     (`type Box\<$Panel extends IDENTGEN23>`, `\<$Panel remains STARTCOMPACT23>`): NOT flow, never
+          //     pairs, so the flow's own later closer can't reach past it to mispair and the needle survives.
+          //     A CLEAN standalone same-name opener (`\<$Panel b="2">` filling its chunk) is real nested flow.
+          //   - No same-name flow open → a generic/JSX-shaped opener that is not call-glued IS this flow's
+          //     opener (`prefix\<$Panel extends FLOWATTR23>INTRO`), eligible to pair with its real later closer.
+          const beforeLt = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt);
+          const glued = beforeLt.trim() !== '';
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
-          const callGlued = /[)\]>]$/.test(text.slice(0, tag.esc ? tag.lt - 1 : tag.lt));
-          const endsChunk = tag.closed && text.slice(tag.end).trim() === '';
+          const callGlued = /[)\]>]$/.test(beforeLt); // `)`/`]`/`>` before `<` ⇒ a type-argument, never a fresh element
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
-          const flow = lossy || (!callGlued && (generic ? endsChunk : tag.closed));
+          const sameOpen = global.some((g) => g.name === tag.name) || local.some((l) => l.name === tag.name && l.endsChunk);
+          const inBody = sameOpen && (glued || callGlued || generic || !tag.closed);
+          const flow = !inBody && !callGlued && (lossy || generic || tag.closed);
+          // A same-name UNCLOSED in-body generic reads as a JSX opener to the per-chunk grammar (`\<$Panel
+          // remains STARTCOMPACT23` = two bare attrs) and would be wrongly stripped by stripComponentResidue,
+          // which has no cross-chunk flow context. Record it as a `keep:` position so sanitize preserves it.
+          // Closed in-body generics (`\<$Panel extends IDENTGEN23>`, call-glued `factory()\<$Panel<G>>()`) are
+          // already kept by sanitize's grammar fallback — don't `keep:` them, that would truncate nested `<…>`.
+          if (inBody && !tag.closed) paired.add(`keep:${ci}:${tag.lt}`);
           local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow });
         }
       }
@@ -215,24 +222,29 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     let { esc, closed, end: k } = tag;
     const { lt, closing, selfClose } = tag;
     const isPaired = paired.has(`${chunkIndex}:${lt}`); // positionally matched with a closer → component
+    // A same-name UNCLOSED in-body TS generic that pairResidues recognized as flow-INTERNAL content
+    // (`\<$Panel remains STARTCOMPACT23` inside an open same-name flow) — keep it verbatim; the per-chunk
+    // grammar below can't see the cross-chunk flow context and would wrongly strip it as a fresh opener.
+    if (paired.has(`keep:${chunkIndex}:${lt}`)) { out += deEscape(text.slice(lt)); i = text.length; continue; }
     const glued = out.trim() !== ''; // real prose precedes this `<` in the same chunk
     // A positionally-paired opener whose closer lives in ANOTHER chunk is a genuine cross-chunk FLOW
     // opener residue: structure() split the component around a nested heading, so it
     // emitted the WHOLE opening tag (name + all attributes) as this chunk while body and closer became
     // LATER chunks. `isPaired` (a real `</Name>` residue matched it in another chunk) confirms it, and
     // `closerAfter === -1` confirms NO closer lives in THIS chunk (so it is not a self-contained inline
-    // element). Strip from `<` to the LAST `>` in this chunk — a lossy attribute (structure() dropped a
-    // quote/bracket escape) makes scanTag stop at a FAKE early `>` still inside the attribute string
-    // (`… } > SINGLELEAK", x)}>`, `… ]} > LUCKY", "c"]}>`), but the tag's REAL `>` is always the last one;
-    // a clean opener (`\<$Panel>FLOWINTRO`) has a single `>`, so last == k and its intro survives. This
-    // needs NO visible-body scan, so an honest code span `` `arr[i]}>0` `` in a DIFFERENT chunk is untouched.
-    // A whole-chunk `<const dataÉ="x">` / `<out T="x">` is shape-identical to a valid TS generic, stays
-    // UNpaired, and is kept by the grammar branches below.
+    // element). Strip ONLY the opener tag, using a boundary from the OPENER'S OWN scan — never the whole
+    // chunk's `lastIndexOf('>')`, which eats honest intro that itself contains a `>` (a comparison
+    // `\<$Panel>LEFT arr\[i]>0 RIGHT`, a code span `` `arr[i]}>0` ``, a nested-opener intro). For a CLEAN
+    // opener scanTag's `>` (`k`) is the real tag end, so strip `[lt, k)` and the visible intro after it
+    // survives. Only a LOSSY opener — whose own consumed span (`nameEnd..k`) is bracket/quote-desynced
+    // because structure() dropped an attribute escape and scanTag stopped at a FAKE early `>` still inside
+    // the attribute string (`… } > SINGLELEAK", x)}>`) — has its REAL `>` later, so fall back to the last
+    // `>`. This reads only the opener's serialization, never scans the visible body.
     const closerRe = rawCloserRe(tag.name);
     const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` (escape-tolerant), offset relative to nameEnd
     if (isPaired && !closing && !selfClose && closerAfter === -1) {
-      const lastGt = text.lastIndexOf('>');
-      out += ' '; i = lastGt >= k - 1 ? lastGt + 1 : k;
+      const lossyOpener = !closed || bracketDesync(text.slice(tag.nameEnd, k));
+      out += ' '; i = lossyOpener ? text.lastIndexOf('>') + 1 : k;
       continue;
     }
     // Lossy `>`-recovery for a GLUED opener whose matching `</Name>` sits LATER IN THIS CHUNK.
@@ -398,8 +410,9 @@ function rawCloserRe(name: string): RegExp {
 // early at a fake `>` inside the corrupted attribute, leaving unmatched / mismatched brackets. This
 // is a quote-AWARE, TYPE-checked bracket stack over the OPENER span ONLY (never the visible body —
 // the caller passes `nameEnd..k`, so a body apostrophe / stray `[` can't misfire, EVE's round-18 &
-// round-20 counterexamples). `{`/`[` must close with the matching `}`/`]`; a leftover open bracket,
-// a mismatch, or an unterminated quote all mark desync.
+// round-20 counterexamples). `{`/`[`/`(` must close with the matching `}`/`]`/`)`; a leftover open
+// bracket, a mismatch, or an unterminated quote all mark desync. Parens catch a dropped string-quote
+// that leaves a call like `fn(` unbalanced (EVE's single-close `value={fn("a " } > SINGLELEAK", x)}>`).
 function bracketDesync(seg: string): boolean {
   const stack: string[] = [];
   let quote = '';
@@ -408,9 +421,10 @@ function bracketDesync(seg: string): boolean {
     if (ch === '\\') { ch = seg[m + 1] ?? ''; m++; if (quote) continue; }
     else if (quote) { if (ch === quote) quote = ''; continue; }
     else if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
-    if (ch === '{' || ch === '[') stack.push(ch);
+    if (ch === '{' || ch === '[' || ch === '(') stack.push(ch);
     else if (ch === '}') { if (stack.pop() !== '{') return true; }
     else if (ch === ']') { if (stack.pop() !== '[') return true; }
+    else if (ch === ')') { if (stack.pop() !== '(') return true; }
   }
   return stack.length !== 0 || quote !== '';
 }

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -136,19 +136,18 @@ export function pairResidues(chunks: string[]): Set<string> {
   const paired = new Set<string>();
   // Two stacks decide the real hierarchy on the COMPLETE chunk stream. `global` pairs a FLOW
   // component's opener with its closer ACROSS chunks; `local` (rebuilt per chunk) pairs an INLINE
-  // component within one chunk. The distinction is structure()'s own serialization: it emits a flow
-  // opener as a chunk that ENDS at the opener's `>` (heading/body/closer become later chunks), whereas
-  // an in-body TS generic (`factory()\<$Panel extends GEN>()`, `a\<$Panel>b`) and a self-contained
-  // inline element (`\<$Panel>x\</$Panel>`) both sit MID-chunk with more text after the `>`. So a
-  // closer pops the nearest same-name LOCAL opener first (real inline nesting), then the GLOBAL one
-  // (flow). An unclosed leftover opener joins `global` ONLY if its `>` ended its chunk — the flow
-  // signature; a mid-chunk leftover is an in-body generic and is dropped from pairing entirely, so a
-  // later flow closer can never reach past it to mispair (EVE's outer→generic→inline→outer-closer
-  // case) and a cross-chunk flow JSX opener is still paired by its real later-chunk closer (never
-  // mistaken for a generic just because THIS chunk holds no closer). Code-span aware throughout.
-  const global: { name: string; key: string }[] = [];
+  // component within one chunk. A closer pops the NEAREST same-name opener (LOCAL first, then GLOBAL) —
+  // real LIFO nesting, never a name-set membership test — so a prior stale generic left on `global`
+  // is out-competed by the real flow opener that sits nearer the closer (EVE's `STALEGEN24` →
+  // `FLOWINTRO24` case: the lone `</$Panel>` pops the nearer flow, the stale generic stays unpaired
+  // → kept). Each global entry records whether it is a DEFINITE flow (a bare/attr opener — a real
+  // component) or a TENTATIVE one (a generic-shaped opener that MIGHT be a stale in-body generic):
+  // only a DEFINITE same-name flow being open makes a later same-name generic in-body content (so the
+  // flow's own closer can't reach past it — EVE's `IDENTGEN23`), while a tentative generic never
+  // poisons a subsequent real flow's classification. Code-span aware throughout.
+  const global: { name: string; key: string; definite: boolean }[] = [];
   chunks.forEach((text, ci) => {
-    const local: { name: string; key: string; endsChunk: boolean }[] = [];
+    const local: { name: string; key: string; endsChunk: boolean; definite: boolean }[] = [];
     let i = 0;
     while (i < text.length) {
       if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
@@ -160,39 +159,44 @@ export function pairResidues(chunks: string[]): Set<string> {
           for (let s = local.length - 1; s >= 0; s--) if (local[s].name === tag.name) { paired.add(local[s].key); paired.add(`${ci}:${tag.lt}`); local.length = s; popped = true; break; }
           if (!popped) for (let s = global.length - 1; s >= 0; s--) if (global[s].name === tag.name) { paired.add(global[s].key); paired.add(`${ci}:${tag.lt}`); global.length = s; break; }
         } else {
-          // FLOW (later-chunk closer eligible, via `global`) vs an IN-BODY TS generic is a BIDIRECTIONAL
-          // decision keyed on whether a same-name flow is ALREADY OPEN — never on whether this opener's `>`
-          // ends its chunk (structure() emits `factory()\<$Panel extends GEN>` — a generic that ends its
-          // chunk — and `prefix\<$Panel extends FLOWATTR23>INTRO` — a real flow opener whose body reads as
-          // TS — indistinguishably by position):
-          //   - Same-name flow OPEN and this opener reads as in-body (glued to prose, call/index-glued, a
-          //     multi-token generic, or compact/unclosed) → it is a TS generic INSIDE that flow's body
-          //     (`type Box\<$Panel extends IDENTGEN23>`, `\<$Panel remains STARTCOMPACT23>`): NOT flow, never
-          //     pairs, so the flow's own later closer can't reach past it to mispair and the needle survives.
-          //     A CLEAN standalone same-name opener (`\<$Panel b="2">` filling its chunk) is real nested flow.
-          //   - No same-name flow open → a generic/JSX-shaped opener that is not call-glued IS this flow's
-          //     opener (`prefix\<$Panel extends FLOWATTR23>INTRO`), eligible to pair with its real later closer.
+          // Classify a leftover opener as one of: DEFINITE flow (a real component — bare `\<$Panel>` or
+          // attr'd `\<$Panel a="1">`), a TENTATIVE flow (a generic-SHAPED opener `\<$Panel extends X>` when
+          // no same-name flow is open — could be a real generic-shaped flow OR a stale in-body generic; a
+          // later closer decides by LIFO nearest-pop), or IN-BODY prose (never stacked — call-glued, or a
+          // generic while a DEFINITE same-name flow is already open). No decision keys on whether the
+          // opener's `>` ends its chunk (structure() emits both a generic that ends its chunk and a flow
+          // opener with trailing intro that way).
           const beforeLt = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt);
           const glued = beforeLt.trim() !== '';
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
           const callGlued = /[)\]>]$/.test(beforeLt); // `)`/`]`/`>` before `<` ⇒ a type-argument, never a fresh element
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
-          const sameOpen = global.some((g) => g.name === tag.name) || local.some((l) => l.name === tag.name && l.endsChunk);
-          const inBody = sameOpen && (glued || callGlued || generic || !tag.closed);
-          const flow = !inBody && !callGlued && (lossy || generic || tag.closed);
+          const flowOpen = global.some((g) => g.name === tag.name && g.definite) || local.some((l) => l.name === tag.name && l.endsChunk);
+          const trailing = tag.closed && text.slice(tag.end).trim() !== ''; // content after the opener's `>` in THIS chunk
+          // A same-name opener while a DEFINITE flow is open is IN-BODY prose when it is GLUED (a
+          // mid-sentence generic, `Box\<$Panel extends IDENTGEN23>`), UNCLOSED (`\<$Panel remains
+          // STARTCOMPACT23`, structure() split its `>` away), or a CLOSED generic with more content
+          // trailing in its own chunk (`\<$Panel extends GEN22C>() then …` — a real flow opener stands
+          // ALONE in its chunk, structure() splits it around the nested heading). A STANDALONE, CLOSED
+          // same-name opener is instead a real NESTED flow (`\<$Panel extends INNERATTR24>` on its own
+          // line) that must pair by LIFO. `generic` alone never forces in-body — that would swallow a
+          // generic-shaped nested flow opener.
+          const inBody = callGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
+          const definite = !generic && !glued && (tag.closed || lossy); // bare/attr'd real component, not generic-shaped
+          const flow = !inBody && (definite || lossy || generic || tag.closed);
           // A same-name UNCLOSED in-body generic reads as a JSX opener to the per-chunk grammar (`\<$Panel
           // remains STARTCOMPACT23` = two bare attrs) and would be wrongly stripped by stripComponentResidue,
           // which has no cross-chunk flow context. Record it as a `keep:` position so sanitize preserves it.
           // Closed in-body generics (`\<$Panel extends IDENTGEN23>`, call-glued `factory()\<$Panel<G>>()`) are
           // already kept by sanitize's grammar fallback — don't `keep:` them, that would truncate nested `<…>`.
           if (inBody && !tag.closed) paired.add(`keep:${ci}:${tag.lt}`);
-          local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow });
+          local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow, definite });
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
     }
-    for (const o of local) if (o.endsChunk) global.push({ name: o.name, key: o.key });
+    for (const o of local) if (o.endsChunk) global.push({ name: o.name, key: o.key, definite: o.definite });
   });
   return paired;
 }
@@ -236,15 +240,35 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // chunk's `lastIndexOf('>')`, which eats honest intro that itself contains a `>` (a comparison
     // `\<$Panel>LEFT arr\[i]>0 RIGHT`, a code span `` `arr[i]}>0` ``, a nested-opener intro). For a CLEAN
     // opener scanTag's `>` (`k`) is the real tag end, so strip `[lt, k)` and the visible intro after it
-    // survives. Only a LOSSY opener — whose own consumed span (`nameEnd..k`) is bracket/quote-desynced
-    // because structure() dropped an attribute escape and scanTag stopped at a FAKE early `>` still inside
-    // the attribute string (`… } > SINGLELEAK", x)}>`) — has its REAL `>` later, so fall back to the last
-    // `>`. This reads only the opener's serialization, never scans the visible body.
+    // survives. A LOSSY opener (structure() dropped an attribute escape, so scanTag stopped at a FAKE early
+    // `>` still inside the corrupted `\{…}` expression, `… } > SINGLELEAK", x)}>`) has its REAL end at the
+    // attribute expression's structural close GLUED to the tag `>` — a `}>` / `]}>` / `)}>` at/after `k`.
+    // That glued close is unambiguous leaked-attribute serialization (structure() escapes opening brackets
+    // but leaves closes bare, so an honest intro `>` is a BARE comparison preceded by an alnum/space — `arr\[i]>0`
+    // — never a structural close glued to `>`). Searching FROM `k` skips the fake early `>` and stops at the
+    // first real glued close, so honest intro AFTER it (including a later code span) survives. This reads
+    // only the opener's own serialized residue, never the visible body.
     const closerRe = rawCloserRe(tag.name);
     const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` (escape-tolerant), offset relative to nameEnd
     if (isPaired && !closing && !selfClose && closerAfter === -1) {
-      const lossyOpener = !closed || bracketDesync(text.slice(tag.nameEnd, k));
-      out += ' '; i = lossyOpener ? text.lastIndexOf('>') + 1 : k;
+      // scanTag can stop at a FAKE early `>` inside a corrupted attribute expression (structure()
+      // dropped a string-quote backslash so `value=\{fn("a \" } > x", y)}>` reads its inner `>` as the
+      // tag end). The attribute expression's REAL structural close then leaks past the fake `>` as a
+      // DOUBLE close glued to the true tag `>` — `)}>` / `]}>` / `}}>` — because a `\{…}`/`\[…]` nests
+      // at least two brackets. Honest intro after a clean opener never produces that OUTSIDE code: its
+      // `>` is a BARE comparison preceded by a SINGLE close at most (`arr\[i]>0` → lone `]>`), and a
+      // regex `/\(/` or comment `/* ( */` inside an honest attribute stays inside scanTag's balanced
+      // span. A code span CAN hold a literal `]}>` (`` `arr[i]}>0` ``), so the scan SKIPS code spans —
+      // a leaked attribute close is never inside one. Absent a double-close-glued-`>`, `k` is the real
+      // tag end (clean opener) and the visible intro after it survives.
+      let gc = -1;
+      for (let m = k; m < text.length; ) {
+        if (text[m] === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs; continue; } }
+        const mm = /^[)\]}]{2}\s*>/.exec(text.slice(m));
+        if (mm) { gc = m + mm[0].length; break; }
+        m++;
+      }
+      out += ' '; i = gc === -1 ? k : gc;
       continue;
     }
     // Lossy `>`-recovery for a GLUED opener whose matching `</Name>` sits LATER IN THIS CHUNK.
@@ -410,9 +434,9 @@ function rawCloserRe(name: string): RegExp {
 // early at a fake `>` inside the corrupted attribute, leaving unmatched / mismatched brackets. This
 // is a quote-AWARE, TYPE-checked bracket stack over the OPENER span ONLY (never the visible body —
 // the caller passes `nameEnd..k`, so a body apostrophe / stray `[` can't misfire, EVE's round-18 &
-// round-20 counterexamples). `{`/`[`/`(` must close with the matching `}`/`]`/`)`; a leftover open
-// bracket, a mismatch, or an unterminated quote all mark desync. Parens catch a dropped string-quote
-// that leaves a call like `fn(` unbalanced (EVE's single-close `value={fn("a " } > SINGLELEAK", x)}>`).
+// round-20 counterexamples). `{`/`[` must close with the matching `}`/`]`; a leftover open bracket,
+// a mismatch, or an unterminated quote all mark desync. Parens are intentionally NOT tracked — a
+// regex `/(/` or comment `/* ( */` inside an honest attribute would otherwise read as unbalanced.
 function bracketDesync(seg: string): boolean {
   const stack: string[] = [];
   let quote = '';
@@ -421,10 +445,9 @@ function bracketDesync(seg: string): boolean {
     if (ch === '\\') { ch = seg[m + 1] ?? ''; m++; if (quote) continue; }
     else if (quote) { if (ch === quote) quote = ''; continue; }
     else if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
-    if (ch === '{' || ch === '[' || ch === '(') stack.push(ch);
+    if (ch === '{' || ch === '[') stack.push(ch);
     else if (ch === '}') { if (stack.pop() !== '{') return true; }
     else if (ch === ']') { if (stack.pop() !== '[') return true; }
-    else if (ch === ')') { if (stack.pop() !== '(') return true; }
   }
   return stack.length !== 0 || quote !== '';
 }

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -160,15 +160,26 @@ export function pairResidues(chunks: string[]): Set<string> {
           for (let s = local.length - 1; s >= 0; s--) if (local[s].name === tag.name) { paired.add(local[s].key); paired.add(`${ci}:${tag.lt}`); local.length = s; popped = true; break; }
           if (!popped) for (let s = global.length - 1; s >= 0; s--) if (global[s].name === tag.name) { paired.add(global[s].key); paired.add(`${ci}:${tag.lt}`); global.length = s; break; }
         } else {
-          // A leftover opener is FLOW (joins `global` for a later-chunk closer) when it is a standalone
-          // residue: its `>` ends the chunk (clean flow opener), OR it is a chunk-start opener whose
-          // lossy attribute DESYNCED scanTag into stopping at a fake early `>` (bracket-unbalanced
-          // consumed span, trailing residue but nothing real precedes it). A chunk-start CLEAN opener
-          // with real trailing code (`\<$Panel extends GEN>() …`) is an in-body generic, not flow — so
-          // desync, not mere position, gates the `!glued` case. A GLUED mid-chunk leftover is likewise an
-          // in-body generic — dropped from pairing so no later closer mispairs across it.
+          // Whether a leftover opener is FLOW (eligible for a later-chunk closer via `global`) vs an in-body
+          // TS generic depends on three position-independent signals, since neither position nor `>`-ends-chunk
+          // alone separates every case (structure() emits `factory()\<$Panel extends GEN>` — a generic that
+          // ends its chunk — and `prefix \<$Panel extends CROSSATTR>` — a flow opener whose body reads as TS):
+          //   G — the body is a MULTI-TOKEN valid TS generic (`$Panel extends GEN`, `T, U = …`); content only.
+          //   C — the `<` is glued to a CALL/INDEX/nested-generic RESULT (`factory()<…>`, `a[i]<…>`,
+          //       `Foo<Bar<X>>`): the char before is `)`/`]`/`>`. Such a `<` is a type-argument, never a fresh
+          //       element (an identifier or whitespace before `<` is instead a flow opener / a `<` comparison).
+          //   E — the opener's `>` ENDS the chunk (nothing but whitespace after it) — the clean flow signature.
+          // A call-glued opener (C) is an in-body type-arg (kept, never pairs). A fresh-started generic-bodied
+          // opener (G) is FLOW only when it ends the chunk (EVE's CROSSATTR); otherwise it is an in-body generic.
+          // A fresh-started non-generic opener that CLOSED (a real element `<$Panel>`, `{...spread}`) is FLOW;
+          // an unclosed one is only FLOW when its span is lossy (structure() dropped an attribute escape).
           const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-          const flow = !tag.closed || text.slice(tag.end).trim() === '' || (!glued && bracketDesync(text.slice(tag.nameEnd, tag.end)));
+          const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
+          const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
+          const callGlued = /[)\]>]$/.test(text.slice(0, tag.esc ? tag.lt - 1 : tag.lt));
+          const endsChunk = tag.closed && text.slice(tag.end).trim() === '';
+          const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
+          const flow = lossy || (!callGlued && (generic ? endsChunk : tag.closed));
           local.push({ name: tag.name, key: `${ci}:${tag.lt}`, endsChunk: flow });
         }
       }
@@ -205,16 +216,25 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     const { lt, closing, selfClose } = tag;
     const isPaired = paired.has(`${chunkIndex}:${lt}`); // positionally matched with a closer → component
     const glued = out.trim() !== ''; // real prose precedes this `<` in the same chunk
-    // A positionally-paired opener whose closer lives in ANOTHER chunk is a genuine cross-chunk
-    // flow residue — structure() emitted the whole opener (name + attributes) as its own standalone
-    // chunk. Its corrupted attribute can hide a `}]` that drops scanTag's brace depth to 0 at a `>`
-    // still inside the attribute string, so scanTag's `>` position is untrustworthy: the whole chunk
-    // is markup, strip it to end. (When the closer is in THIS chunk the tag is a self-contained
-    // inline element — `\<Tabs …> body </Tabs>` — so fall through to keep its body.)
+    // A positionally-paired opener whose closer lives in ANOTHER chunk is a genuine cross-chunk FLOW
+    // opener residue: structure() split the component around a nested heading, so it
+    // emitted the WHOLE opening tag (name + all attributes) as this chunk while body and closer became
+    // LATER chunks. `isPaired` (a real `</Name>` residue matched it in another chunk) confirms it, and
+    // `closerAfter === -1` confirms NO closer lives in THIS chunk (so it is not a self-contained inline
+    // element). Strip from `<` to the LAST `>` in this chunk — a lossy attribute (structure() dropped a
+    // quote/bracket escape) makes scanTag stop at a FAKE early `>` still inside the attribute string
+    // (`… } > SINGLELEAK", x)}>`, `… ]} > LUCKY", "c"]}>`), but the tag's REAL `>` is always the last one;
+    // a clean opener (`\<$Panel>FLOWINTRO`) has a single `>`, so last == k and its intro survives. This
+    // needs NO visible-body scan, so an honest code span `` `arr[i]}>0` `` in a DIFFERENT chunk is untouched.
+    // A whole-chunk `<const dataÉ="x">` / `<out T="x">` is shape-identical to a valid TS generic, stays
+    // UNpaired, and is kept by the grammar branches below.
     const closerRe = rawCloserRe(tag.name);
-    const closerInChunk = closerRe.test(text.slice(k));
     const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` (escape-tolerant), offset relative to nameEnd
-    if (isPaired && !glued && !closing && !selfClose && !closerInChunk) { i = text.length; out = out.trimEnd(); continue; }
+    if (isPaired && !closing && !selfClose && closerAfter === -1) {
+      const lastGt = text.lastIndexOf('>');
+      out += ' '; i = lastGt >= k - 1 ? lastGt + 1 : k;
+      continue;
+    }
     // Lossy `>`-recovery for a GLUED opener whose matching `</Name>` sits LATER IN THIS CHUNK.
     // structure() can drop the escaping backslash of a quote/template inside an opener's attribute,
     // desyncing scanTag's quote tracking. structure() markdown-escapes EVERY opening bracket (`\{`,

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -141,13 +141,18 @@ export function pairResidues(chunks: string[]): Set<string> {
       if (text[i] === '`') { let f = 0; while (text[i + f] === '`') f++; const e = text.indexOf(text.slice(i, i + f), i + f); i = e === -1 ? text.length : e + f; continue; }
       const tag = scanTag(text, i);
       if (!tag) { i++; continue; }
-      // A tag whose name is immediately followed by a top-level `,` (`<Name, U>` — a type-argument
-      // list like `factory()<𐐀Panel, INNER>()`) is a TS generic, NEVER a JSX opener, so it must not
-      // enter the pairing stack: otherwise a same-named inner generic inside a component's body would
-      // be popped by the outer `</Name>` instead of the real opener. Skip it (advance past it).
-      const afterName = text.slice(tag.nameEnd, tag.closed ? tag.end - 1 : tag.end).trimStart();
-      const isGenericArgList = afterName.startsWith(',');
-      if (!tag.selfClose && !isGenericArgList) {
+      // Only a STANDALONE residue opener enters the pairing stack. structure() emits a flow
+      // component's opener/closer residue as its own chunk (leading `\` aside), whereas a `\<Name …>`
+      // GLUED to preceding code in the same text run is a TS construct structure() escaped as prose —
+      // a type-argument (`factory()\<Name>()`), a constrained generic (`\<Name extends …>`), a
+      // comparison (`a\<Name`) or a nested first-param (`\<Name\<U>>`). Pushing such a same-named
+      // in-body generic lets the outer `</Name>` pop IT instead of the real opener, deleting the
+      // generic and leaking the outer markup. Skip a glued ESCAPED tag UNLESS its own matching
+      // closer sits later in THIS chunk — a real inline component (`prefix\<Panel …>b</Panel>suffix`)
+      // carries its closer in-chunk, but an in-body generic never does (its `</Name>` is elsewhere).
+      const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
+      const inBodyGeneric = glued && tag.esc && !new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(text.slice(tag.closed ? tag.end : tag.nameEnd));
+      if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
       }
@@ -184,15 +189,26 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     const { lt, closing, selfClose } = tag;
     const isPaired = paired.has(`${chunkIndex}:${lt}`); // positionally matched with a closer → component
     const glued = out.trim() !== ''; // real prose precedes this `<` in the same chunk
+    // A positionally-paired opener whose closer lives in ANOTHER chunk is a genuine cross-chunk
+    // flow residue — structure() emitted the whole opener (name + attributes) as its own standalone
+    // chunk. Its corrupted attribute can hide a `}]` that drops scanTag's brace depth to 0 at a `>`
+    // still inside the attribute string, so scanTag's `>` position is untrustworthy: the whole chunk
+    // is markup, strip it to end. (When the closer is in THIS chunk the tag is a self-contained
+    // inline element — `\<Tabs …> body </Tabs>` — so fall through to keep its body.)
+    const closerInChunk = new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(text.slice(k));
+    if (isPaired && !glued && !closing && !selfClose && !closerInChunk) { i = text.length; out = out.trimEnd(); continue; }
     // Lossy `>`-recovery: structure() can drop the escaping backslash of a quote/template
     // inside an opener's attribute, so scanTag's quote tracking desyncs and never sees the
     // real closing `>` (closed=false, body swallows the element's own text + suffix). Recover
     // by cutting at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name — the
     // brace/bracket escapes survive the lossy collapse even when the quotes do not, so a `>`
-    // hiding inside `items={["a > b"]}` is skipped and the real tag end is found. For an escaped
-    // opener only when GLUED (real prose/body shares the chunk) or positionally paired; a
-    // standalone escaped UNCLOSED opener is whole-element residue, stripped to end below.
-    if (!closed && (isPaired || !esc || glued)) {
+    // hiding inside `items={["a > b"]}` is skipped and the real tag end is found. Run recovery
+    // ONLY for a GLUED or non-escaped opener — there recovery preserves genuine in-chunk suffix.
+    // A STANDALONE escaped lossy opener has no real suffix in its own chunk: the desynced quotes
+    // mean the hunt can stop at a `>` still inside the corrupted attribute string and expose fake
+    // suffix (`items={["a }] > LEAK"]}>` → `LEAK"]}>`), so leave it unclosed and let the escaped
+    // strip-to-end branch below drop the whole residue.
+    if (!closed && (!esc || glued)) {
       let depth = 0;
       for (let m = tag.nameEnd; m < text.length; m++) {
         const ch = text[m];

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -170,7 +170,7 @@ export function pairResidues(chunks: string[]): Set<string> {
   // budget reserves one slot per standalone generic and a glued generic only stacks on the surplus
   // ABOVE that reserve (EVE's STALEFIRST28: a leading glued generic must not steal the lone closer that
   // belongs to a later standalone real flow).
-  const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>(), standaloneGenerics = new Map<string, number>();
+  const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>(), standaloneGenerics = new Map<string, number>(), gluedGenerics = new Map<string, number>();
   chunks.forEach((text) => {
     let i = 0;
     while (i < text.length) {
@@ -182,21 +182,27 @@ export function pairResidues(chunks: string[]): Set<string> {
         else {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const isGeneric = /[\s,=]/.test(inner) && isTsGeneric(inner);
-          // A GLUED opener is only a real component when its own `>` is immediately followed by glued
-          // body (a name-start / `<` / structure-escaped `\`) or ends the chunk (a split-flow opener) —
-          // a prose TS instantiation / generic reads with whitespace or punctuation after `>` (`Box<$Panel>
-          // holds`, `Technical<$Panel extends X>.`) and must NOT be counted as an opener that claims a closer.
+          // A GLUED closed opener is prose (a TS instantiation / type-argument — `Box<$Panel>`,
+          // `Foo<Bar, Baz>`) only when `name<inner>` parses in OPERAND position (a call `f<…>()` or a
+          // relational `a<…>b`) — the glue proves an operand sits before `<`. A residue opener never does
+          // (`$Panel extends X`, `$Panel a="1"` reject in operand position), so it is NOT skipped here. No
+          // guess on the char AFTER `>`: a real flow opener's visible intro may start with a space, digit or
+          // punctuation, which a char whitelist wrongly rejected.
           const gluedOpener = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-          // A LOSSY opener's `>` (`tag.end`) is a FAKE early one still inside a corrupted attribute, so the
-          // char after it is meaningless — only trust the body-glued tell on a clean, EXPRESSION-free opener.
-          // An opener carrying a `{…}`/`[…]` attribute expression (structure escapes its open as `\{`/`\[`)
-          // is a JSX component regardless of what follows a possibly-fake `>`.
+          // A LOSSY opener's `>` (`tag.end`) is a FAKE early one still inside a corrupted attribute; an
+          // opener carrying a `{…}`/`[…]` attribute expression (structure escapes its open as `\{`/`\[`) is
+          // a JSX component — neither is a prose generic, so both keep counting as a real opener.
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !gluedOpener;
           const hasExprAttr = /\\[{[]/.test(text.slice(tag.nameEnd, tag.end));
-          const bodyGlued = !tag.closed || lossy || hasExprAttr || text[tag.end] === undefined || /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
-          if (gluedOpener && !bodyGlued) { i = tag.closed ? tag.end : tag.nameEnd; continue; } // prose generic/instantiation, not a residue
+          // Real component body glued right after `>` (a name-start / `<` / structure escape) is a split-flow
+          // opener whose visible intro glued — keep it. This is the ONLY sound char-after-`>` signal; the
+          // chunk-end case is NOT one (a prose instantiation like `Box<$Panel>` also ends its chunk).
+          const nameStartGlued = /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
+          const proseGlued = gluedOpener && tag.closed && !lossy && !hasExprAttr && !nameStartGlued && gluedGeneric(inner);
+          if (proseGlued) { i = tag.closed ? tag.end : tag.nameEnd; continue; } // prose instantiation/type-argument, not a residue
           if (!isGeneric) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
           else if (!gluedOpener) standaloneGenerics.set(tag.name, (standaloneGenerics.get(tag.name) ?? 0) + 1);
+          else gluedGenerics.set(tag.name, (gluedGenerics.get(tag.name) ?? 0) + 1);
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
@@ -204,6 +210,12 @@ export function pairResidues(chunks: string[]): Set<string> {
   });
   const genericFlowBudget = new Map<string, number>(), standaloneReserve = new Map(standaloneGenerics);
   for (const [name, c] of closers) genericFlowBudget.set(name, c - (nonGenericOpeners.get(name) ?? 0));
+  // How many GLUED generics of each name may stack as flow (the surplus above the standalone reserve),
+  // and how many remain UNSEEN as the main pass advances. LIFO gives a scarce closer to the NEAREST
+  // (latest) opener, so a glued generic stacks only once the remaining-unseen count has dropped to its
+  // winning quota — the LAST `gluedSlots` win, not the first (fixes leading-generic order bias).
+  const gluedSlots = new Map<string, number>(), gluedRemaining = new Map(gluedGenerics);
+  for (const [name, n] of gluedGenerics) gluedSlots.set(name, Math.max(0, Math.min(n, (genericFlowBudget.get(name) ?? 0) - (standaloneGenerics.get(name) ?? 0))));
   chunks.forEach((text, ci) => {
     const local: { name: string; key: string; endsChunk: boolean; definite: boolean; generic: boolean }[] = [];
     let i = 0;
@@ -235,13 +247,14 @@ export function pairResidues(chunks: string[]): Set<string> {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
           const callGlued = /[)\]>]$/.test(beforeLt); // `)`/`]`/`>` before `<` ⇒ a type-argument, never a fresh element
-          // A GLUED closed opener is prose (a TS instantiation / generic — `Box\<$Panel> holds`,
-          // `Technical\<$Panel extends X>.`) unless its `>` is followed by glued component body (a
-          // name-start / `<` / escape) or ends the chunk (a split-flow opener). Mirrors the pre-scan's
-          // budget count so a prose generic never competes with a real same-name flow for the closer.
-          const bodyGlued = !tag.closed || /\\[{[]/.test(text.slice(tag.nameEnd, tag.end)) || text[tag.end] === undefined || /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
+          // A GLUED closed opener is prose (a TS instantiation / type-argument — `Box<$Panel>`,
+          // `Foo<Bar, Baz>`) only when `name<inner>` parses in OPERAND position. Mirrors the pre-scan's
+          // budget count so a prose generic never competes with a real same-name flow for the closer. No
+          // guess on the char after `>`: a real flow opener's visible intro may start with any character.
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
-          const proseGlued = glued && tag.closed && !lossy && !bodyGlued;
+          const hasExprAttr = /\\[{[]/.test(text.slice(tag.nameEnd, tag.end));
+          const nameStartGlued = /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
+          const proseGlued = glued && tag.closed && !lossy && !hasExprAttr && !nameStartGlued && gluedGeneric(inner);
           const flowOpen = global.some((g) => g.name === tag.name && g.definite) || local.some((l) => l.name === tag.name && l.endsChunk && l.definite);
           const trailing = tag.closed && text.slice(tag.end).trim() !== ''; // content after the opener's `>` in THIS chunk
           // A same-name opener while a DEFINITE flow is open is IN-BODY prose when it is GLUED (a
@@ -255,11 +268,14 @@ export function pairResidues(chunks: string[]): Set<string> {
           const inBody = callGlued || proseGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
           const definite = !generic && !glued && (tag.closed || lossy); // bare/attr'd real component, not generic-shaped
           // A generic-shaped opener stacks as flow only while a same-name closer remains for it (see
-          // genericFlowBudget). A STANDALONE generic draws its own reserved slot; a GLUED one only stacks
-          // on the surplus ABOVE the still-unclaimed standalone reserve, so a leading technical generic
-          // can't steal the closer a later standalone real flow needs (EVE's STALEFIRST28).
+          // genericFlowBudget). A STANDALONE generic draws its own reserved slot; a GLUED one stacks only
+          // when it is among the LAST `gluedSlots` glued generics of its name — the nearest closer pops the
+          // nearest opener by LIFO, so an earlier glued generic can't steal a later flow's closer regardless
+          // of source order (EVE round-30 STALEGLUED29 → REALGLUED29 order-independence).
           const budget = genericFlowBudget.get(tag.name) ?? 0, reserve = standaloneReserve.get(tag.name) ?? 0;
-          const genericFlow = !inBody && generic && tag.closed && budget > 0 && (!glued || budget > reserve);
+          if (generic && glued && tag.closed) { const r = (gluedRemaining.get(tag.name) ?? 0) - 1; gluedRemaining.set(tag.name, r); }
+          const gluedWins = !glued || (gluedRemaining.get(tag.name) ?? 0) < (gluedSlots.get(tag.name) ?? 0);
+          const genericFlow = !inBody && generic && tag.closed && budget > 0 && (!glued || budget > reserve) && gluedWins;
           if (genericFlow) { genericFlowBudget.set(tag.name, budget - 1); if (!glued && reserve > 0) standaloneReserve.set(tag.name, reserve - 1); }
           const flow = !inBody && (definite || lossy || (generic ? genericFlow : tag.closed));
           // A same-name UNCLOSED in-body generic reads as a JSX opener to the per-chunk grammar (`\<$Panel
@@ -432,6 +448,18 @@ function isTsGeneric(body: string): boolean {
   return clean(`type _<${inner}> = 0;`) || clean(`f<${inner}>();`) || clean(`x = a<${inner}>b;`);
 }
 
+// Does `name<inner>` parse as a generic in OPERAND position — a call `f<…>()` or a relational
+// `a<…>b`, but NOT the standalone type-parameter-list context? A GLUED opener (`Box<$Panel>`,
+// `Foo<Bar, Baz>` — real prose preceding `<`) sits after an operand, so a valid operand-position
+// parse proves it is a TS instantiation / type-argument, not component residue. A residue opener
+// (`$Panel extends X`, `$Panel a="1"`) rejects in operand position. This is the grammar signal that
+// replaces guessing the opener's role from the character after its `>`.
+function gluedGeneric(inner: string): boolean {
+  const s = deEscape(inner).replace(/\s+/g, ' ').trim();
+  const clean = (src: string) => ((ts.createSourceFile('t.ts', src, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS) as ts.SourceFile & { parseDiagnostics?: unknown[] }).parseDiagnostics ?? []).length === 0;
+  return clean(`f<${s}>();`) || clean(`x = a<${s}>b;`);
+}
+
 function opensJsxElement(body: string): boolean {
   const inner = deEscape(body).replace(/\s+/g, ' ').trim();
   if (isTsGeneric(body)) return false; // valid TS → prose, keep
@@ -537,7 +565,10 @@ function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
     let m = k;
     for (; m < text.length; m++) { const ch = text[m]; if (ch === '\\') { m++; continue; } if (ch === leakQuote[1]) { m++; break; } }
     const end = scanToTagEnd(text, m);
-    if (end !== -1) return end;
+    // Accept the recovery ONLY when the recovered `>` looks like a REAL opener end: glued to body
+    // (next char non-space) or ending the chunk. A clean opener's `>` (at `k`) already IS the end, and
+    // scanning its visible body would land on a body `">` whose `>` is followed by whitespace — reject.
+    if (end !== -1 && (end >= text.length || !/\s/.test(text[end] ?? ''))) return end;
   }
   // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
   // (structure() escapes its open as `\{`/`\[`). A clean string-only attribute opener (`a="1">`) has
@@ -551,7 +582,7 @@ function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
     if (ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
     if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } } // regex only after a non-operand
     if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; if (n && !/\s/.test(n)) prevSig = n; continue; } // structure()'s escaped opening bracket
-    if (ch === '}' || ch === ']') { depth--; if (depth < 0) { const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (cb) return m + cb[0].length; } }
+    if (ch === '}' || ch === ']') { depth--; if (depth < 0) { const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (cb) { const e = m + cb[0].length; if (e >= text.length || !/\s/.test(text[e] ?? '')) return e; } } }
     if (!/\s/.test(ch)) prevSig = ch;
   }
   return -1;

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -153,7 +153,7 @@ export function pairResidues(chunks: string[]): Set<string> {
       // A CLOSING tag is never a generic, so it must always pair (else a glued `\</$Panel>` whose
       // suffix has no further closer would be skipped and its opener never pops).
       const glued = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
-      const inBodyGeneric = glued && tag.esc && !tag.closing && !new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`).test(deEscape(text.slice(tag.closed ? tag.end : tag.nameEnd)));
+      const inBodyGeneric = glued && tag.esc && !tag.closing && !rawCloserRe(tag.name).test(outsideCode(text.slice(tag.closed ? tag.end : tag.nameEnd)));
       if (!tag.selfClose && !inBodyGeneric) {
         if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
         else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
@@ -197,23 +197,23 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // still inside the attribute string, so scanTag's `>` position is untrustworthy: the whole chunk
     // is markup, strip it to end. (When the closer is in THIS chunk the tag is a self-contained
     // inline element — `\<Tabs …> body </Tabs>` — so fall through to keep its body.)
-    const closerRe = new RegExp(`</${tag.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`);
+    const closerRe = rawCloserRe(tag.name);
     const closerInChunk = closerRe.test(text.slice(k));
-    const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` anywhere past the name (whole-text, not scanTag's k)
+    const closerAfter = text.slice(tag.nameEnd).search(closerRe); // matching `</Name>` (escape-tolerant), offset relative to nameEnd
     if (isPaired && !glued && !closing && !selfClose && !closerInChunk) { i = text.length; out = out.trimEnd(); continue; }
-    // Lossy `>`-recovery for a GLUED opener that has its matching `</Name>` LATER IN THIS CHUNK.
+    // Lossy `>`-recovery for a GLUED opener whose matching `</Name>` sits LATER IN THIS CHUNK.
     // structure() can drop the escaping backslash of a quote/template inside an opener's attribute,
     // desyncing scanTag's quote tracking. structure() markdown-escapes EVERY opening bracket (`\{`,
     // `\[`) — structural AND string-content alike — but leaves closes bare, so a brace/bracket-depth
     // scan is fooled by unbalanced brackets inside the corrupted attribute STRING: `items={["a }] > x"]}>`
     // under-counts and scanTag cuts EARLY at the string-internal `>` (attr residue leaks as fake suffix),
-    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed). A lossy
-    // escaped backtick can even desync the code-span skip so pairing misses the opener entirely. The
-    // in-chunk `</Name>` is escape-free and a reliable anchor: the opener's real `>` is the LAST `>`
-    // before that closer (the visible body carries no tag punctuation). Re-anchor there — overriding
-    // scanTag's `>`, which may be the fake one — and keep the in-chunk body/suffix. Depends only on the
-    // closer's presence, not on pairing, so it survives the code-span desync too.
-    if (glued && !closing && !selfClose && closerAfter !== -1) {
+    // while `items={["a { [ x"]}>` over-counts so scanTag never closes (body+suffix swallowed).
+    // Re-anchor the real `>` to the LAST `>` before that closer — but ONLY for a CONFIRMED-DESYNC
+    // opener: scanTag never reached the closer (`!closed`), or the region it left between its `>` and
+    // the closer is UNBALANCED (leaked string/bracket residue). A clean glued opener's visible body can
+    // legitimately hold a `>` (`LEFT > RIGHT`), an entity, or a nested inline tag — re-anchoring it would
+    // delete that body, so leave scanTag's honest `>` untouched.
+    if (glued && !closing && !selfClose && closerAfter !== -1 && (!closed || !balancedBody(text.slice(k, tag.nameEnd + closerAfter)))) {
       const gt = text.lastIndexOf('>', tag.nameEnd + closerAfter);
       if (gt > tag.nameEnd) { k = gt + 1; closed = true; }
     }
@@ -257,12 +257,14 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
     // the ones the TS grammar rejects (`<const dataÉ="x">`, whose `dataÉ` is not a type param).
     if (closed && standalone && hasAttrShape(body) && !isTsGeneric(body)) { out += ' '; i = k; continue; }
     // KEEP: this `<…>` is prose (a TS generic / type-argument / comparison / placeholder).
-    // A multi-token body (`keyof X`, `T, U = …`, `a instanceof B`) or a qualified name
-    // (`ns.Member`) parses as a JSX element downstream and would be silently dropped, so
-    // emit its `<` as `&lt;` (decodeContentEntities restores a searchable `<`). A bare
-    // single-name opener (`<T>`, `<version>`, and residual `<Step>` component markup) keeps
-    // the old literal path — the parser drops the stray tag, matching prior behavior.
-    if (closed && /[\s,=]|\.[A-Za-z_$]/.test(deEscape(body).trim())) { out += '&lt;'; i = lt + 1; continue; }
+    // A multi-token body (`keyof X`, `T, U = …`, `a instanceof B`), a qualified name
+    // (`ns.Member`), a nested type-argument (`Foo<Bar` — body carries a `<`) or a nested
+    // generic CLOSE (`Bar` in `Foo<Bar>>`, the char past `>` is another `>`) parses as a JSX
+    // element downstream and would be silently dropped, so emit its `<` as `&lt;`
+    // (decodeContentEntities restores a searchable `<`). A bare single-name opener (`<T>`,
+    // `<version>`, and residual `<Step>` component markup) keeps the old literal path — the
+    // parser drops the stray tag, matching prior behavior.
+    if (closed && (/[\s,=<]|\.[A-Za-z_$]/.test(deEscape(body).trim()) || text[k] === '>')) { out += '&lt;'; i = lt + 1; continue; }
     out += c; i++;
   }
   return out;
@@ -310,6 +312,44 @@ function opensJsxElement(body: string): boolean {
 // sniff see the real tag text.
 function deEscape(s: string): string {
   return s.replace(/\\([^0-9A-Za-z\s])/g, '$1');
+}
+
+// A `</Name>` closer regex tolerant of structure()'s per-char markdown escaping (`</\_Panel>`,
+// `</\$Panel>`), so a custom-name closer is located directly in RAW text and its match offsets
+// stay in raw space — no deEscape/offset remapping needed. Iterates code points (astral-safe).
+function rawCloserRe(name: string): RegExp {
+  const body = [...name].map((c) => '\\\\?' + c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('');
+  return new RegExp(`</${body}\\s*>`);
+}
+
+// Blank out code-span regions so a `</Name>` inside `` `…` `` isn't counted when probing whether
+// a glued opener carries its own closer later in the chunk (else a fake code-span closer makes an
+// in-body generic look like a real inline component and mispairs with the outer closer).
+function outsideCode(text: string): string {
+  let out = '', i = 0;
+  while (i < text.length) {
+    if (text[i] === '`') { let f = 0; while (text[i + f] === '`') f++; const e = text.indexOf(text.slice(i, i + f), i + f); i = e === -1 ? text.length : e + f; continue; }
+    out += text[i++];
+  }
+  return out;
+}
+
+// Does a candidate body region (between scanTag's `>` and the real closer) carry balanced quotes
+// and brackets? A CLEAN component body is visible prose — balanced, possibly with a stray `>`. A
+// LOSSY opener whose corrupted attribute leaked past scanTag's fake `>` exposes unbalanced string /
+// bracket residue (`… "c"]}`). Used ONLY to gate the closer anchor so it never re-cuts a clean
+// glued opener's real body (which may legitimately contain `>`, entities, nested inline tags).
+function balancedBody(seg: string): boolean {
+  let quote = '', depth = 0;
+  for (let m = 0; m < seg.length; m++) {
+    const ch = seg[m];
+    if (ch === '\\') { m++; continue; }
+    if (quote) { if (ch === quote) quote = ''; continue; }
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{' || ch === '[') depth++;
+    else if (ch === '}' || ch === ']') { if (depth === 0) return false; depth--; }
+  }
+  return quote === '' && depth === 0;
 }
 
 // Unambiguous JSX-opener body: an `attr={…}` JSX expression or a `{...spread}`. Neither can

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -115,10 +115,11 @@ function scanTag(text: string, i: number): Tag | null {
     // Inside a `{…}` expression, a `/` starts a comment or (when not a division operator) a regex
     // literal whose body can hold literal `}` / `>` (`pattern=\{/\[}>]/}`). Skip those runs so their
     // punctuation can't be mistaken for the expression/tag close — structure() preserves the `{…}`
-    // intact, so this stays deterministic. A `/` after an operand (ident / `)` / `]`) is division.
+    // intact, so this stays deterministic. A `/` after an operand (ident / `)` / `]` / `}` — a closed
+    // object or block literal, `\{{w:1}/2\}` — or a string) is division, NOT a regex.
     if (brace > 0 && ch === '/' && text[k + 1] === '*') { const e = text.indexOf('*/', k + 2); k = e === -1 ? text.length : e + 2; continue; }
     if (brace > 0 && ch === '/' && text[k + 1] === '/') { const e = text.indexOf('\n', k + 2); k = e === -1 ? text.length : e; continue; }
-    if (brace > 0 && ch === '/' && !/[\w$)\]"'`]/.test(prevSig)) {
+    if (brace > 0 && ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) {
       let m = k + 1, cls = false;
       for (; m < text.length; m++) { const r = text[m]; if (r === '\\') { m++; continue; } if (r === '[') cls = true; else if (r === ']') cls = false; else if (r === '/' && !cls) break; }
       k = m + 1; prevSig = '/'; continue;
@@ -158,6 +159,31 @@ export function pairResidues(chunks: string[]): Set<string> {
   // flow's own closer can't reach past it — EVE's `IDENTGEN23`), while a tentative generic never
   // poisons a subsequent real flow's classification. Code-span aware throughout.
   const global: { name: string; key: string; definite: boolean; generic: boolean }[] = [];
+  // Per-name generic-flow budget: a generic-SHAPED opener (`\<$Panel extends X>`) is a real nested
+  // flow only if a same-name closer is left over after every NON-generic opener (a real component)
+  // has claimed one. STANDALONEKEEP25 (one component + one standalone generic + ONE closer) and its
+  // byte-identical nested sibling (SAME openers + TWO closers) are indistinguishable by position
+  // under pure LIFO — the surplus closer is the only honest signal. So count `closers − nonGeneric
+  // openers` per name; only that many generic-shaped openers may stack as flow, the rest stay prose.
+  const closers = new Map<string, number>(), nonGenericOpeners = new Map<string, number>();
+  chunks.forEach((text) => {
+    let i = 0;
+    while (i < text.length) {
+      if (text[i] === '`') { const cs = codeSpanEnd(text, i); if (cs !== -1) { i = cs; continue; } }
+      const tag = scanTag(text, i);
+      if (!tag) { i++; continue; }
+      if (!tag.selfClose) {
+        if (tag.closing) closers.set(tag.name, (closers.get(tag.name) ?? 0) + 1);
+        else {
+          const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
+          if (!(/[\s,=]/.test(inner) && isTsGeneric(inner))) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
+        }
+      }
+      i = tag.closed ? tag.end : tag.nameEnd;
+    }
+  });
+  const genericFlowBudget = new Map<string, number>();
+  for (const [name, c] of closers) genericFlowBudget.set(name, c - (nonGenericOpeners.get(name) ?? 0));
   chunks.forEach((text, ci) => {
     const local: { name: string; key: string; endsChunk: boolean; definite: boolean; generic: boolean }[] = [];
     let i = 0;
@@ -167,17 +193,13 @@ export function pairResidues(chunks: string[]): Set<string> {
       if (!tag) { i++; continue; }
       if (!tag.selfClose) {
         if (tag.closing) {
-          // A closer pops the nearest same-name opener (LOCAL first, then GLOBAL), preferring a
-          // NON-generic-shaped opener over an ambiguous generic-shaped one at the same name. A real
-          // component always emits its own closer; a technical generic never does — so a lone closer
-          // belongs to the real opener even when a standalone generic sits nearer (EVE's
-          // `STANDALONEKEEP25`, kept). Balanced closers still resolve true nesting: the inner closer
-          // finds the inner opener before any farther one.
-          const pop = (stack: { name: string; key: string; generic: boolean }[]) => {
-            let idx = -1;
-            for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { if (!stack[s].generic) { idx = s; break; } if (idx === -1) idx = s; }
-            if (idx === -1) return false;
-            paired.add(stack[idx].key); paired.add(`${ci}:${tag.lt}`); stack.splice(idx, 1); return true;
+          // A closer pops the TOPMOST same-name opener by true LIFO within ONE stack — LOCAL first (an
+          // inline pair closes in its chunk), else GLOBAL. No generic/non-generic preference and no
+          // reaching past a nearer same-name opener: which generic-shaped openers are even eligible to
+          // stack is already settled at push time by genericFlowBudget, so pairing is pure position.
+          const pop = (stack: { name: string; key: string }[]) => {
+            for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.splice(s, 1); return true; }
+            return false;
           };
           pop(local) || pop(global);
         } else {
@@ -194,7 +216,7 @@ export function pairResidues(chunks: string[]): Set<string> {
           const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
           const callGlued = /[)\]>]$/.test(beforeLt); // `)`/`]`/`>` before `<` ⇒ a type-argument, never a fresh element
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
-          const flowOpen = global.some((g) => g.name === tag.name && g.definite) || local.some((l) => l.name === tag.name && l.endsChunk);
+          const flowOpen = global.some((g) => g.name === tag.name && g.definite) || local.some((l) => l.name === tag.name && l.endsChunk && l.definite);
           const trailing = tag.closed && text.slice(tag.end).trim() !== ''; // content after the opener's `>` in THIS chunk
           // A same-name opener while a DEFINITE flow is open is IN-BODY prose when it is GLUED (a
           // mid-sentence generic, `Box\<$Panel extends IDENTGEN23>`), UNCLOSED (`\<$Panel remains
@@ -206,7 +228,12 @@ export function pairResidues(chunks: string[]): Set<string> {
           // generic-shaped nested flow opener.
           const inBody = callGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
           const definite = !generic && !glued && (tag.closed || lossy); // bare/attr'd real component, not generic-shaped
-          const flow = !inBody && (definite || lossy || generic || tag.closed);
+          // A STANDALONE generic-shaped opener stacks as flow only while a same-name closer remains
+          // surplus (see genericFlowBudget) — otherwise it is a lone technical generic (no closer of
+          // its own) and stays prose so a real component's closer isn't stolen by pure LIFO.
+          const genericFlow = !inBody && generic && tag.closed && (genericFlowBudget.get(tag.name) ?? 0) > 0;
+          if (genericFlow) genericFlowBudget.set(tag.name, (genericFlowBudget.get(tag.name) ?? 0) - 1);
+          const flow = !inBody && (definite || lossy || (generic ? genericFlow : tag.closed));
           // A same-name UNCLOSED in-body generic reads as a JSX opener to the per-chunk grammar (`\<$Panel
           // remains STARTCOMPACT23` = two bare attrs) and would be wrongly stripped by stripComponentResidue,
           // which has no cross-chunk flow context. Record it as a `keep:` position so sanitize preserves it.
@@ -284,15 +311,15 @@ function stripComponentResidue(text: string, chunkIndex: number, paired: Set<str
       out += ' '; i = gc === -1 ? k : gc;
       continue;
     }
-    // Same recovery when the matching `</Name>` sits LATER IN THIS CHUNK (a GLUED inline opener whose
-    // close was not split off). lossyOpenerEnd handles the UNDER-count / dropped-quote / double-close
-    // leaks (scanTag stopped at a fake early `>`); it returns -1 for a clean inline tag AND for the
-    // OVER-count swallow case (`items={["a { [ x"]}>` — unbalanced opens so scanTag never closed and ran
-    // to end, `k` past the closer). That swallow case can't be reached by a forward-from-`k` scan, so it
-    // falls through to the closer-anchored recovery below: re-anchor to the LAST `>` before the in-chunk
-    // closer. Gated on the opener span being genuinely desynced so a clean inline tag is left to the
-    // grammar classifier (which strips a balanced tag whole).
-    if (glued && esc && !closing && !selfClose && closerAfter !== -1) {
+    // Same recovery when the matching `</Name>` sits LATER IN THIS CHUNK (an inline opener whose close
+    // was not split off) — GLUED to prose or at the CHUNK START alike (cross/same-chunk share one path).
+    // lossyOpenerEnd handles the UNDER-count / dropped-quote / double-close leaks (scanTag stopped at a
+    // fake early `>`); it returns -1 for a clean inline tag AND for the OVER-count swallow case
+    // (`items={["a { [ x"]}>` — unbalanced opens so scanTag never closed and ran to end, `k` past the
+    // closer). That swallow case can't be reached by a forward-from-`k` scan, so it falls through to the
+    // closer-anchored recovery below: re-anchor to the LAST `>` before the in-chunk closer. Gated on the
+    // opener span being genuinely desynced so a clean inline tag is left to the grammar classifier.
+    if (esc && !closing && !selfClose && closerAfter !== -1) {
       const gc = lossyOpenerEnd(text, tag.nameEnd, k);
       if (gc !== -1) { out += ' '; i = gc; continue; }
       if (!closed || bracketDesync(text.slice(tag.nameEnd, k))) {
@@ -429,37 +456,57 @@ function rawCloserRe(name: string): RegExp {
 // The single lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be
 // FAKE. structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, and it can
 // drop the backslash of a `\"` inside a string attribute — either way an opener's REAL end can leak
-// PAST `k`. Two opener-global tells over the residue from `nameEnd`, mutually exclusive by quote parity,
-// each enable ONE branch of a forward scan from `k`; a clean opener trips neither and this returns -1 so
-// `k` stays the boundary and the visible intro survives:
+// PAST `k`. Two mutually-exclusive tells over the opener residue (from `nameEnd`) each enable ONE branch
+// of a forward scan from `k`; a clean opener trips neither and this returns -1 so `k` stays the boundary
+// and the visible intro survives:
 //   • QUOTE leak (ODD unescaped `"`) — a dropped `\"` (`title="a \" > X"` → `title="a " > X"`) desyncs
-//     the quotes; quote state is CORRUPTED so bracket counting is meaningless. The string's real close
-//     leaks as a `">` glued to the true tag `>`; the quote branch recovers past it.
-//   • BRACKET leak (EVEN `"`, quotes TRUSTWORTHY) — a `\{…}` attribute expression leaked a close
-//     (`value=\{x } > DIVLEAK / 2}>`, or `value=\{"} > X" / 2}>` with the `}` inside a string). A
-//     quote-aware bracket count (escaped-open `\{`/`\[` = +1, bare `}`/`]` = −1) going NEGATIVE marks it;
-//     the bracket branch recovers past the unmatched close glued to `>`.
-// A DOUBLE structural close glued to `>` (`)}>` / `]}>` / `}}>`) is an unambiguous leak in BOTH branches
-// (`\{fn("…" } > X", x)}>` closes call + expression at once past the fake `>`). Code spans are skipped so
-// a literal `]}>` inside `` `…` `` never trips it. Honest body never emits two bare closes before a `>`.
+//     the quotes; the string's real close leaks as a `">` glued to the true tag `>`.
+//   • BRACKET leak (EVEN `"`) — a `\{…}` attribute expression leaked a close (`value=\{x } > X / 2}>`).
+//     A quote-aware bracket count (escaped-open `\{`/`\[` = +1, bare `}`/`]` = −1) going NEGATIVE marks it.
+// BOTH the tell pre-count and the forward scan are LEXICALLY SAFE: a regex literal `/…/`, a `/* … */` /
+// `// …` comment inside a `{…}` attribute, and a code span `` `…` `` are skipped, so a literal `}` / `]`
+// / `>` / quote in `pattern={/[}>]/}` or `x={/* } */ 1}` never miscounts. A DOUBLE structural close
+// glued to `>` (`)}>` / `]}>` / `}}>`) is an unambiguous leak in either branch. `}` after a closed
+// string / object operand is division, not a regex — matched by regexEnd's operand awareness.
 function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
   const seg = text.slice(nameEnd);
-  const oddQuote = ((seg.replace(/\\./g, '').match(/"/g)?.length ?? 0) % 2) === 1;
-  let bnet = 0, bracketLeak = false, q = '';
-  if (!oddQuote) for (let m = 0; m < seg.length; m++) { const ch = seg[m]; if (ch === '\\') { const n = seg[m + 1]; if (!q && (n === '{' || n === '[')) bnet++; m++; continue; } if (q) { if (ch === q) q = ''; continue; } if (ch === '"' || ch === "'" || ch === '`') { q = ch; continue; } if (ch === '}' || ch === ']') { bnet--; if (bnet < 0) bracketLeak = true; } }
+  let sq = '', quoteCount = 0, bnet = 0, bracketLeak = false, prevSig = '';
+  for (let m = 0; m < seg.length; m++) {
+    const ch = seg[m];
+    if (sq) { if (ch === '\\') { m++; continue; } if (ch === '"') quoteCount++; if (ch === sq) { sq = ''; prevSig = '"'; } continue; }
+    if (ch === '\\') { const n = seg[m + 1]; if (n === '{' || n === '[') { bnet++; prevSig = n; } m++; continue; } // structure()'s escaped opening bracket
+    if (ch === '`') { const cs = codeSpanEnd(seg, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
+    if (ch === '/' && seg[m + 1] === '*') { const e = seg.indexOf('*/', m + 2); m = e === -1 ? seg.length : e + 1; continue; }
+    if (ch === '/' && seg[m + 1] === '/') { const e = seg.indexOf('\n', m + 2); m = e === -1 ? seg.length : e; continue; }
+    if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(seg, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } } // regex only after a non-operand
+    if (ch === '"') quoteCount++;
+    if (ch === '"' || ch === "'" || ch === '`') { sq = ch; continue; }
+    if (ch === '}' || ch === ']') { bnet--; if (bnet < 0) bracketLeak = true; }
+    if (!/\s/.test(ch)) prevSig = ch;
+  }
+  const oddQuote = quoteCount % 2 === 1;
   if (!oddQuote && !bracketLeak) return -1;
-  let depth = 0, parity = 0, sq = '';
+  let depth = 0, parity = 0, q = '';
   for (let m = k; m < text.length; m++) {
     const ch = text[m];
     if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; continue; } }
-    const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m)); if (dbl) return m + dbl[0].length;
+    const dbl = /^[)\]}]{2}\s*>/.exec(text.slice(m)); if (dbl) return m + dbl[0].length; // double structural close glued to `>` — unambiguous leak in either branch
     if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; continue; }
     if (oddQuote && ch === '"') { const cq = /^"\s*>/.exec(text.slice(m)); if (parity === 0 && cq) return m + cq[0].length; parity ^= 1; continue; }
-    if (bracketLeak && sq) { if (ch === sq) sq = ''; continue; }
-    if (bracketLeak && (ch === '"' || ch === "'" || ch === '`')) { sq = ch; continue; }
+    if (bracketLeak && q) { if (ch === q) q = ''; continue; }
+    if (bracketLeak && (ch === '"' || ch === "'" || ch === '`')) { q = ch; continue; }
     if (ch === '{' || ch === '[') { depth++; continue; }
     if (bracketLeak && (ch === '}' || ch === ']')) { depth--; const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (depth < 0 && cb) return m + cb[0].length; }
   }
+  return -1;
+}
+
+// End of a `/…/` regex literal opened at `p` (the `/`), or -1 if it doesn't close on the line. Skips an
+// escaped `\/` and a `/` inside a `[…]` char class. Used to keep a regex body's literal `}` / `>` /
+// quotes from being counted as structure — mirrors scanTag's own regex skip.
+function regexEnd(s: string, p: number): number {
+  let cls = false;
+  for (let m = p + 1; m < s.length; m++) { const r = s[m]; if (r === '\\') { m++; continue; } if (r === '\n') return -1; if (r === '[') cls = true; else if (r === ']') cls = false; else if (r === '/' && !cls) return m + 1; }
   return -1;
 }
 

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -59,27 +59,105 @@ function nodeText(node: Nodes): string {
 //
 // The genuinely ambiguous case — `<out disabled>` / `<const dataÉ="x">` / `<in title="x">`
 // — is a valid JSX element AND a valid TS generic at the SAME time, so no per-chunk grammar
-// oracle can separate the two. structure() hands us a stronger, cross-chunk signal: it emits
-// a matching `</Name>` closing-residue chunk for every real flow component, but NEVER for a
-// TS generic. So `closerNames` (every `</Name>` seen anywhere in the page's chunk stream) is
-// the authority — if an opener's name is paired with a page closer, it is a component.
-// Falling back to structural signals for the unpaired remainder:
+// oracle can separate the two. structure() hands us a stronger signal: whenever it splits a
+// flow component around a nested heading it emits BOTH an opener residue and a matching closer
+// residue, but never a closer for a TS generic. `pairResidues` walks the page's chunk stream in
+// order with a POSITIONAL, hierarchy-aware stack (a closer pops the nearest matching opener,
+// like real nesting) and is code-span aware, so a literal `` `</T>` `` in prose can't pair off
+// and delete an unrelated generic in another chunk. A positionally-paired opener is a confirmed
+// component. Falling back to structural signals for the unpaired remainder:
 //   - a `</Name>` / self-closing / fragment residue is always markup,
-//   - an opener that is JSX-valid but not TS-valid, or that fills its whole chunk standalone,
-//     is a split flow component,
+//   - an opener that is JSX-valid but not TS-valid is a split flow component,
+//   - a lossy attributed opener filling its whole chunk (structure() dropped its closer's
+//     escaping so it never paired) is a component too,
 //   - everything else (a bare `<T>`, an `a<b` comparison, a `<T, U = …>` generic) is prose.
 // The scan is code-span, quote, template-literal, brace and entity aware, so a `>` hiding
 // inside an attribute string / `{…}` / `` `…` `` can't end a tag early.
-function stripComponentResidue(text: string, closerNames: Set<string>): string {
-  // A JSX/TS name may start with a letter, `_`, `$` or any Unicode ID_Start, and continue
-  // with those plus digits / `.` / `-`. structure() markdown-escapes a leading/embedded `_`
-  // as `\_`, so a name char can arrive as a two-char `\x` — the *Len helpers report how many
-  // source chars one logical name char spans (0 when it isn't one) so the scanner sees
-  // through the escape and covers `µPanel` and other Unicode identifiers, not just `À-￿`.
-  const NAME_START = /[\p{ID_Start}$_]/u;
-  const NAME_CONT = /[\p{ID_Continue}$.-]/u;
-  const nameStartLen = (p: number) => (text[p] === '\\' && NAME_START.test(text[p + 1] ?? '') ? 2 : NAME_START.test(text[p] ?? '') ? 1 : 0);
-  const nameContLen = (p: number) => (text[p] === '\\' && NAME_CONT.test(text[p + 1] ?? '') ? 2 : NAME_CONT.test(text[p] ?? '') ? 1 : 0);
+// A JSX/TS name may start with a letter, `_`, `$` or any Unicode ID_Start, and continue with
+// those plus digits / `.` / `:` / `-`. structure() markdown-escapes a leading/embedded `_` as
+// `\_`, and an astral identifier spans two UTF-16 units — the *Len helpers report how many
+// SOURCE chars one logical name char spans (0 when it isn't one), using codePointAt so a full
+// Unicode code point (not a lone surrogate) is tested against ID_Start.
+const NAME_START = /[\p{ID_Start}$_]/u;
+const NAME_CONT = /[\p{ID_Continue}$.:-]/u;
+const cpLen = (c: number) => (c > 0xffff ? 2 : 1);
+const nameLen = (re: RegExp, text: string, p: number) => {
+  const esc = text[p] === '\\';
+  const c = text.codePointAt(p + (esc ? 1 : 0));
+  return c !== undefined && re.test(String.fromCodePoint(c)) ? (esc ? 1 : 0) + cpLen(c) : 0;
+};
+
+type Tag = { esc: boolean; lt: number; closing: boolean; name: string; nameEnd: number; end: number; selfClose: boolean; closed: boolean };
+
+// Try to read a tag opener/closer starting at `i`. Returns null if `i` isn't a `<` / `\<`
+// followed by a JSX name start. Scans to the terminating `>` at brace depth 0, honoring
+// quotes / template literals / structure()'s markdown-escaped punctuation so a `>` hidden
+// inside an attribute value can't end the tag early. `closed` is false when the `>` never
+// arrives (a multiline opener split across chunks, or a lossy-serialized attribute).
+function scanTag(text: string, i: number): Tag | null {
+  const esc = text[i] === '\\' && text[i + 1] === '<';
+  const lt = esc ? i + 1 : i;
+  if (text[lt] !== '<') return null;
+  const closing = text[lt + 1] === '/';
+  const nameAt = lt + 1 + (closing ? 1 : 0);
+  if (nameLen(NAME_START, text, nameAt) === 0) return null;
+  let j = nameAt, nl: number;
+  while ((nl = nameLen(NAME_CONT, text, j)) > 0) j += nl;
+  const name = deEscape(text.slice(nameAt, j));
+  let quote = '', brace = 0, closed = false, selfClose = false, k = j;
+  while (k < text.length) {
+    const ch = text[k];
+    if (quote) {
+      if (ch === '\\') { k += 2; continue; } // escaped char inside a string/template
+      if (ch === quote) quote = '';
+      k++; continue;
+    }
+    if (ch === '\\' && /[<>{}[\]]/.test(text[k + 1] ?? '')) { // structure()'s markdown-escaped punctuation
+      const p = text[k + 1];
+      if (p === '{') brace++; else if (p === '}' && brace > 0) brace--;
+      k += 2; continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{') brace++;
+    else if (ch === '}' && brace > 0) brace--;
+    else if (ch === '/' && !brace && text[k + 1] === '>') selfClose = true;
+    else if (ch === '>' && !brace) { k++; closed = true; break; }
+    k++;
+  }
+  return { esc, lt, closing, name, nameEnd: j, end: k, selfClose, closed };
+}
+
+// Walk the page's ordered chunk stream and pair opener residues with their closers using a
+// positional, hierarchy-aware stack: a `</Name>` pops the nearest still-open `<Name>` (so real
+// nesting is respected), not a name-set membership test. Code-span aware, so a `` `</T>` ``
+// literal in prose never pairs. Returns the set of `chunkIndex:offset` positions that are
+// confirmed component tags (both the opener and its matched closer).
+export function pairResidues(chunks: string[]): Set<string> {
+  const paired = new Set<string>();
+  const stack: { name: string; key: string }[] = [];
+  chunks.forEach((text, ci) => {
+    let i = 0;
+    while (i < text.length) {
+      if (text[i] === '`') { let f = 0; while (text[i + f] === '`') f++; const e = text.indexOf(text.slice(i, i + f), i + f); i = e === -1 ? text.length : e + f; continue; }
+      const tag = scanTag(text, i);
+      if (!tag) { i++; continue; }
+      // A tag whose name is immediately followed by a top-level `,` (`<Name, U>` — a type-argument
+      // list like `factory()<𐐀Panel, INNER>()`) is a TS generic, NEVER a JSX opener, so it must not
+      // enter the pairing stack: otherwise a same-named inner generic inside a component's body would
+      // be popped by the outer `</Name>` instead of the real opener. Skip it (advance past it).
+      const afterName = text.slice(tag.nameEnd, tag.closed ? tag.end - 1 : tag.end).trimStart();
+      const isGenericArgList = afterName.startsWith(',');
+      if (!tag.selfClose && !isGenericArgList) {
+        if (tag.closing) { for (let s = stack.length - 1; s >= 0; s--) if (stack[s].name === tag.name) { paired.add(stack[s].key); paired.add(`${ci}:${tag.lt}`); stack.length = s; break; } }
+        else stack.push({ name: tag.name, key: `${ci}:${tag.lt}` });
+      }
+      i = tag.closed ? tag.end : tag.nameEnd;
+    }
+  });
+  return paired;
+}
+
+function stripComponentResidue(text: string, chunkIndex: number, paired: Set<string>): string {
   let out = '';
   let i = 0;
   while (i < text.length) {
@@ -100,64 +178,54 @@ function stripComponentResidue(text: string, closerNames: Set<string>): string {
     // span was copied verbatim by the branch above), so it is real markup — drop it.
     // A `<!-- … -->` INSIDE a code span never gets here, so its literal text stays.
     if (text.startsWith('<!--', i)) { const e = text.indexOf('-->', i + 4); out += ' '; i = e === -1 ? text.length : e + 3; continue; }
-    // A tag opener: `<` or escaped `\<`, then optional `/`, then a JSX name start
-    // (letter / `_` / `$` / Unicode ID_Start, possibly markdown-escaped as `\_`).
-    const esc = c === '\\' && text[i + 1] === '<';
-    const lt = esc ? i + 1 : i;
-    const closing = text[lt + 1] === '/';
-    const nameAt = lt + 1 + (closing ? 1 : 0);
-    const opensTag = text[lt] === '<' && nameStartLen(nameAt) > 0;
-    if (!opensTag) { out += c; i++; continue; }
-    let j = nameAt;
-    let nl: number;
-    while ((nl = nameContLen(j)) > 0) j += nl;
-    const name = deEscape(text.slice(nameAt, j)); // tag name, unescaped for the pairing lookup
-    const paired = !closing && closerNames.has(name); // a `</name>` residue exists elsewhere in the page → component
+    const tag = scanTag(text, i);
+    if (!tag) { out += c; i++; continue; }
+    let { esc, closed, end: k } = tag;
+    const { lt, closing, selfClose } = tag;
+    const isPaired = paired.has(`${chunkIndex}:${lt}`); // positionally matched with a closer → component
     const glued = out.trim() !== ''; // real prose precedes this `<` in the same chunk
-    // Scan to the terminating `>` at brace depth 0 so a `>` hidden in an attribute
-    // string / `{…}` expression / `` `…` `` template can't end the tag early. structure()
-    // markdown-escapes the JSX punctuation (`\{`, `\[`, `\<`), so a `\{` counts as a brace;
-    // inside a quote / template a `\`-escape hides the next char, so a `\"` / escaped
-    // backtick can't close the attribute string early. The tag body (`lt+1 … >`) is then
-    // handed to opensJsxElement() for the JSX-vs-generic decision.
-    let quote = '', brace = 0, closed = false, selfClose = false;
-    let k = j;
-    while (k < text.length) {
-      const ch = text[k];
-      if (quote) {
-        if (ch === '\\') { k += 2; continue; } // escaped char inside a string/template
-        if (ch === quote) quote = '';
-        k++; continue;
+    // Lossy `>`-recovery: structure() can drop the escaping backslash of a quote/template
+    // inside an opener's attribute, so scanTag's quote tracking desyncs and never sees the
+    // real closing `>` (closed=false, body swallows the element's own text + suffix). Recover
+    // by cutting at the first `>` OUTSIDE any `{…}`/`[…]` expression past the tag name — the
+    // brace/bracket escapes survive the lossy collapse even when the quotes do not, so a `>`
+    // hiding inside `items={["a > b"]}` is skipped and the real tag end is found. For an escaped
+    // opener only when GLUED (real prose/body shares the chunk) or positionally paired; a
+    // standalone escaped UNCLOSED opener is whole-element residue, stripped to end below.
+    if (!closed && (isPaired || !esc || glued)) {
+      let depth = 0;
+      for (let m = tag.nameEnd; m < text.length; m++) {
+        const ch = text[m];
+        if (ch === '\\' && /[{}[\]]/.test(text[m + 1] ?? '')) { const p = text[m + 1]; if (p === '{' || p === '[') depth++; else if (depth > 0) depth--; m++; continue; }
+        if (ch === '{' || ch === '[') depth++;
+        else if ((ch === '}' || ch === ']') && depth > 0) depth--;
+        else if (ch === '>' && depth === 0) { k = m + 1; closed = true; break; }
       }
-      if (ch === '\\' && /[<>{}[\]]/.test(text[k + 1] ?? '')) { // structure()'s markdown-escaped punctuation
-        const p = text[k + 1];
-        if (p === '{') brace++; else if (p === '}' && brace > 0) brace--;
-        k += 2; continue;
-      }
-      if (ch === '"' || ch === "'" || ch === '`') quote = ch;
-      else if (ch === '{') brace++;
-      else if (ch === '}' && brace > 0) brace--;
-      else if (ch === '/' && !brace && text[k + 1] === '>') selfClose = true;
-      else if (ch === '>' && !brace) { k++; closed = true; break; }
-      k++;
     }
-    // Lossy recovery: structure() drops backslashes inside an attribute string (`\"` → `"`),
-    // which can desync the quote state machine so it never finds the real `>`. For a GLUED
-    // paired opener (a confirmed component with real prose before it), retry with a naive
-    // first unescaped `>` so the visible body/suffix after the tag survives. A STANDALONE
-    // opener chunk is left unclosed on purpose — it is swallowed to end-of-chunk below.
-    if (!closed && paired && glued) { let m = j; while (m < text.length) { if (text[m] === '>' && text[m - 1] !== '\\') { k = m + 1; closed = true; break; } m++; } }
     // The opener body is the tag name + attributes, up to (not including) the closing `>`.
-    // A page closer pairs it (component); otherwise the grammars + standalone shape decide.
     const body = text.slice(lt + 1, closed ? k - 1 : k).replace(/\/\s*$/, '');
     const standalone = !glued && (!closed || text.slice(k).trim() === ''); // opener fills its whole chunk
-    const isComponent = !closing && !selfClose && (paired || opensJsxElement(body, standalone));
-    // An UNCLOSED opener is split-flow residue (strip to end) when it is confirmed a component
-    // (name paired), or its body carries a JSX `attr={…}` / `{...spread}`, or it fills the whole
-    // chunk and parses as JSX. A standalone prose generic (`\<T, U = "x">`) or a compact
-    // `alpha\<needle remains body` comparison matches none, so it is kept verbatim.
-    if (!closed && esc && (paired || looksLikeOpener(body) || (standalone && opensJsxElement(body, true)))) { i = text.length; out = out.trimEnd(); continue; }
+    const isComponent = !closing && !selfClose && (isPaired || opensJsxElement(body));
+    // An UNCLOSED escaped opener is split-flow residue (strip to end) when it is a paired
+    // component, its body carries a JSX `attr={…}` / `{...spread}`, or the body is JSX-valid
+    // but not TS (`Panel disabled`, `Panel title="x"` — an own-line-`>` split opener whose `>`
+    // lives in the next chunk). The JSX-valid tell only applies when NOT glued to prose: a
+    // glued `alpha\<Needle remains …` is a `<` comparison, kept verbatim. A standalone prose
+    // generic (`\<T, U = "x">`, which is closed) or a compact comparison matches none below.
+    if (!closed && esc && (isPaired || looksLikeOpener(body) || (!glued && opensJsxElement(body)))) { i = text.length; out = out.trimEnd(); continue; }
     if (closed && (closing || selfClose || isComponent)) { out += ' '; i = k; continue; }
+    // An opener body carrying an unambiguous JSX `attr={…}` / `{...spread}` shape is a
+    // component — a JSX expression attribute is never a TS generic default (`= value`), so this
+    // wins even when the mangled body also parses as TS (`<out T={[…]}>` reads `out` as a
+    // variance modifier). Strip just the opener, keeping the visible body + suffix — covers
+    // glued lossy openers (`title={a \ b}`) and whole-chunk attributed residue alike.
+    if (closed && looksLikeOpener(body)) { out += ' '; i = k; continue; }
+    // A whole-chunk `tagName attr="…"` string attribute (`<const dataÉ="x">`): shape-identical
+    // to a generic default with a variance modifier (`<in T="x">`), so only a component when it
+    // is NOT glued to prose. But a bare `<out T="x">` / `<in T="x">` / `<const T="x">` is ALSO a
+    // valid TS variance/modifier generic — keep those (they must stay searchable), and only drop
+    // the ones the TS grammar rejects (`<const dataÉ="x">`, whose `dataÉ` is not a type param).
+    if (closed && standalone && hasAttrShape(body) && !isTsGeneric(body)) { out += ' '; i = k; continue; }
     // KEEP: this `<…>` is prose (a TS generic / type-argument / comparison / placeholder).
     // A multi-token body (`keyof X`, `T, U = …`, `a instanceof B`) or a qualified name
     // (`ns.Member`) parses as a JSX element downstream and would be silently dropped, so
@@ -172,30 +240,36 @@ function stripComponentResidue(text: string, closerNames: Set<string>): string {
 
 // Classify a `<…>` opener body (everything after `<` up to but excluding the closing `>`,
 // tag name included) as a JSX ELEMENT (strip) or as TypeScript / prose (keep), using the
-// REAL grammars. This is the fallback for openers the caller could NOT settle by cross-chunk
-// pairing (no matching `</Name>` residue in the page):
+// REAL grammars. This is the fallback for openers the caller could NOT settle by positional
+// residue pairing (no matching closer at a matching nesting level):
 //   - The TypeScript parser decides whether the body is legal TS: a type-PARAMETER list
 //     (`type _<B> = 0;`), a call's type ARGUMENTS (`f<B>();`, covering `keyof X` / `ns.Q`),
 //     or a relational expression (`x = a<B>b;`, covering `a instanceof B`). Any clean → TS.
 //   - The MDX grammar decides whether the body is a valid JSX opening element.
-//   - Both can be true for a genuinely ambiguous body (`out disabled`, `const dataÉ="x"`).
-//     Without a page closer to break the tie, `standalone` does: an opener that fills its
-//     WHOLE chunk is split flow-component residue (structure() only emits a bare opener chunk
-//     when it split a component around a nested heading), so strip it; an ambiguous body that
-//     sits INSIDE prose is a generic, so keep it.
+//   - A body that is JSX-valid but NOT valid TS is unambiguously a component (`{...spread}`,
+//     `attr={…}`). A genuinely-ambiguous body that BOTH grammars accept (`out disabled`) is
+//     left to the caller's positional pairing / lossy-chunk fallback, so here it counts as TS
+//     (not a component) and is kept — a whole-chunk prose generic must never be deleted.
 // structure() markdown-escapes JSX punctuation (`\<`, `\{`, `\_`, …); undo every such escape
 // for the grammar probes (the caller still deletes from the original text).
-function opensJsxElement(body: string, standalone: boolean): boolean {
+// Does the opener body parse as legal TypeScript — a type-parameter list, a call's type
+// arguments, or a relational expression? Any clean parse → it is TS/prose, never a component.
+function isTsGeneric(body: string): boolean {
   const inner = deEscape(body).replace(/\s+/g, ' ').trim();
   // `parseDiagnostics` is TS-internal (not on the public SourceFile type) but is the
   // cheapest syntactic-error signal without a full Program — cast to reach it.
   const clean = (src: string) => ((ts.createSourceFile('t.ts', src, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS) as ts.SourceFile & { parseDiagnostics?: unknown[] }).parseDiagnostics ?? []).length === 0;
-  const tsValid = clean(`type _<${inner}> = 0;`) || clean(`f<${inner}>();`) || clean(`x = a<${inner}>b;`);
+  return clean(`type _<${inner}> = 0;`) || clean(`f<${inner}>();`) || clean(`x = a<${inner}>b;`);
+}
+
+function opensJsxElement(body: string): boolean {
+  const inner = deEscape(body).replace(/\s+/g, ' ').trim();
+  if (isTsGeneric(body)) return false; // valid TS → prose, keep
   try {
     let jsx = false;
     const walk = (n: { type: string; children?: unknown[] }) => { if (n.type.startsWith('mdxJsx')) jsx = true; for (const ch of (n.children ?? []) as typeof n[]) walk(ch); };
     walk(fromMarkdown(`<${inner} />`, { extensions: [mdxjs()], mdastExtensions: [mdxFromMarkdown()] }) as never);
-    return jsx && (!tsValid || standalone); // JSX-shaped, and either not-TS or a whole-chunk opener residue
+    return jsx && !isTsGeneric(body); // JSX-shaped and NOT valid TS → unambiguous component
   } catch {
     return false;
   }
@@ -208,13 +282,22 @@ function deEscape(s: string): string {
   return s.replace(/\\([^0-9A-Za-z\s])/g, '$1');
 }
 
-// An UNCLOSED escaped opener is split-flow component residue only if its body actually
-// looks like a JSX opening tag: it has an `attr={…}` JSX expression or a `{...spread}`.
-// A standalone prose generic (`\<T, U = "x">`) or an `alpha\<needle …` comparison has
-// neither, so we must NOT strip to end-of-chunk for those.
+// Unambiguous JSX-opener body: an `attr={…}` JSX expression or a `{...spread}`. Neither can
+// be a TS generic default (those are `= value`, never `attr={…}`), so a body with either is a
+// component regardless of what else it parses as. A plain `tagName attr="…"` string attribute
+// is NOT here — it is shape-identical to a generic default with a modifier (`<in T="x">`), so
+// the caller disambiguates it via `glued` (prose context) instead.
 function looksLikeOpener(body: string): boolean {
   const inner = deEscape(body);
   return /[\w$]+=\{/.test(inner) || /\{\s*\.\.\./.test(inner);
+}
+
+// A `tagName attrName="…"` (or `={…}`) attribute shape: a fresh identifier after the tag name
+// and whitespace, then a value attached to `=` with no surrounding space. This shape is shared
+// by a JSX string attribute (`<Panel title="x">`) and a TS generic default with a variance
+// modifier (`<in T="x">`), so the caller only treats it as a component when NOT glued to prose.
+function hasAttrShape(body: string): boolean {
+  return /^[^\s,<]+\s+[\p{ID_Continue}$.:-]+=["'{]/u.test(deEscape(body).trim());
 }
 
 // structuredData chunks carry raw markdown (inline-code backticks, **bold**,
@@ -239,13 +322,14 @@ function looksLikeOpener(body: string): boolean {
 //  4. Any chunk still not valid MDX (residual escapes, odd fragments) falls back to
 //     a CommonMark parse; step 2 already removed the component markup, so nothing
 //     tag-shaped remains to mis-handle.
-export function sanitizeSearchText(input: string, closerNames: Set<string> = collectCloserNames([input])): string {
+export function sanitizeSearchText(input: string, chunkIndex = 0, paired: Set<string> = pairResidues([input])): string {
   // stripComponentResidue removes component markup — including HTML comments — with
   // code-span awareness, so a `<!-- … -->` literal inside `` `…` `` survives while a
   // real comment outside code is dropped. It runs on the raw (still entity-encoded)
-  // chunk so a `>` hidden in an attribute entity can't end a tag early. closerNames is
-  // the page-wide `</Name>` set so an opener split away from its closer still pairs.
-  const cleaned = stripComponentResidue(decodeMarkdownPunctEntities(input), closerNames);
+  // chunk so a `>` hidden in an attribute entity can't end a tag early. `paired` is the
+  // page-wide set of positionally-matched residue offsets so an opener split away from
+  // its closer into another chunk is still recognized as a component.
+  const cleaned = stripComponentResidue(decodeMarkdownPunctEntities(input), chunkIndex, paired);
   let text: string;
   try {
     text = nodeText(fromMarkdown(cleaned, { extensions: [mdxjs()], mdastExtensions: [mdxFromMarkdown()] }));
@@ -261,33 +345,23 @@ export function sanitizeSearchText(input: string, closerNames: Set<string> = col
     .trim();
 }
 
-// Collect every component name that appears as a `</Name>` closing residue anywhere in a
-// page's chunk stream (headings + contents). structure() emits one per real flow component
-// but never for a TS generic, so this set is the cross-chunk authority that tells an
-// ambiguous `<out …>` / `<const …>` opener apart from a same-named generic. Names are
-// deEscaped (structure() writes `</\_Panel>`) so they match the opener's unescaped name.
-export function collectCloserNames(chunks: Iterable<string>): Set<string> {
-  const names = new Set<string>();
-  for (const raw of chunks) for (const m of deEscape(raw).matchAll(/<\/\s*([^>\s/]+)\s*>/gu)) names.add(m[1]);
-  return names;
-}
-
 // Custom buildIndex passed to createFromSource: same shape as fumadocs' default
 // extractor, but every heading and content chunk is sanitized so the static
 // search JSON holds clean prose instead of markdown/entities.
 export async function buildIndex(page: Page) {
   const structuredData = await page.data.structuredData;
-  // Precompute the page-wide `</Name>` set once from every chunk so each opener is
-  // disambiguated against closers that structure() may have split into other chunks.
-  const closerNames = collectCloserNames([...structuredData.headings, ...structuredData.contents].map((c) => c.content));
+  // Pair residue openers/closers once over the ORDERED content chunk stream so an opener
+  // that structure() split away from its closer into a later chunk is still recognized.
+  const contents = structuredData.contents.map((c) => c.content);
+  const paired = pairResidues(contents);
   return {
     id: page.url,
     title: page.data.title ?? '',
     description: page.data.description,
     url: page.url,
     structuredData: {
-      headings: structuredData.headings.map((h) => ({ ...h, content: sanitizeSearchText(h.content, closerNames) })),
-      contents: structuredData.contents.map((c) => ({ ...c, content: sanitizeSearchText(c.content, closerNames) })),
+      headings: structuredData.headings.map((h) => ({ ...h, content: sanitizeSearchText(h.content) })),
+      contents: structuredData.contents.map((c, ci) => ({ ...c, content: sanitizeSearchText(c.content, ci, paired) })),
     },
   };
 }

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -273,7 +273,10 @@ export function pairResidues(chunks: string[]): Set<string> {
           // nearest opener by LIFO, so an earlier glued generic can't steal a later flow's closer regardless
           // of source order (EVE round-30 STALEGLUED29 → REALGLUED29 order-independence).
           const budget = genericFlowBudget.get(tag.name) ?? 0, reserve = standaloneReserve.get(tag.name) ?? 0;
-          if (generic && glued && tag.closed) { const r = (gluedRemaining.get(tag.name) ?? 0) - 1; gluedRemaining.set(tag.name, r); }
+          // Only a glued generic that pre-scan actually COUNTED into gluedGenerics advances the remaining
+          // window — a proseGlued opener was skipped there, so decrementing on it would shift the window and
+          // hand a scarce closer to an EARLIER glued generic (EVE round-31 STALESHIFT31 → REALSHIFT31).
+          if (generic && glued && tag.closed && !proseGlued) { const r = (gluedRemaining.get(tag.name) ?? 0) - 1; gluedRemaining.set(tag.name, r); }
           const gluedWins = !glued || (gluedRemaining.get(tag.name) ?? 0) < (gluedSlots.get(tag.name) ?? 0);
           const genericFlow = !inBody && generic && tag.closed && budget > 0 && (!glued || budget > reserve) && gluedWins;
           if (genericFlow) { genericFlowBudget.set(tag.name, budget - 1); if (!glued && reserve > 0) standaloneReserve.set(tag.name, reserve - 1); }
@@ -448,16 +451,15 @@ function isTsGeneric(body: string): boolean {
   return clean(`type _<${inner}> = 0;`) || clean(`f<${inner}>();`) || clean(`x = a<${inner}>b;`);
 }
 
-// Does `name<inner>` parse as a generic in OPERAND position — a call `f<…>()` or a relational
-// `a<…>b`, but NOT the standalone type-parameter-list context? A GLUED opener (`Box<$Panel>`,
-// `Foo<Bar, Baz>` — real prose preceding `<`) sits after an operand, so a valid operand-position
-// parse proves it is a TS instantiation / type-argument, not component residue. A residue opener
-// (`$Panel extends X`, `$Panel a="1"`) rejects in operand position. This is the grammar signal that
-// replaces guessing the opener's role from the character after its `>`.
+// Does `name<inner>` parse as a generic in CALL-ARGUMENT position — `f<…>()`? A GLUED opener
+// (`Box<$Panel>`, `Foo<Bar, Baz>` — real prose preceding `<`) sits after an operand, so a valid
+// type-argument-list parse proves it is a TS instantiation / type-argument, not component residue. A
+// residue opener rejects: `$Panel extends X` (not a type-arg list), and — crucially — a JSX boolean
+// prop `$Panel in X` / `$Panel as X` / `$Panel satisfies X` too. The relational template `a<…>b` was
+// dropped: it wrongly accepted those boolean props as a binary-operator chain (`a < $Panel in X > b`).
 function gluedGeneric(inner: string): boolean {
   const s = deEscape(inner).replace(/\s+/g, ' ').trim();
-  const clean = (src: string) => ((ts.createSourceFile('t.ts', src, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS) as ts.SourceFile & { parseDiagnostics?: unknown[] }).parseDiagnostics ?? []).length === 0;
-  return clean(`f<${s}>();`) || clean(`x = a<${s}>b;`);
+  return ((ts.createSourceFile('t.ts', `f<${s}>();`, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS) as ts.SourceFile & { parseDiagnostics?: unknown[] }).parseDiagnostics ?? []).length === 0;
 }
 
 function opensJsxElement(body: string): boolean {
@@ -555,25 +557,33 @@ function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
   // backslash, so the string closed one char early and the DANGLING value-close quote is preceded by
   // the space that used to sit before the escaped quote (`title="a \" >…` → `…a " >`). A CLEAN opener
   // GLUES its real close-quote to the last value char (`a="1" >` — `1" >`, no space BEFORE the quote),
-  // so this never fires on an honest trailing-space tag. `leakQuote[1]` is the leaked string's quote.
+  // so this fires on an honest opener only in the pathological case of an attribute VALUE that itself
+  // ends in a literal space (`a="1 " >`), which serializes byte-identically to a dropped-quote leak —
+  // no opener-local signal can tell the two apart, so we treat the leak (the real structure() failure
+  // mode, EVE rounds 26-30) as canonical. `leakQuote[1]` is the leaked string's quote.
   const leakQuote = /\s(["'])\s+>$/.exec(text.slice(nameEnd, k));
   if (leakQuote) {
     // scanTag stopped at a FAKE `>` still INSIDE a string whose closing quote structure() dropped the
     // backslash of (`title="a \" >…` → `title="a " >…`). We are mid-string at `k`. Close that string at
     // its REAL quote, then finish a normal brace/quote/regex-aware tag scan to the tag's real `>` — so a
     // later honest attribute (`pattern={/">/.test(X)}>`) is consumed instead of leaking into the body.
+    // The decision is purely OPENER-LOCAL: the leak signature is read from the opener span, and the end
+    // is then found by a deterministic lexical scan — no dependency on the visible body's first char
+    // (an earlier `text[end]` whitespace guess both leaked a real `"> ` end and ate a clean body's `">`).
     let m = k;
     for (; m < text.length; m++) { const ch = text[m]; if (ch === '\\') { m++; continue; } if (ch === leakQuote[1]) { m++; break; } }
     const end = scanToTagEnd(text, m);
-    // Accept the recovery ONLY when the recovered `>` looks like a REAL opener end: glued to body
-    // (next char non-space) or ending the chunk. A clean opener's `>` (at `k`) already IS the end, and
-    // scanning its visible body would land on a body `">` whose `>` is followed by whitespace — reject.
-    if (end !== -1 && (end >= text.length || !/\s/.test(text[end] ?? ''))) return end;
+    if (end !== -1) return end;
   }
   // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
-  // (structure() escapes its open as `\{`/`\[`). A clean string-only attribute opener (`a="1">`) has
-  // no such expression, so an honest body `"}>` / `]>` must NOT be mistaken for a leaked bracket close.
-  if (!/\\[{[]/.test(text.slice(nameEnd, k))) return -1;
+  // (structure() escapes its open as `\{`/`\[`) AND that span is opener-provably lossy: either
+  // bracket-DESYNCED, or scanTag landed on a FAKE early `>` preceded by whitespace (`… }] >` / `… ]} >`
+  // — a dropped string-quote let the leaked closes drift, so the `>` sits after a space). A CLEAN
+  // expression attribute (`b={x}>` — the bracket close is GLUED to the real `>`, no space) is neither,
+  // so an honest body `"}>` / `]>` is never mistaken for a leaked bracket close. Opener-local: reads
+  // only the opener span, never the visible body.
+  const bspan = text.slice(nameEnd, k);
+  if (!/\\[{[]/.test(bspan) || !(bracketDesync(bspan) || /\s>$/.test(bspan))) return -1;
   let depth = 0, prevSig = '';
   for (let m = k; m < text.length; m++) {
     const ch = text[m];
@@ -582,7 +592,7 @@ function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
     if (ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
     if (ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } } // regex only after a non-operand
     if (ch === '\\') { const n = text[m + 1]; if (n === '{' || n === '[') depth++; m++; if (n && !/\s/.test(n)) prevSig = n; continue; } // structure()'s escaped opening bracket
-    if (ch === '}' || ch === ']') { depth--; if (depth < 0) { const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (cb) { const e = m + cb[0].length; if (e >= text.length || !/\s/.test(text[e] ?? '')) return e; } } }
+    if (ch === '}' || ch === ']') { depth--; if (depth < 0) { const cb = /^[}\]]\s*>/.exec(text.slice(m)); if (cb) return m + cb[0].length; } }
     if (!/\s/.test(ch)) prevSig = ch;
   }
   return -1;

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -2,11 +2,28 @@ import { fromMarkdown } from 'mdast-util-from-markdown';
 import { toString } from 'mdast-util-to-string';
 import { mdxjs } from 'micromark-extension-mdxjs';
 import { mdxFromMarkdown } from 'mdast-util-mdx';
+import { structure } from 'fumadocs-core/mdx-plugins/remark-structure';
 import type { Nodes } from 'mdast';
 import ts from 'typescript';
 import type { source } from './source';
 
 type Page = (typeof source)['$inferPage'];
+
+// A markdown-escaped quote (`\"` / `\'`) inside a JSX attribute is the ONE lossy case
+// structure() can't be recovered from downstream: it drops the backslash, so a leaked
+// dropped-quote attribute (`title="a \" > NEEDLE">`) serializes BYTE-IDENTICALLY to a
+// legit value that ends in a literal space (`a="1 " >`). Encode the escaped quote to a
+// private-use sentinel BEFORE structure() runs: the leaked string then stays balanced
+// (its inner `>` sits inside the quoted region, so scanTag lands on the REAL tag `>` and
+// strips the whole opener, needle and all), while a legit close-quote remains a real
+// quote and its body survives. Private-use code points no real doc text contains; decoded
+// back to the quote in sanitizeSearchText's final output, so no sentinel enters the index
+// and a legit prose `\"quote\"` keeps its characters (won't conflict with body text).
+const SENTINEL_DQUOTE = '\uE000';
+const SENTINEL_SQUOTE = '\uE001';
+export function encodeEscapedQuotes(raw: string): string {
+  return raw.replace(/\\"/g, SENTINEL_DQUOTE).replace(/\\'/g, SENTINEL_SQUOTE);
+}
 
 const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
 
@@ -527,70 +544,22 @@ function rawCloserRe(name: string): RegExp {
   return new RegExp(`</${body}\\s*>`);
 }
 
-// The single lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be
-// FAKE. structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, and it can
-// drop the backslash of a `\"` / `\'` inside a string attribute — either way an opener's REAL end can
-// leak PAST `k`. Both tells are OPENER-LOCAL (derived from the span `nameEnd..k`, never the visible
-// body) and single/double-quote consistent; a clean opener trips neither, so this returns -1 and `k`
-// stays the boundary (the visible intro survives):
-//   • QUOTE leak — the span ENDS with `["']\s+>`: a dropped quote-backslash closed the string one char
-//     early (`title="a \" >…` → `title="a " >…`, `title='a \' >…` → `title='a ' >…`), so the residual
-//     value-close quote sits with whitespace before the fake `>`. A CLEAN opener glues its `>` to the
-//     last attribute token (`a="1">`), so this never fires on honest intro. Recover to the leaked
-//     string's REAL close `["']\s*>` in the body.
+// The lexical-safe boundary scanner for a same-name FLOW opener whose scanTag `>` (`k`) may be FAKE.
+// structure() escapes EVERY opening bracket (`\{`, `\[`) and leaves EVERY close bare, so an opener's
+// REAL end can leak PAST `k` when its `{…}` attribute expression carries a bare close. The tell is
+// OPENER-LOCAL (derived from the span `nameEnd..k`, never the visible body); a clean opener trips it
+// not, so this returns -1 and `k` stays the boundary (the visible intro survives). A dropped-quote
+// leak (`title="a \" > NEEDLE">`) is NOT handled here: encodeEscapedQuotes runs BEFORE structure(),
+// turning the escaped quote into a sentinel so the leaked string stays balanced and scanTag lands on
+// the REAL `>` — no fake early `>`, no recovery needed, and a legit trailing-space attr (`a="1 " >`)
+// keeps its body (the two are no longer byte-identical).
 //   • BRACKET leak — a depth scan from `k` where structure()'s escaped opens (`\{`/`\[`) are +1 and bare
 //     closes (`}`/`]`) are −1. Honest body brackets are ALWAYS structure-escaped, so depth only goes
 //     NEGATIVE on a `}`/`]` leaked from the opener's own `{…}` attribute expression; that negative-depth
-//     close glued to `>` (`}>` / `]}>` / `)}>`) is the real end. This also covers the quote-leak variant
-//     whose corrupting quote sits PAST `k` (`value={fn("a \" } > X", …)}>` — the span looks balanced but
-//     the real end is the trailing `)}>`). Lexically safe: regex literals `/…/`, `/* … */` / `// …`
-//     comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>` never miscount.
-// Resume a tag scan at `start` (just PAST a recovered leaked string) and return the index just past the
-// tag's real `>` at brace depth 0, or -1 if none. Mirrors scanTag's lexical rules over structure()'s
-// serialized residue: escaped opening brackets (`\{`/`\[`) raise depth, bare closes lower it, and quote /
-// regex / comment / code-span runs are skipped so their `>` never ends the tag early.
-function scanToTagEnd(text: string, start: number): number {
-  let quote = '', brace = 0, prevSig = '';
-  for (let m = start; m < text.length; m++) {
-    const ch = text[m];
-    if (quote) { if (ch === '\\') { m++; continue; } if (ch === quote) { quote = ''; prevSig = '"'; } continue; }
-    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
-    if (brace > 0 && ch === '/' && text[m + 1] === '*') { const e = text.indexOf('*/', m + 2); m = e === -1 ? text.length : e + 1; continue; }
-    if (brace > 0 && ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
-    if (brace > 0 && ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } }
-    if (ch === '\\' && /[<>{}[\]]/.test(text[m + 1] ?? '')) { const p = text[m + 1]; if (p === '{') brace++; else if (p === '}' && brace > 0) brace--; m++; prevSig = p; continue; }
-    if (ch === '"' || ch === "'") { quote = ch; continue; }
-    if (ch === '{') brace++;
-    else if (ch === '}' && brace > 0) brace--;
-    else if (ch === '>' && !brace) return m + 1;
-    if (!/\s/.test(ch)) prevSig = ch;
-  }
-  return -1;
-}
-
+//     close glued to `>` (`}>` / `]}>` / `)}>`) is the real end. Lexically safe: regex literals `/…/`,
+//     `/* … */` / `// …` comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>`
+//     never miscount.
 function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
-  // QUOTE leak — the span ends with `<space><quote><space>+>`: structure() dropped a `\"`/`\'`
-  // backslash, so the string closed one char early and the DANGLING value-close quote is preceded by
-  // the space that used to sit before the escaped quote (`title="a \" >…` → `…a " >`). A CLEAN opener
-  // GLUES its real close-quote to the last value char (`a="1" >` — `1" >`, no space BEFORE the quote),
-  // so this fires on an honest opener only in the pathological case of an attribute VALUE that itself
-  // ends in a literal space (`a="1 " >`), which serializes byte-identically to a dropped-quote leak —
-  // no opener-local signal can tell the two apart, so we treat the leak (the real structure() failure
-  // mode, EVE rounds 26-30) as canonical. `leakQuote[1]` is the leaked string's quote.
-  const leakQuote = /\s(["'])\s+>$/.exec(text.slice(nameEnd, k));
-  if (leakQuote) {
-    // scanTag stopped at a FAKE `>` still INSIDE a string whose closing quote structure() dropped the
-    // backslash of (`title="a \" >…` → `title="a " >…`). We are mid-string at `k`. Close that string at
-    // its REAL quote, then finish a normal brace/quote/regex-aware tag scan to the tag's real `>` — so a
-    // later honest attribute (`pattern={/">/.test(X)}>`) is consumed instead of leaking into the body.
-    // The decision is purely OPENER-LOCAL: the leak signature is read from the opener span, and the end
-    // is then found by a deterministic lexical scan — no dependency on the visible body's first char
-    // (an earlier `text[end]` whitespace guess both leaked a real `"> ` end and ate a clean body's `">`).
-    let m = k;
-    for (; m < text.length; m++) { const ch = text[m]; if (ch === '\\') { m++; continue; } if (ch === leakQuote[1]) { m++; break; } }
-    const end = scanToTagEnd(text, m);
-    if (end !== -1) return end;
-  }
   // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
   // (structure() escapes its open as `\{`/`\[`) AND that span is opener-provably lossy: either
   // bracket-DESYNCED, or scanTag landed on a FAKE early `>` preceded by whitespace (`… }] >` / `… ]} >`
@@ -713,6 +682,10 @@ export function sanitizeSearchText(input: string, chunkIndex = 0, paired: Set<st
     text = toString(fromMarkdown(cleaned), { includeHtml: false }).replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ');
   }
   return decodeContentEntities(text)
+    // Decode the escaped-quote sentinels back to real quotes so a legit prose `\"quote\"`
+    // keeps its characters and NO sentinel code point ever enters the search index.
+    .replace(new RegExp(SENTINEL_DQUOTE, 'g'), '"')
+    .replace(new RegExp(SENTINEL_SQUOTE, 'g'), "'")
     // Drop stray backticks the AST left as literal text (a lone/unpaired `,
     // e.g. from a decoded `&#x60;`). Only backticks — never `_` or word chars —
     // so identifiers are untouched.
@@ -725,7 +698,13 @@ export function sanitizeSearchText(input: string, chunkIndex = 0, paired: Set<st
 // extractor, but every heading and content chunk is sanitized so the static
 // search JSON holds clean prose instead of markdown/entities.
 export async function buildIndex(page: Page) {
-  const structuredData = await page.data.structuredData;
+  // Recompute structure() from the RAW markdown with escaped quotes sentinel-encoded, so the
+  // dropped-quote leak (`title="a \" > NEEDLE">`) becomes a self-balancing string that scanTag
+  // strips cleanly — the prebuilt page.data.structuredData already lost the `\` backslash and
+  // can't be recovered. Production and the regression tests both go through encodeEscapedQuotes,
+  // so buildIndex only ever consumes this explicit signal instead of guessing at the byte sequence.
+  const raw = await page.data.getText('raw');
+  const structuredData = structure(encodeEscapedQuotes(raw));
   // Pair residue openers/closers once over the ORDERED content chunk stream so an opener
   // that structure() split away from its closer into a later chunk is still recognized.
   const contents = structuredData.contents.map((c) => c.content);

--- a/site/app/lib/search-index.ts
+++ b/site/app/lib/search-index.ts
@@ -182,8 +182,21 @@ export function pairResidues(chunks: string[]): Set<string> {
         else {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const isGeneric = /[\s,=]/.test(inner) && isTsGeneric(inner);
+          // A GLUED opener is only a real component when its own `>` is immediately followed by glued
+          // body (a name-start / `<` / structure-escaped `\`) or ends the chunk (a split-flow opener) —
+          // a prose TS instantiation / generic reads with whitespace or punctuation after `>` (`Box<$Panel>
+          // holds`, `Technical<$Panel extends X>.`) and must NOT be counted as an opener that claims a closer.
+          const gluedOpener = text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() !== '';
+          // A LOSSY opener's `>` (`tag.end`) is a FAKE early one still inside a corrupted attribute, so the
+          // char after it is meaningless — only trust the body-glued tell on a clean, EXPRESSION-free opener.
+          // An opener carrying a `{…}`/`[…]` attribute expression (structure escapes its open as `\{`/`\[`)
+          // is a JSX component regardless of what follows a possibly-fake `>`.
+          const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !gluedOpener;
+          const hasExprAttr = /\\[{[]/.test(text.slice(tag.nameEnd, tag.end));
+          const bodyGlued = !tag.closed || lossy || hasExprAttr || text[tag.end] === undefined || /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
+          if (gluedOpener && !bodyGlued) { i = tag.closed ? tag.end : tag.nameEnd; continue; } // prose generic/instantiation, not a residue
           if (!isGeneric) nonGenericOpeners.set(tag.name, (nonGenericOpeners.get(tag.name) ?? 0) + 1);
-          else if (text.slice(0, tag.esc ? tag.lt - 1 : tag.lt).trim() === '') standaloneGenerics.set(tag.name, (standaloneGenerics.get(tag.name) ?? 0) + 1);
+          else if (!gluedOpener) standaloneGenerics.set(tag.name, (standaloneGenerics.get(tag.name) ?? 0) + 1);
         }
       }
       i = tag.closed ? tag.end : tag.nameEnd;
@@ -222,7 +235,13 @@ export function pairResidues(chunks: string[]): Set<string> {
           const inner = deEscape(text.slice(tag.lt + 1, tag.closed ? tag.end - 1 : tag.end)).trim();
           const generic = /[\s,=]/.test(inner) && isTsGeneric(inner);
           const callGlued = /[)\]>]$/.test(beforeLt); // `)`/`]`/`>` before `<` ⇒ a type-argument, never a fresh element
+          // A GLUED closed opener is prose (a TS instantiation / generic — `Box\<$Panel> holds`,
+          // `Technical\<$Panel extends X>.`) unless its `>` is followed by glued component body (a
+          // name-start / `<` / escape) or ends the chunk (a split-flow opener). Mirrors the pre-scan's
+          // budget count so a prose generic never competes with a real same-name flow for the closer.
+          const bodyGlued = !tag.closed || /\\[{[]/.test(text.slice(tag.nameEnd, tag.end)) || text[tag.end] === undefined || /[\p{ID_Start}$_<\\]/u.test(text[tag.end] ?? '');
           const lossy = tag.closed ? bracketDesync(text.slice(tag.nameEnd, tag.end)) : !glued;
+          const proseGlued = glued && tag.closed && !lossy && !bodyGlued;
           const flowOpen = global.some((g) => g.name === tag.name && g.definite) || local.some((l) => l.name === tag.name && l.endsChunk && l.definite);
           const trailing = tag.closed && text.slice(tag.end).trim() !== ''; // content after the opener's `>` in THIS chunk
           // A same-name opener while a DEFINITE flow is open is IN-BODY prose when it is GLUED (a
@@ -233,7 +252,7 @@ export function pairResidues(chunks: string[]): Set<string> {
           // same-name opener is instead a real NESTED flow (`\<$Panel extends INNERATTR24>` on its own
           // line) that must pair by LIFO. `generic` alone never forces in-body — that would swallow a
           // generic-shaped nested flow opener.
-          const inBody = callGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
+          const inBody = callGlued || proseGlued || (flowOpen && (glued || !tag.closed || (generic && trailing)));
           const definite = !generic && !glued && (tag.closed || lossy); // bare/attr'd real component, not generic-shaped
           // A generic-shaped opener stacks as flow only while a same-name closer remains for it (see
           // genericFlowBudget). A STANDALONE generic draws its own reserved slot; a GLUED one only stacks
@@ -480,14 +499,50 @@ function rawCloserRe(name: string): RegExp {
 //     whose corrupting quote sits PAST `k` (`value={fn("a \" } > X", …)}>` — the span looks balanced but
 //     the real end is the trailing `)}>`). Lexically safe: regex literals `/…/`, `/* … */` / `// …`
 //     comments, and code spans `` `…` `` are skipped so their literal `}` / `]` / `>` never miscount.
-function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
-  if (/["']\s+>$/.test(text.slice(nameEnd, k))) {
-    for (let m = k; m < text.length; m++) {
-      const ch = text[m];
-      if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; continue; } }
-      if (ch === '"' || ch === "'") { const cq = /^["']\s*>/.exec(text.slice(m)); if (cq) return m + cq[0].length; }
-    }
+// Resume a tag scan at `start` (just PAST a recovered leaked string) and return the index just past the
+// tag's real `>` at brace depth 0, or -1 if none. Mirrors scanTag's lexical rules over structure()'s
+// serialized residue: escaped opening brackets (`\{`/`\[`) raise depth, bare closes lower it, and quote /
+// regex / comment / code-span runs are skipped so their `>` never ends the tag early.
+function scanToTagEnd(text: string, start: number): number {
+  let quote = '', brace = 0, prevSig = '';
+  for (let m = start; m < text.length; m++) {
+    const ch = text[m];
+    if (quote) { if (ch === '\\') { m++; continue; } if (ch === quote) { quote = ''; prevSig = '"'; } continue; }
+    if (ch === '`') { const cs = codeSpanEnd(text, m); if (cs !== -1) { m = cs - 1; prevSig = '`'; continue; } }
+    if (brace > 0 && ch === '/' && text[m + 1] === '*') { const e = text.indexOf('*/', m + 2); m = e === -1 ? text.length : e + 1; continue; }
+    if (brace > 0 && ch === '/' && text[m + 1] === '/') { const e = text.indexOf('\n', m + 2); m = e === -1 ? text.length : e; continue; }
+    if (brace > 0 && ch === '/' && !/[\w$)\]}"'`]/.test(prevSig)) { const e = regexEnd(text, m); if (e !== -1) { m = e - 1; prevSig = '/'; continue; } }
+    if (ch === '\\' && /[<>{}[\]]/.test(text[m + 1] ?? '')) { const p = text[m + 1]; if (p === '{') brace++; else if (p === '}' && brace > 0) brace--; m++; prevSig = p; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === '{') brace++;
+    else if (ch === '}' && brace > 0) brace--;
+    else if (ch === '>' && !brace) return m + 1;
+    if (!/\s/.test(ch)) prevSig = ch;
   }
+  return -1;
+}
+
+function lossyOpenerEnd(text: string, nameEnd: number, k: number): number {
+  // QUOTE leak — the span ends with `<space><quote><space>+>`: structure() dropped a `\"`/`\'`
+  // backslash, so the string closed one char early and the DANGLING value-close quote is preceded by
+  // the space that used to sit before the escaped quote (`title="a \" >…` → `…a " >`). A CLEAN opener
+  // GLUES its real close-quote to the last value char (`a="1" >` — `1" >`, no space BEFORE the quote),
+  // so this never fires on an honest trailing-space tag. `leakQuote[1]` is the leaked string's quote.
+  const leakQuote = /\s(["'])\s+>$/.exec(text.slice(nameEnd, k));
+  if (leakQuote) {
+    // scanTag stopped at a FAKE `>` still INSIDE a string whose closing quote structure() dropped the
+    // backslash of (`title="a \" >…` → `title="a " >…`). We are mid-string at `k`. Close that string at
+    // its REAL quote, then finish a normal brace/quote/regex-aware tag scan to the tag's real `>` — so a
+    // later honest attribute (`pattern={/">/.test(X)}>`) is consumed instead of leaking into the body.
+    let m = k;
+    for (; m < text.length; m++) { const ch = text[m]; if (ch === '\\') { m++; continue; } if (ch === leakQuote[1]) { m++; break; } }
+    const end = scanToTagEnd(text, m);
+    if (end !== -1) return end;
+  }
+  // BRACKET leak — only when the opener's OWN span carried a `{…}`/`[…]` attribute expression
+  // (structure() escapes its open as `\{`/`\[`). A clean string-only attribute opener (`a="1">`) has
+  // no such expression, so an honest body `"}>` / `]>` must NOT be mistaken for a leaked bracket close.
+  if (!/\\[{[]/.test(text.slice(nameEnd, k))) return -1;
   let depth = 0, prevSig = '';
   for (let m = k; m < text.length; m++) {
     const ch = text[m];


### PR DESCRIPTION
Supersedes #148, which was conflicted (`CONFLICTING/DIRTY`) and carried unrelated files from a stale base. This branch is rebuilt on the latest `main` and carries **only** the two sanitizer files.

## What

Rebuild the Fumadocs search-index sanitizer so `structure()`'s lossily serialized MDX flow components are stripped from the index, while TS generics, type arguments, comparisons and prose `<…>` stay searchable.

## Round-15 blockers fixed (EVE's exact real-chain counterexamples)

- **Lossy `>`-recovery** now cuts at the real tag end at **brace/bracket depth 0**. When `structure()` drops the escaping quote in `items={["a > b"]}`, the `>` hiding inside the expression is skipped instead of ending the tag early — element body and suffix survive (paired, glued chunk-start, and template variants all covered).
- **Same-name inner generic** no longer mispaired: `pairResidues` skips a `<Name, U>` type-argument list (a top-level `,` right after the name), so `factory()<𐐀Panel, INNER>()` inside a `<𐐀Panel>` body is not popped by the outer `</𐐀Panel>`. The inner generic stays searchable (`$`/`_`/`ns.Qualified` variants too).
- **Bare `<out/in/const T="x">`** variance/modifier generics are kept — grammatically valid TS, so never speculatively deleted. The grammatically-identical `<const dataÉ="x">` is likewise kept (deleting a real generic is the worse failure); the round-14 assertion that expected it stripped was corrected.

## Evidence at exact head `59cb74b`

- `pnpm typecheck` — clean.
- `pnpm verify` — green: `react-router build` prerenders `/api/search` → `build/client/api/search`, then `REQUIRE_BUILT_INDEX=1` Orama e2e, **10/10**.
- **Route-wiring gate** proven: removing `build/client/api/search` fails the gate (`exit 1`, `REQUIRE_BUILT_INDEX set but … route or its buildIndex wiring did not emit the static index`); artifact restored identical by SHA-256.

## Diff scope

2 files vs `main`: `site/app/lib/search-index.ts`, `site/app/lib/search-index.test.ts`.
