### PR TITLE
Prevent duplicate live chat turns

### DIFF
--- a/server/src/lib/live-registry.test.ts
+++ b/server/src/lib/live-registry.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { liveGet, livePush, liveStart } from './live-registry.js';
+
+test('ring eviction retains meta and user-text replay identity', () => {
+  const sid = 'ring-identity-session';
+  const startedAt = 1_234;
+  const images = [{ mimeType: 'image/png', dataUrl: 'data:image/png;base64,YQ==' }];
+
+  liveStart(sid, { cwd: '/repo', startedAt });
+  livePush(sid, { type: 'user-text', text: 'hello', images });
+  for (let index = 0; index < 4_050; index++) {
+    livePush(sid, { type: 'delta', text: `chunk-${index}` });
+  }
+
+  const events = liveGet(sid)?.events;
+  assert.ok(events);
+  assert.equal(events.length, 4_000);
+  assert.deepEqual(events[0], { type: 'meta', cwd: '/repo', sessionId: sid, startedAt });
+  assert.deepEqual(events[1], { type: 'user-text', text: 'hello', images });
+  assert.deepEqual(events.at(-1), { type: 'delta', text: 'chunk-4049' });
+});

--- a/server/src/lib/live-registry.ts
+++ b/server/src/lib/live-registry.ts
@@ -16,23 +16,32 @@ const LIVE_RING = 4000;
 const KEEP_AROUND_MS = 60_000;
 const sessions = new Map<string, LiveSession>();
 
-export function liveStart(sid: string, meta: { cwd: string }): void {
+export function liveStart(sid: string, meta: { cwd: string; startedAt?: number }): number {
   // A resume on a stable sid (the codex route) can re-liveStart while a prior
   // turn's liveEnd delete timer is still pending — clear it so the fresh entry
   // isn't reaped mid-turn.
   clearTimeout(sessions.get(sid)?.gc);
+  const startedAt = meta.startedAt ?? Date.now();
   sessions.set(sid, {
-    events: [{ type: 'meta', cwd: meta.cwd, sessionId: sid }],
+    events: [{ type: 'meta', cwd: meta.cwd, sessionId: sid, startedAt }],
     subs: new Set(),
     ended: false,
   });
+  return startedAt;
 }
 
 export function livePush(sid: string, payload: SessionStreamEvent): void {
   const ls = sessions.get(sid);
   if (!ls || ls.ended) return;
   ls.events.push(payload);
-  if (ls.events.length > LIVE_RING) ls.events.splice(0, ls.events.length - LIVE_RING);
+  if (ls.events.length > LIVE_RING) {
+    // The replay identity is not disposable ring data. A long turn can easily
+    // exceed LIVE_RING through tool_input_delta events; dropping meta/user-text
+    // would leave a reattaching client unable to match the live turn to JSONL.
+    let pinned = ls.events[0]?.type === 'meta' ? 1 : 0;
+    if (ls.events[pinned]?.type === 'user-text') pinned += 1;
+    ls.events.splice(pinned, ls.events.length - LIVE_RING);
+  }
   for (const sub of ls.subs) {
     try {
       sseSend(sub, payload);

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -26,6 +26,10 @@ type FireResult = { ok: boolean; sessionId: string | null; error?: string };
 // whether the runner actually completed cleanly.
 async function drain(schedule: Schedule, stream: AsyncGenerator<RunnerEvent>): Promise<FireResult> {
   const isClaude = schedule.engine === 'claude';
+  // Capture before starting the async iterator. A cold runner can take long
+  // enough to emit its session id that Date.now() at liveStart would be newer
+  // than the JSONL user record and make snapshot reconciliation impossible.
+  const startedAt = Date.now();
   let sid = '';
   let ok = true;
   let sawDone = false;
@@ -34,7 +38,7 @@ async function drain(schedule: Schedule, stream: AsyncGenerator<RunnerEvent>): P
       if (ev.kind === 'session' && !sid) {
         sid = ev.sessionId;
         if (isClaude) {
-          liveStart(sid, { cwd: schedule.cwd });
+          liveStart(sid, { cwd: schedule.cwd, startedAt });
           livePush(sid, { type: 'user-text', text: schedule.prompt });
         }
       } else if (!isClaude) {

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -408,14 +408,15 @@ export async function registerSessionRoutes(app: FastifyInstance, options: Sessi
         // failure still takes the corresponding terminal cleanup path.
         sseStarted = true;
         startSSE(reply);
-        safeSend({ type: 'meta', cwd, sessionId: sid });
+        const startedAt = Date.now();
+        safeSend({ type: 'meta', cwd, sessionId: sid, startedAt });
 
         // Keep a server-authoritative copy of this turn independent of the
         // original response. A browser refresh closes that response, but the SDK
         // keeps running; /live replays this ring and then follows new events.
         liveStarted = true;
-        liveStart(sid, { cwd });
-        livePush(sid, { type: 'user-text', text });
+        liveStart(sid, { cwd, startedAt });
+        livePush(sid, { type: 'user-text', text, images });
 
         // The Settings-selected active provider determines which
         // Anthropic-compatible endpoint the SDK talks to (default = ambient

--- a/server/src/routes/workspaces.ts
+++ b/server/src/routes/workspaces.ts
@@ -224,6 +224,7 @@ export async function registerWorkspaceRoutes(app: FastifyInstance): Promise<voi
       // once it has a sid) can interrupt this stream. Navigating away does
       // NOT abort — only an explicit /stop does.
       const abortController = new AbortController();
+      const startedAt = Date.now();
       const stream = runClaude({ prompt: text, cwd, model, permissionMode, images, envOverrides: providerEnv, abortController });
 
       let clientGone = false;
@@ -246,11 +247,11 @@ export async function registerWorkspaceRoutes(app: FastifyInstance): Promise<voi
         for await (const ev of stream) {
           if (ev.kind === 'session' && !capturedSid) {
             capturedSid = ev.sessionId;
-            liveStart(capturedSid, { cwd });
+            liveStart(capturedSid, { cwd, startedAt });
             registerRun(capturedSid, abortController);
             if (pendingWt) bindWorktree(capturedSid, pendingWt).catch(() => {});
-            livePush(capturedSid, { type: 'user-text', text });
-            safeSend({ type: 'meta', cwd, sessionId: capturedSid });
+            livePush(capturedSid, { type: 'user-text', text, images });
+            safeSend({ type: 'meta', cwd, sessionId: capturedSid, startedAt });
           } else if (ev.kind === 'delta') {
             safeSend({ type: 'delta', text: ev.text });
             if (capturedSid) livePush(capturedSid, { type: 'delta', text: ev.text });

--- a/server/test/session-live-route.test.ts
+++ b/server/test/session-live-route.test.ts
@@ -48,6 +48,7 @@ test('resumed bypass turn survives original SSE disconnect and replays through /
   let finishRun!: () => void;
   const continueGate = new Promise<void>((resolve) => { continueRun = resolve; });
   const finishGate = new Promise<void>((resolve) => { finishRun = resolve; });
+  const attachedImages = [{ mimeType: 'image/png', dataUrl: 'data:image/png;base64,YQ==' }];
   let observedOptions: RunOptions | undefined;
 
   async function* fakeRunClaude(opts: RunOptions): AsyncGenerator<RunnerEvent> {
@@ -75,18 +76,20 @@ test('resumed bypass turn survives original SSE disconnect and replays through /
   const original = await fetch(`${base}${sessionPath}/message`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text: 'keep working', permissionMode: 'bypassPermissions' }),
+    body: JSON.stringify({ text: 'keep working', permissionMode: 'bypassPermissions', images: attachedImages }),
   });
   assert.equal(original.status, 200);
   assert.ok(original.body);
   const originalReader = original.body.getReader();
   const originalText = await readUntil(originalReader, 'before refresh');
   assert.match(originalText, /"type":"meta"/);
+  assert.match(originalText, /"startedAt":\d+/);
   assert.match(originalText, /before refresh/);
   await originalReader.cancel();
 
   assert.equal(observedOptions?.resume, sid);
   assert.equal(observedOptions?.permissionMode, 'bypassPermissions');
+  assert.deepEqual(observedOptions?.images, attachedImages);
   assert.equal(observedOptions?.abortController?.signal.aborted, false);
 
   const duplicate = await fetch(`${base}${sessionPath}/message`, {
@@ -105,7 +108,8 @@ test('resumed bypass turn survives original SSE disconnect and replays through /
   const liveReader = reattached.body.getReader();
   let liveText = await readUntil(liveReader, 'before refresh');
   assert.match(liveText, /"type":"meta"/);
-  assert.match(liveText, /"type":"user-text","text":"keep working"/);
+  assert.match(liveText, /"startedAt":\d+/);
+  assert.ok(liveText.includes(JSON.stringify({ type: 'user-text', text: 'keep working', images: attachedImages })));
 
   continueRun();
   liveText = await readUntil(liveReader, 'after refresh', liveText);

--- a/shared/src/sse.ts
+++ b/shared/src/sse.ts
@@ -16,9 +16,9 @@ export type CodexApprovalKind = 'command' | 'file' | 'network';
 export type CodexDecision = 'accept' | 'acceptForSession' | 'decline' | 'cancel';
 
 export type SessionStreamEvent =
-  | { type: 'meta'; cwd: string; sessionId: string }
+  | { type: 'meta'; cwd: string; sessionId: string; startedAt?: number }
   | { type: 'starting'; cwd: string }
-  | { type: 'user-text'; text: string }
+  | { type: 'user-text'; text: string; images?: Array<{ mimeType: string; dataUrl: string }> }
   | { type: 'delta'; text: string }
   // Reasoning/thinking stream, distinct from assistant `delta` so the client
   // can style/collapse it as its own block rather than inline prose.

--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -7,6 +7,7 @@
 // → the returned promise resolves with the sessionId so Workspace can navigate.
 // Session subscribes and gets the current buffer + live updates.
 
+import type { Message } from '@macaron/shared';
 import { extractPartialCode } from './partialJson';
 import { authedFetch } from './auth';
 
@@ -41,6 +42,9 @@ export type LiveTurnItem =
 export type LiveUserImage = { mimeType: string; dataUrl: string };
 export type LiveState = {
   cwd: string;
+  // Server timestamp for this specific runner invocation. Snapshot handoff
+  // uses it to distinguish a newly-persisted turn from an older identical one.
+  startedAt: number;
   userText: string;
   // Attachments on the in-flight user turn. Kept in the module store so
   // they survive a component remount (e.g. Workspace promotes a draft
@@ -58,8 +62,120 @@ export type LiveState = {
   // len/4 estimate). Reset to -1 at the start of each new turn.
   outputTokens: number;
   done: boolean;
+  // True only after the server's explicit terminal event. Transport EOF is
+  // not proof that the runner stopped and must never authorize a handoff.
+  terminalSeen: boolean;
   error?: string;
 };
+
+export type LiveTurnFingerprint = {
+  startedAt: number;
+  userText: string;
+  userImages: LiveUserImage[];
+  assistantText: string;
+  toolUseIds: string[];
+  resolvedToolUseIds: string[];
+  terminalSeen: boolean;
+};
+
+const SNAPSHOT_CLOCK_SKEW_MS = 2_000;
+
+function imagePayload(dataUrl: string): { mimeType: string; data: string } {
+  const match = /^data:([^;]+);base64,(.*)$/.exec(dataUrl);
+  return { mimeType: match?.[1] || '', data: match?.[2] || '' };
+}
+
+/** Freeze the terminal live state before the module store is consumed. */
+export function fingerprintLiveTurn(state: LiveState): LiveTurnFingerprint {
+  const toolUseIds: string[] = [];
+  const resolvedToolUseIds: string[] = [];
+  let assistantText = '';
+  for (const item of state.timeline) {
+    if (item.kind === 'text') {
+      assistantText += item.text;
+      continue;
+    }
+    if (item.kind === 'permission') continue;
+    const toolUseId = item.kind === 'genui'
+      ? item.toolUseId
+      : item.id.startsWith('live-')
+        ? item.id.slice('live-'.length)
+        : item.id;
+    toolUseIds.push(toolUseId);
+    if ((item.kind === 'tool' && item.result !== undefined)
+      || (item.kind === 'genui' && item.status !== 'pending')) {
+      resolvedToolUseIds.push(toolUseId);
+    }
+  }
+  return {
+    startedAt: state.startedAt,
+    userText: state.userText,
+    userImages: state.userImages.map((image) => ({ ...image })),
+    assistantText,
+    toolUseIds,
+    resolvedToolUseIds,
+    terminalSeen: state.terminalSeen,
+  };
+}
+
+function matchesLiveUser(message: Message, turn: LiveTurnFingerprint): boolean {
+  if (message.role !== 'user') return false;
+  const timestamp = Date.parse(message.timestamp || '');
+  if (!Number.isFinite(timestamp) || timestamp < turn.startedAt - SNAPSHOT_CLOCK_SKEW_MS) return false;
+  const text = message.blocks
+    .filter((block) => block.kind === 'text')
+    .map((block) => block.text)
+    .join('')
+    .trim();
+  if (text !== turn.userText.trim()) return false;
+  const images = message.blocks
+    .filter((block) => block.kind === 'image')
+    .map((block) => ({ mimeType: block.mimeType, data: block.data }));
+  const expectedImages = turn.userImages.map((image) => imagePayload(image.dataUrl));
+  return images.length === expectedImages.length
+    && images.every((image, index) => image.mimeType === expectedImages[index]?.mimeType
+      && image.data === expectedImages[index]?.data);
+}
+
+/**
+ * True only when the persisted transcript contains the complete live turn.
+ * A message count cannot prove this: JSONL may expose an old history or only
+ * the new user record while the assistant record is still being flushed.
+ */
+export function snapshotCoversLiveTurn(messages: Message[], turn: LiveTurnFingerprint): boolean {
+  if (!turn.terminalSeen) return false;
+
+  let userIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (matchesLiveUser(messages[index]!, turn)) {
+      userIndex = index;
+      break;
+    }
+  }
+  if (userIndex < 0) return false;
+
+  let assistantText = '';
+  const toolUseIds = new Set<string>();
+  const resolvedToolUseIds = new Set<string>();
+  for (let index = userIndex + 1; index < messages.length; index++) {
+    const message = messages[index]!;
+    // A later visible user prompt belongs to the next logical turn. Tool-result
+    // user records carry no text/image blocks and remain part of this segment.
+    if (message.role === 'user' && message.blocks.some((block) => block.kind === 'text' || block.kind === 'image')) break;
+    for (const block of message.blocks) {
+      if (message.role === 'assistant' && block.kind === 'text') assistantText += block.text;
+      else if (block.kind === 'tool_use') toolUseIds.add(block.id);
+      else if (block.kind === 'tool_result' && block.toolUseId) resolvedToolUseIds.add(block.toolUseId);
+    }
+  }
+
+  // An explicitly terminal empty/error turn is complete once its current user
+  // record is present. Non-empty turns still require every visible assistant
+  // fragment and resolved tool result below.
+  return assistantText === turn.assistantText
+    && turn.toolUseIds.every((id) => toolUseIds.has(id))
+    && turn.resolvedToolUseIds.every((id) => resolvedToolUseIds.has(id));
+}
 
 let liveTextIdSeq = 0;
 function appendText(items: LiveTurnItem[], text: string): void {
@@ -78,10 +194,25 @@ function appendText(items: LiveTurnItem[], text: string): void {
 function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown }): void {
   if (p.type === 'meta') {
     const s = states.get(sid);
-    if (s && typeof p.cwd === 'string') s.cwd = p.cwd;
+    if (s) {
+      if (typeof p.cwd === 'string') s.cwd = p.cwd;
+      if (typeof p.startedAt === 'number') s.startedAt = p.startedAt;
+    }
   } else if (p.type === 'user-text') {
     const s = states.get(sid);
-    if (s) { s.userText = String(p.text || ''); notify(sid); }
+    if (s) {
+      s.userText = String(p.text || '');
+      if (Array.isArray(p.images)) {
+        s.userImages = p.images.flatMap((image) => {
+          if (!image || typeof image !== 'object') return [];
+          const value = image as { mimeType?: unknown; dataUrl?: unknown };
+          return typeof value.mimeType === 'string' && typeof value.dataUrl === 'string'
+            ? [{ mimeType: value.mimeType, dataUrl: value.dataUrl }]
+            : [];
+        });
+      }
+      notify(sid);
+    }
   } else if (p.type === 'delta') {
     const s = states.get(sid);
     if (s) { appendText(s.timeline, String(p.text || '')); notify(sid); }
@@ -187,7 +318,7 @@ function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown })
     followupWatchers.get(sid)?.forEach((cb) => cb(String(p.text || '')));
   } else if (p.type === 'done') {
     const s = states.get(sid);
-    if (s) { s.done = true; notify(sid); }
+    if (s) { s.done = true; s.terminalSeen = true; notify(sid); }
   } else if (p.type === 'error') {
     const s = states.get(sid);
     if (s) { s.error = String(p.error || ''); notify(sid); }
@@ -196,6 +327,9 @@ function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown })
 
 const states = new Map<string, LiveState>();
 const watchers = new Map<string, Set<(s: LiveState) => void>>();
+type ConsumedLive = { startedAt: number; expiresAt: number };
+const consumedLive = new Map<string, ConsumedLive>();
+const CONSUMED_LIVE_TTL_MS = 60_000;
 type AttachResult = 'attached' | 'not-live';
 type LiveAttachment = { ready: Promise<AttachResult> };
 // A reattach reader stays alive after `ready` resolves. Keep it registered
@@ -233,9 +367,35 @@ function notify(sid: string): void {
 
 // Discard buffered state once the consumer has merged it into the canonical
 // jsonl-derived data (Session.tsx calls this after load()).
-export function clearLive(sid: string): void {
+export function clearLive(sid: string, startedAt?: number): void {
+  const consumedStartedAt = startedAt ?? states.get(sid)?.startedAt;
   states.delete(sid);
   watchers.delete(sid);
+  // The server retains an ended replay ring for 60s. Remember that this exact
+  // ring was consumed so a remount cannot replay the completed turn on top of
+  // the JSONL snapshot during the handoff window.
+  if (typeof consumedStartedAt === 'number') {
+    consumedLive.set(sid, {
+      startedAt: consumedStartedAt,
+      expiresAt: Date.now() + CONSUMED_LIVE_TTL_MS,
+    });
+  }
+}
+
+/** Drop a broken transport buffer without marking its server turn consumed. */
+export function discardLive(sid: string): void {
+  states.delete(sid);
+  watchers.delete(sid);
+}
+
+function liveWasConsumed(sid: string, startedAt: number): boolean {
+  const consumed = consumedLive.get(sid);
+  if (!consumed) return false;
+  if (consumed.expiresAt <= Date.now()) {
+    consumedLive.delete(sid);
+    return false;
+  }
+  return consumed.startedAt === startedAt;
 }
 
 // Subscribe to the add-on follow-up stream for a session. Callback fires per
@@ -320,6 +480,7 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                 if (!states.has(sid)) {
                   states.set(sid, {
                     cwd: p.cwd || '',
+                    startedAt: typeof p.startedAt === 'number' ? p.startedAt : Date.now(),
                     userText: text,
                     // Carry the user's attachments so a draft→real remount
                     // in the Workspace canvas doesn't lose the image chips
@@ -331,6 +492,7 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                     timeline: [],
                     outputTokens: -1,
                     done: false,
+                    terminalSeen: false,
                   });
                 }
                 notify(sid);
@@ -446,6 +608,7 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                 const s = states.get(sid);
                 if (s) {
                   s.done = true;
+                  s.terminalSeen = true;
                   notify(sid);
                 }
               } else if (sid && p.type === 'error') {
@@ -495,6 +658,12 @@ export function attachLive(project: string, sid: string): Promise<AttachResult> 
   const settle = (result: AttachResult) => {
     if (readySettled) return;
     readySettled = true;
+    // A negative probe has no reader for later callers to share. Remove it
+    // before resolving so an immediate new turn on the same sid cannot inherit
+    // this already-settled `not-live` result.
+    if (result === 'not-live' && liveAttachments.get(sid) === attachment) {
+      liveAttachments.delete(sid);
+    }
     settleReady(result);
   };
   liveAttachments.set(sid, attachment);
@@ -536,14 +705,23 @@ export function attachLive(project: string, sid: string): Promise<AttachResult> 
               return;
             }
             if (!seenAnyEvent) {
+              if (p.type === 'meta'
+                && typeof p.startedAt === 'number'
+                && liveWasConsumed(sid, p.startedAt)) {
+                settle('not-live');
+                await reader.cancel();
+                return;
+              }
               seenAnyEvent = true;
               states.set(sid, {
                 cwd: p.type === 'meta' && typeof p.cwd === 'string' ? p.cwd : '',
+                startedAt: p.type === 'meta' && typeof p.startedAt === 'number' ? p.startedAt : Date.now(),
                 userText: '',
                 userImages: [],
                 timeline: [],
                 outputTokens: -1,
                 done: false,
+                terminalSeen: false,
               });
               settle('attached');
             }

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -75,7 +75,7 @@ export async function streamOpenAI(
 // Parse our session-message protocol ({type:'delta'|'meta'|'event'|'error'|'done'}).
 export type SessionStreamHandlers = {
   onDelta?: (text: string) => void;
-  onMeta?: (m: { cwd: string; sessionId: string }) => void;
+  onMeta?: (m: { cwd: string; sessionId: string; startedAt?: number }) => void;
   onStarting?: (m: { cwd: string }) => void;
   onEvent?: (e: { event: string; subtype?: string | null }) => void;
   onToolUse?: (t: { id: string; name: string; input: unknown }) => void;
@@ -86,7 +86,7 @@ export type SessionStreamHandlers = {
   onPermissionResolved?: (p: { id: string; decision: 'allow' | 'deny' }) => void;
   onUsage?: (u: { outputTokens: number; thinkingTokens?: number }) => void;
   onError?: (msg: string) => void;
-  onDone?: () => void;
+  onDone?: (terminalSeen: boolean) => void;
   onFollowupDelta?: (text: string) => void;
 };
 
@@ -95,9 +95,21 @@ export async function streamSession(
   body: unknown,
   h: SessionStreamHandlers,
 ): Promise<void> {
+  let terminalSeen = false;
+  let doneNotified = false;
+  const notifyDone = (terminal: boolean) => {
+    if (terminal) terminalSeen = true;
+    if (doneNotified) return;
+    doneNotified = true;
+    h.onDone?.(terminalSeen);
+  };
   const finishWithError = (msg: string) => {
+    // The main turn can finish before the server's optional follow-up stream.
+    // A later socket close must not report a second completion/error into a
+    // newer turn that the user already started.
+    if (doneNotified) return;
     h.onError?.(msg);
-    h.onDone?.();
+    notifyDone(false);
   };
   let resp: Response;
   try {
@@ -133,7 +145,7 @@ export async function streamSession(
           .trim();
         if (!data) continue;
         if (data === '[DONE]') {
-          h.onDone?.();
+          notifyDone(false);
           return;
         }
         try {
@@ -149,14 +161,18 @@ export async function streamSession(
           else if (p.type === 'permission_request') h.onPermissionRequest?.(p);
           else if (p.type === 'permission_resolved') h.onPermissionResolved?.(p);
           else if (p.type === 'usage') h.onUsage?.(p);
-          else if (p.type === 'error') h.onError?.(p.error);
+          else if (p.type === 'error') {
+            if (!doneNotified) h.onError?.(p.error);
+          }
           else if (p.type === 'warn') console.warn('[claude]', p.text);
           // The server keeps the stream open after `done` to append follow-up
           // suggestions, so fire onDone on the business event — the turn is
           // over the moment it arrives, not when the socket closes. The
-          // trailing onDone at stream close stays as the error-path fallback
-          // (it's idempotent).
-          else if (p.type === 'done') h.onDone?.();
+          // transport close remains the fallback only when no terminal event
+          // was seen; notifyDone guarantees one completion callback per POST.
+          else if (p.type === 'done') {
+            notifyDone(true);
+          }
           else if (p.type === 'followup_delta') h.onFollowupDelta?.(p.text);
         } catch {
           /* ignore */
@@ -167,5 +183,5 @@ export async function streamSession(
     finishWithError((e as Error).message);
     return;
   }
-  h.onDone?.();
+  notifyDone(false);
 }

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -13,7 +13,18 @@ import {
   type SlashCommand,
 } from '../lib/api';
 import { streamSession } from '../lib/sse';
-import { getLive, subscribeLive, clearLive, subscribeFollowup, startNewSession, attachLive } from '../lib/liveStore';
+import {
+  attachLive,
+  clearLive,
+  discardLive,
+  fingerprintLiveTurn,
+  getLive,
+  snapshotCoversLiveTurn,
+  startNewSession,
+  subscribeFollowup,
+  subscribeLive,
+  type LiveTurnFingerprint,
+} from '../lib/liveStore';
 import { peekPendingCwd, takePendingCwd, takePendingPrompt } from '../lib/newSession';
 import { hasActiveModal } from '../lib/modal';
 import { extractPartialCode, parseFollowups } from '../lib/partialJson';
@@ -1138,6 +1149,10 @@ export function Session(props: SessionProps = {}) {
   // subscribeLive branch runs the same way it does for a freshly-started
   // session.
   const [reattached, setReattached] = useState(false);
+  // A pending prop can stay true across a transport reconnect, so boolean
+  // isPending alone is not enough to restart the liveStore subscription.
+  const [liveSubscriptionGen, setLiveSubscriptionGen] = useState(0);
+  const liveDisconnected = useRef(false);
   const isPending = routePending || Boolean(props.initialPending) || reattached;
   const onCreated = props.onCreated;
   const onPendingConsumed = props.onPendingConsumed;
@@ -1146,6 +1161,8 @@ export function Session(props: SessionProps = {}) {
   const focused = props.focused ?? true;
   const hideBar = props.hideBar ?? false;
   const refreshKey = props.refreshKey ?? 0;
+  const [reconnectKey, setReconnectKey] = useState(0);
+  const lastRefreshKey = useRef({ refreshKey, reconnectKey });
   const onSendingChange = props.onSendingChange;
   // Ref rather than closure — send() captures props once, but permission
   // notifications may fire long after the send call. Ref lets the click
@@ -1169,15 +1186,22 @@ export function Session(props: SessionProps = {}) {
   // 'error' cue as if the turn had actually failed.
   const stoppingRef = useRef(false);
   const [data, setData] = useState<SessionDetail | null>(null);
+  // Invalidates a post-done JSONL poll when the session changes or another
+  // turn starts before the prior handoff finishes.
+  const snapshotHandoffGen = useRef(0);
+  const pendingSnapshotTurn = useRef<ReturnType<typeof fingerprintLiveTurn> | null>(null);
+  const directSnapshotTurn = useRef<LiveTurnFingerprint | null>(null);
+  const directTurnStartedAt = useRef<number | undefined>(undefined);
   const [error, setError] = useState('');
   const [sending, setSending] = useState(false);
   const [polling, setPolling] = useState(false);
+  const [handoffPending, setHandoffPending] = useState(false);
   // Notify the parent tile whenever the effective "running" state flips
   // (either an in-flight send OR the initial new-session SSE poll). Debounced
   // by a microtask so React batches state updates naturally.
   useEffect(() => {
-    onSendingChange?.(sending || polling);
-  }, [sending, polling, onSendingChange]);
+    onSendingChange?.(sending || polling || handoffPending);
+  }, [sending, polling, handoffPending, onSendingChange]);
   // Browser notification on stream completion. Tracks the running edge:
   // fires on true→false when we actually streamed this turn (avoids
   // pinging on the initial jsonl load when everything starts at false).
@@ -1560,22 +1584,54 @@ export function Session(props: SessionProps = {}) {
     }
   }, [project, sid, toast]);
 
+  const commitSnapshot = useCallback((next: SessionDetail, clearLiveOverlay = false) => {
+    setData(next);
+    setShown(PAGE_SIZE);
+    setCompletedTurns([]);
+    if (clearLiveOverlay) {
+      // Commit the authoritative snapshot and retire every volatile source in
+      // the same React batch. Rendering data first and clearing live after an
+      // await exposes both copies for a frame.
+      setLiveUser('');
+      setLiveTurn([]);
+      setLiveUserImages([]);
+      setOutputTokens(-1);
+    }
+  }, []);
+
+  const fetchSnapshot = useCallback(() => api.session(project, sid), [project, sid]);
+
   const load = useCallback(async (opts?: { silent?: boolean }) => {
     if (!opts?.silent) setError('');
     try {
-      const d = await api.session(project, sid);
-      setData(d);
-      setShown(PAGE_SIZE);
-      // A successful load means the jsonl is now canonical; drop any
-      // in-memory completedTurns that were carrying the tail across a stale
-      // "done" event.
-      setCompletedTurns([]);
+      const d = await fetchSnapshot();
+      commitSnapshot(d);
       return d;
     } catch (e) {
       if (!opts?.silent) setError((e as Error).message);
       return null;
     }
-  }, [project, sid]);
+  }, [commitSnapshot, fetchSnapshot]);
+
+  const refreshFromDisk = useCallback(async () => {
+    const generation = ++snapshotHandoffGen.current;
+    setError('');
+    try {
+      const next = await fetchSnapshot();
+      if (snapshotHandoffGen.current !== generation) return;
+      const liveTurn = pendingSnapshotTurn.current ?? directSnapshotTurn.current;
+      if (liveTurn && !snapshotCoversLiveTurn(next.messages, liveTurn)) {
+        setError('Transcript is still flushing; the complete live turn was kept visible.');
+        return;
+      }
+      pendingSnapshotTurn.current = null;
+      directSnapshotTurn.current = null;
+      commitSnapshot(next, true);
+      clearLive(sid, directTurnStartedAt.current);
+    } catch (e) {
+      if (snapshotHandoffGen.current === generation) setError((e as Error).message);
+    }
+  }, [commitSnapshot, fetchSnapshot, sid]);
 
   // Pick exactly one source for the current turn. A freshly-created session
   // already has startNewSession's POST reader writing to liveStore; opening a
@@ -1583,6 +1639,25 @@ export function Session(props: SessionProps = {}) {
   // page refresh the module store is empty, so probe /live first and only load
   // the canonical jsonl when the server confirms there is no active stream.
   useEffect(() => {
+    const refreshRequested = refreshKey !== lastRefreshKey.current.refreshKey
+      || reconnectKey !== lastRefreshKey.current.reconnectKey;
+    lastRefreshKey.current = { refreshKey, reconnectKey };
+    // Canvas refresh is a source switch. Ignore a stale/programmatic click
+    // while a direct POST, reattach, or snapshot handoff still owns the turn.
+    if (refreshRequested && (sending || polling || handoffPending)) return;
+    // If automatic handoff exhausted its retry window, a later tile refresh
+    // must still pass the same completeness gate instead of dropping the live
+    // overlay and loading a stale/partial snapshot.
+    if (refreshRequested && (pendingSnapshotTurn.current || directSnapshotTurn.current)) {
+      void refreshFromDisk();
+      return;
+    }
+    snapshotHandoffGen.current += 1;
+    pendingSnapshotTurn.current = null;
+    directSnapshotTurn.current = null;
+    directTurnStartedAt.current = undefined;
+    if (!refreshRequested) liveDisconnected.current = false;
+    setHandoffPending(false);
     setData(null);
     setLiveTurn([]);
     setLiveUser('');
@@ -1594,6 +1669,10 @@ export function Session(props: SessionProps = {}) {
     if (local) {
       setReattached(true);
       setSending(!local.done);
+      if (liveDisconnected.current) {
+        liveDisconnected.current = false;
+        setLiveSubscriptionGen((generation) => generation + 1);
+      }
       return;
     }
 
@@ -1613,6 +1692,10 @@ export function Session(props: SessionProps = {}) {
         }
         setReattached(true);
         setSending(!current.done);
+        if (liveDisconnected.current) {
+          liveDisconnected.current = false;
+          setLiveSubscriptionGen((generation) => generation + 1);
+        }
         return;
       }
       void load({ silent: true }).finally(() => {
@@ -1620,7 +1703,7 @@ export function Session(props: SessionProps = {}) {
       });
     });
     return () => { cancelled = true; };
-  }, [project, sid, load, isNew, refreshKey]);
+  }, [project, sid, load, isNew, refreshKey, reconnectKey, refreshFromDisk]);
 
   // Global Shift+Tab → cycle permission mode, matching claude-cli's binding.
   // The browser's own "reverse focus" behaviour is preempted; we surface the
@@ -1720,32 +1803,34 @@ export function Session(props: SessionProps = {}) {
         }),
       );
     };
-    // Snapshot the message count at subscribe time so we can tell when the
-    // CLI has actually flushed our just-streamed turn to disk. The
-    // reload → clear-live handoff below only fires once the count has grown.
-    const preCount = data?.messages?.length ?? 0;
-
-    const finishLive = () => {
+    const finishLive = (finished: NonNullable<typeof seed>) => {
+      const turn = fingerprintLiveTurn(finished);
+      const generation = ++snapshotHandoffGen.current;
+      pendingSnapshotTurn.current = turn;
       setPolling(false);
       setSending(false);
+      setHandoffPending(true);
       setReattached(false);
+      liveDisconnected.current = false;
       clearLive(sid);
       onPendingConsumed?.();
-      // Atomic swap: reload the jsonl and — once disk actually has our new
-      // turn — clear the live buffers so we don't render both the live copy
-      // AND the persisted copy at the same time. Retry a couple times if
-      // the flush lags. If the CLI never catches up, leave live buffers
-      // mounted (the next send's rollLiveIntoHistory sweeps them up).
+      // Poll without publishing intermediate snapshots. JSONL can briefly
+      // contain only old history or the new user line; neither is allowed to
+      // coexist with (or replace) the complete live turn.
       const swap = async () => {
-        for (let attempt = 0; attempt < 6; attempt++) {
-          if (attempt > 0) await new Promise((r) => setTimeout(r, 250 * attempt));
-          const d = await load({ silent: true });
-          if (d && d.messages.length > preCount) {
-            setLiveUser('');
-            setLiveTurn([]);
-            setLiveUserImages([]);
-            return;
+        try {
+          for (let attempt = 0; attempt < 6; attempt++) {
+            if (attempt > 0) await new Promise((r) => setTimeout(r, 250 * attempt));
+            const d = await fetchSnapshot().catch(() => null);
+            if (snapshotHandoffGen.current !== generation) return;
+            if (d && snapshotCoversLiveTurn(d.messages, turn)) {
+              pendingSnapshotTurn.current = null;
+              commitSnapshot(d, true);
+              return;
+            }
           }
+        } finally {
+          if (snapshotHandoffGen.current === generation) setHandoffPending(false);
         }
       };
       void swap();
@@ -1756,7 +1841,15 @@ export function Session(props: SessionProps = {}) {
       // enables this subscription. Consume that terminal snapshot immediately
       // instead of waiting for a future notification that will never arrive.
       if (seed.done) {
-        finishLive();
+        if (seed.terminalSeen) finishLive(seed);
+        else {
+          setPolling(false);
+          setSending(false);
+          setReattached(false);
+          liveDisconnected.current = true;
+          discardLive(sid);
+          setError('Live stream disconnected before completion. Refresh to reconnect.');
+        }
         return;
       }
     }
@@ -1774,7 +1867,15 @@ export function Session(props: SessionProps = {}) {
         // Keep the live buffers mounted while finishLive restores canonical
         // history. The CLI may still be flushing jsonl, so that reload must not
         // replace the just-streamed turn.
-        finishLive();
+        if (s.terminalSeen) finishLive(s);
+        else {
+          setPolling(false);
+          setSending(false);
+          setReattached(false);
+          liveDisconnected.current = true;
+          discardLive(sid);
+          setError('Live stream disconnected before completion. Refresh to reconnect.');
+        }
         // Follow-up suggestions stream AFTER `done` over an independent
         // channel (subscribeFollowup), so clearing the live store here is
         // safe — the stop semantics are identical to before the feature.
@@ -1790,7 +1891,7 @@ export function Session(props: SessionProps = {}) {
     return () => {
       unsub();
     };
-  }, [isPending, sid, load, onPendingConsumed]);
+  }, [commitSnapshot, fetchSnapshot, isPending, liveSubscriptionGen, sid, onPendingConsumed]);
 
   const rawItems = useMemo(() => (data ? flatten(data.messages) : []), [data]);
   // Collapse consecutive read-only tool operations (Read / Grep / Glob /
@@ -1812,7 +1913,7 @@ export function Session(props: SessionProps = {}) {
   const lastItemKind = items[items.length - 1]?.kind;
   const idleFollowupFired = useRef(false);
   useEffect(() => {
-    if (isNew || isPending || sending || polling) return;
+    if (isNew || isPending || sending || polling || handoffPending) return;
     if (lastItemKind !== 'assistant' || followupRaw || idleFollowupFired.current) return;
     idleFollowupFired.current = true;
     const gen = ++followupGen.current;
@@ -1821,7 +1922,7 @@ export function Session(props: SessionProps = {}) {
       {},
       { onFollowupDelta: (t) => { if (followupGen.current === gen) setFollowupRaw((prev) => prev + t); } },
     );
-  }, [project, sid, isNew, isPending, sending, polling, lastItemKind]);
+  }, [project, sid, isNew, isPending, sending, polling, handoffPending, lastItemKind]);
 
   // Latest TodoWrite snapshot (flatten dedupes to keep only one at any time).
   // The status bar mirrors the current in-progress task + progress fraction.
@@ -1919,6 +2020,25 @@ export function Session(props: SessionProps = {}) {
       // New turn ⇒ new follow-up generation: clears the chips and invalidates
       // any deltas still streaming from the previous turn's follow-up query.
       const fGen = resetFollowups();
+      // Any pending snapshot handoff belongs to the previous turn. Also allow
+      // a remount to attach to the fresh server ring for this send instead of
+      // treating the prior ended ring's tombstone as current.
+      snapshotHandoffGen.current += 1;
+      pendingSnapshotTurn.current = null;
+      setHandoffPending(false);
+      directTurnStartedAt.current = undefined;
+      const directTurn: LiveTurnFingerprint | null = isNew
+        ? null
+        : {
+            startedAt: Date.now(),
+            userText: text,
+            userImages: sentImages.map((image) => ({ mimeType: image.mimeType, dataUrl: image.dataUrl })),
+            assistantText: '',
+            toolUseIds: [],
+            resolvedToolUseIds: [],
+            terminalSeen: false,
+          };
+      directSnapshotTurn.current = directTurn;
       // Persist to prompt history (manual and queued sends alike).
       const nextHistory = pushHistory(project, text);
       setHistory(nextHistory);
@@ -1987,7 +2107,16 @@ export function Session(props: SessionProps = {}) {
           images: sentImages.map((i) => ({ mimeType: i.mimeType, dataUrl: i.dataUrl })),
         },
         {
+          onMeta: (meta) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
+            if (typeof meta.startedAt === 'number') {
+              directTurnStartedAt.current = meta.startedAt;
+              directTurn.startedAt = meta.startedAt;
+            }
+          },
           onDelta: (t) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
+            directTurn.assistantText += t;
             setLiveTurn((cur) => {
               const last = cur[cur.length - 1];
               if (last?.kind === 'live-assistant') {
@@ -2003,6 +2132,8 @@ export function Session(props: SessionProps = {}) {
             });
           },
           onToolUse: ({ id, name, input: toolInput }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
+            directTurn.toolUseIds.push(id);
             setLiveTurn((cur) =>
               isRenderUITool(name)
                 ? [
@@ -2016,6 +2147,7 @@ export function Session(props: SessionProps = {}) {
             );
           },
           onToolInputDelta: ({ id, name, accumulated }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             if (!isRenderUITool(name)) return;
             const partial = extractPartialCode(accumulated);
             if (!partial) return;
@@ -2028,6 +2160,7 @@ export function Session(props: SessionProps = {}) {
             );
           },
           onToolInputDone: ({ id, name, final_json }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             try {
               const obj = JSON.parse(final_json);
               if (isRenderUITool(name) && typeof obj?.code === 'string') {
@@ -2046,6 +2179,7 @@ export function Session(props: SessionProps = {}) {
             } catch { /* tolerate parse fail; stream still delivers */ }
           },
           onPermissionRequest: ({ id, toolName, input, suggestion }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             // Nudge the user via native notification when a tool needs
             // approval — otherwise a session in a background tab can
             // silently stall. requireInteraction keeps it visible until
@@ -2078,6 +2212,7 @@ export function Session(props: SessionProps = {}) {
             ]);
           },
           onPermissionResolved: ({ id, decision }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             setLiveTurn((cur) =>
               cur.map((t) =>
                 t.kind === 'permission' && t.permissionId === id ? { ...t, status: decision } : t,
@@ -2085,6 +2220,10 @@ export function Session(props: SessionProps = {}) {
             );
           },
           onToolResult: ({ tool_use_id, text: resultText, isError }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
+            if (!directTurn.resolvedToolUseIds.includes(tool_use_id)) {
+              directTurn.resolvedToolUseIds.push(tool_use_id);
+            }
             setLiveTurn((cur) =>
               cur.map((t) => {
                 if (t.kind === 'genui' && t.toolUseId === tool_use_id) {
@@ -2101,9 +2240,11 @@ export function Session(props: SessionProps = {}) {
             );
           },
           onUsage: ({ outputTokens: ot }) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             setOutputTokens((cur) => (ot > cur ? ot : cur));
           },
           onError: (err) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
             turnErroredRef.current = true;
             // A user Stop surfaces here as an error — suppress the error cue
             // in that case (turnErroredRef above already keeps the trailing
@@ -2121,7 +2262,18 @@ export function Session(props: SessionProps = {}) {
               ];
             });
           },
-          onDone: () => {
+          onDone: (terminalSeen) => {
+            if (!directTurn || directSnapshotTurn.current !== directTurn) return;
+            if (terminalSeen) {
+              directTurn.terminalSeen = true;
+            } else if (!terminalSeen && directTurnStartedAt.current !== undefined) {
+              // The server assigned this turn, so a bare EOF means only the
+              // browser transport died. Keep the rendered overlay, drop the
+              // incomplete disk fingerprint, and let Refresh reattach /live.
+              directSnapshotTurn.current = null;
+              liveDisconnected.current = true;
+              setError('Live stream disconnected before completion. Refresh to reconnect.');
+            }
             // Don't re-read the jsonl here — the CLI writes it asynchronously
             // and it's often still stale at this point, which made the
             // just-streamed reply flicker or vanish. Keep the live buffers
@@ -2434,10 +2586,13 @@ export function Session(props: SessionProps = {}) {
             )}
             <button
               className="icon-btn"
-              onClick={() => load()}
+              onClick={() => {
+                if (liveDisconnected.current) setReconnectKey((key) => key + 1);
+                else void refreshFromDisk();
+              }}
               title="Refresh"
               aria-label="Refresh"
-              disabled={isNew}
+              disabled={isNew || sending || polling || handoffPending}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" />

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -513,10 +513,12 @@ function SortableTile({
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
+            if (isRunning) return;
             setRefreshKey((k) => k + 1);
           }}
           title="Refresh"
           aria-label="Refresh"
+          disabled={isRunning}
         >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" />

--- a/web/test/liveStore.test.ts
+++ b/web/test/liveStore.test.ts
@@ -1,6 +1,16 @@
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
-import { attachLive, clearLive, getLive, startNewSession, subscribeLive } from '../src/lib/liveStore';
+import type { Message } from '@macaron/shared';
+import {
+  attachLive,
+  clearLive,
+  fingerprintLiveTurn,
+  getLive,
+  snapshotCoversLiveTurn,
+  startNewSession,
+  subscribeLive,
+  type LiveState,
+} from '../src/lib/liveStore';
 
 const originalFetch = globalThis.fetch;
 const encoder = new TextEncoder();
@@ -41,7 +51,7 @@ test('concurrent reattach probes share one SSE reader and apply each delta once'
   globalThis.fetch = async () => {
     fetches += 1;
     return sseResponse([
-      { type: 'meta', cwd: '/repo', sessionId: sid },
+      { type: 'meta', cwd: '/repo', sessionId: sid, startedAt: 1234 },
       { type: 'user-text', text: 'question' },
       { type: 'delta', text: 'The ' },
       { type: 'delta', text: 'user' },
@@ -58,9 +68,15 @@ test('concurrent reattach probes share one SSE reader and apply each delta once'
   assert.deepEqual(results, ['attached', 'attached']);
   assert.equal(fetches, 1);
   assert.equal(getLive(sid)?.cwd, '/repo');
+  assert.equal(getLive(sid)?.startedAt, 1234);
   assert.equal(getLive(sid)?.userText, 'question');
   assert.equal(streamedText(sid), 'The user');
   clearLive(sid);
+
+  // The server retains the ended ring briefly. Once consumed, a sequential
+  // remount probes its identity but must not replay that completed turn.
+  assert.equal(await attachLive('project', sid), 'not-live');
+  assert.equal(fetches, 2);
 });
 
 test('an existing new-session POST owner prevents a second live attachment', async () => {
@@ -113,4 +129,131 @@ test('an ended replay can be consumed before the attach promise callback runs', 
   assert.equal(rendered, 'answer');
   assert.equal(getLive(sid), undefined);
   unsubscribe();
+});
+
+function transcriptMessage(
+  role: Message['role'],
+  timestamp: string,
+  blocks: Message['blocks'],
+): Message {
+  return { role, timestamp, blocks };
+}
+
+test('snapshot handoff rejects stale and partial JSONL, then accepts the complete live turn', () => {
+  const startedAt = Date.parse('2026-07-14T10:00:00.000Z');
+  const live: LiveState = {
+    cwd: '/repo',
+    startedAt,
+    userText: 'hello',
+    userImages: [],
+    timeline: [{ kind: 'text', id: 'live-t-1', text: 'Hey! What are you working on today?' }],
+    outputTokens: 9,
+    done: true,
+    terminalSeen: true,
+  };
+  const turn = fingerprintLiveTurn(live);
+  const oldTimestamp = '2026-07-14T09:59:50.000Z';
+  const currentTimestamp = '2026-07-14T10:00:00.100Z';
+
+  const stale: Message[] = [
+    transcriptMessage('user', oldTimestamp, [{ kind: 'text', text: 'hello' }]),
+    transcriptMessage('assistant', oldTimestamp, [{ kind: 'text', text: 'Hey! What are you working on today?' }]),
+  ];
+  assert.equal(snapshotCoversLiveTurn(stale, turn), false);
+
+  const partial: Message[] = [
+    ...stale,
+    transcriptMessage('user', currentTimestamp, [{ kind: 'text', text: 'hello' }]),
+  ];
+  assert.equal(snapshotCoversLiveTurn(partial, turn), false);
+
+  const complete: Message[] = [
+    ...partial,
+    transcriptMessage('assistant', currentTimestamp, [{ kind: 'text', text: 'Hey! What are you working on today?' }]),
+  ];
+  assert.equal(snapshotCoversLiveTurn(complete, turn), true);
+});
+
+test('snapshot handoff waits for persisted tool results that were visible live', () => {
+  const startedAt = Date.parse('2026-07-14T10:00:00.000Z');
+  const live: LiveState = {
+    cwd: '/repo',
+    startedAt,
+    userText: 'inspect it',
+    userImages: [],
+    timeline: [{ kind: 'tool', id: 'live-tool-1', name: 'Read', input: { file_path: '/repo/a.ts' }, result: 'content' }],
+    outputTokens: 0,
+    done: true,
+    terminalSeen: true,
+  };
+  const turn = fingerprintLiveTurn(live);
+  const timestamp = '2026-07-14T10:00:00.100Z';
+  const withoutResult: Message[] = [
+    transcriptMessage('user', timestamp, [{ kind: 'text', text: 'inspect it' }]),
+    transcriptMessage('assistant', timestamp, [{ kind: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/repo/a.ts' } }]),
+  ];
+  assert.equal(snapshotCoversLiveTurn(withoutResult, turn), false);
+
+  const complete: Message[] = [
+    ...withoutResult,
+    transcriptMessage('user', timestamp, [{ kind: 'tool_result', toolUseId: 'tool-1', text: 'content' }]),
+  ];
+  assert.equal(snapshotCoversLiveTurn(complete, turn), true);
+});
+
+test('snapshot handoff accepts an explicitly terminal empty turn but not transport EOF', () => {
+  const startedAt = Date.parse('2026-07-14T10:00:00.000Z');
+  const currentUser = transcriptMessage(
+    'user',
+    '2026-07-14T10:00:00.100Z',
+    [{ kind: 'text', text: 'stop here' }],
+  );
+  const live: LiveState = {
+    cwd: '/repo',
+    startedAt,
+    userText: 'stop here',
+    userImages: [],
+    timeline: [],
+    outputTokens: 0,
+    done: true,
+    terminalSeen: true,
+  };
+
+  assert.equal(snapshotCoversLiveTurn([currentUser], fingerprintLiveTurn(live)), true);
+  assert.equal(snapshotCoversLiveTurn([
+    transcriptMessage('user', '2026-07-14T09:59:50.000Z', [{ kind: 'text', text: 'stop here' }]),
+  ], fingerprintLiveTurn(live)), false);
+  assert.equal(snapshotCoversLiveTurn(
+    [currentUser],
+    fingerprintLiveTurn({ ...live, terminalSeen: false }),
+  ), false);
+});
+
+test('a consumed ended ring does not hide a newer turn on the same session', async () => {
+  const sid = 'turn-aware-tombstone-session';
+  let startedAt = 1_000;
+  let fetches = 0;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    return sseResponse([
+      { type: 'meta', cwd: '/repo', sessionId: sid, startedAt },
+      { type: 'user-text', text: `turn ${startedAt}` },
+      { type: 'delta', text: 'answer' },
+      { type: 'done', exitCode: 0 },
+    ]);
+  };
+
+  assert.equal(await attachLive('project', sid), 'attached');
+  await waitFor(() => getLive(sid)?.terminalSeen === true);
+  clearLive(sid);
+
+  // First probe still sees the retained old ring and consumes its identity.
+  // Its settled single-flight entry must be gone before a newer turn starts.
+  assert.equal(await attachLive('project', sid), 'not-live');
+  startedAt = 2_000;
+  assert.equal(await attachLive('project', sid), 'attached');
+  await waitFor(() => getLive(sid)?.terminalSeen === true);
+  assert.equal(getLive(sid)?.startedAt, 2_000);
+  assert.equal(fetches, 3);
+  clearLive(sid);
 });

--- a/web/test/sse.test.ts
+++ b/web/test/sse.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { streamSession } from '../src/lib/sse';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function sseResponse(...events: unknown[]): Response {
+  const body = events
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join('');
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+test('streamSession reports terminalSeen after an explicit done event', async () => {
+  globalThis.fetch = async () => sseResponse({ type: 'done', exitCode: 0 });
+  const terminalSignals: boolean[] = [];
+
+  await streamSession('/api/session', {}, {
+    onDone: (terminalSeen) => terminalSignals.push(terminalSeen),
+  });
+
+  assert.deepEqual(terminalSignals, [true]);
+});
+
+test('streamSession reports terminalSeen false on EOF without done', async () => {
+  globalThis.fetch = async () => sseResponse({ type: 'delta', text: 'partial' });
+  const terminalSignals: boolean[] = [];
+
+  await streamSession('/api/session', {}, {
+    onDone: (terminalSeen) => terminalSignals.push(terminalSeen),
+  });
+
+  assert.deepEqual(terminalSignals, [false]);
+});


### PR DESCRIPTION
## Summary

- atomically hand completed live turns to a fully matching JSONL snapshot
- preserve turn identity across replay, images, long rings, reconnects, and repeated prompts
- prevent Header/Canvas refreshes and stale stream callbacks from introducing a second source

## Validation

- `pnpm --dir web test` (9/9)
- `pnpm --dir server test` (29/29)
- `pnpm build`
- real built-UI fixture: initial mount, hard reload, and Canvas refresh each rendered exactly one user and one assistant turn with no browser errors

Closes [MAC-8695](https://multica.macaron.xin/issues/25cad453-917c-4506-ac4f-5c1985c45748 "macaron-artifacts 偶发重复显示轮次，刷新后恢复")
