### PR TITLE
Normalize assistant text during snapshot handoff

### DIFF
--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -137,6 +137,10 @@ function matchesLiveUser(message: Message, turn: LiveTurnFingerprint): boolean {
       && image.data === expectedImages[index]?.data);
 }
 
+function persistedAssistantText(text: string): string {
+  return text.replace(/\r\n?/g, '\n').trimEnd();
+}
+
 /**
  * True only when the persisted transcript contains the complete live turn.
  * A message count cannot prove this: JSONL may expose an old history or only
@@ -172,7 +176,7 @@ export function snapshotCoversLiveTurn(messages: Message[], turn: LiveTurnFinger
   // An explicitly terminal empty/error turn is complete once its current user
   // record is present. Non-empty turns still require every visible assistant
   // fragment and resolved tool result below.
-  return assistantText === turn.assistantText
+  return persistedAssistantText(assistantText) === persistedAssistantText(turn.assistantText)
     && turn.toolUseIds.every((id) => toolUseIds.has(id))
     && turn.resolvedToolUseIds.every((id) => resolvedToolUseIds.has(id));
 }

--- a/web/test/liveStore.test.ts
+++ b/web/test/liveStore.test.ts
@@ -174,6 +174,31 @@ test('snapshot handoff rejects stale and partial JSONL, then accepts the complet
   assert.equal(snapshotCoversLiveTurn(complete, turn), true);
 });
 
+test('snapshot handoff tolerates persisted assistant line-ending and trailing-space normalization', () => {
+  const startedAt = Date.parse('2026-07-14T10:00:00.000Z');
+  const turn = fingerprintLiveTurn({
+    cwd: '/repo',
+    startedAt,
+    userText: 'hello',
+    userImages: [],
+    timeline: [{ kind: 'text', id: 'live-t-1', text: 'first\r\nsecond  \r\n' }],
+    outputTokens: 4,
+    done: true,
+    terminalSeen: true,
+  });
+  const timestamp = '2026-07-14T10:00:00.100Z';
+  const normalized: Message[] = [
+    transcriptMessage('user', timestamp, [{ kind: 'text', text: 'hello' }]),
+    transcriptMessage('assistant', timestamp, [{ kind: 'text', text: 'first\nsecond' }]),
+  ];
+
+  assert.equal(snapshotCoversLiveTurn(normalized, turn), true);
+  assert.equal(snapshotCoversLiveTurn([
+    normalized[0]!,
+    transcriptMessage('assistant', timestamp, [{ kind: 'text', text: 'first' }]),
+  ], turn), false);
+});
+
 test('snapshot handoff waits for persisted tool results that were visible live', () => {
   const startedAt = Date.parse('2026-07-14T10:00:00.000Z');
   const live: LiveState = {


### PR DESCRIPTION
## Summary

- normalize CRLF line endings and trailing whitespace before comparing live and persisted assistant text
- keep substantive content matching strict so partial snapshots are still rejected
- add regression coverage for normalized persistence output

Follow-up to #150.