### PR TITLE
Render chat code blocks with borderless Shiki stream

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.15
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@shikijs/stream':
+        specifier: ^4.3.1
+        version: 4.3.1(react@19.2.7)
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.17
@@ -336,6 +339,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: ^4.3.1
+        version: 4.3.1
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1656,6 +1662,55 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.3.1':
+    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.3.1':
+    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/stream@4.3.1':
+    resolution: {integrity: sha512-QsZDisEVgtvnEgLftu/Ng5JkZlPn37AJoJQY330RnFoNcRtszr0JV3ldRLjIpgvl+qPRKF4t6h1P7FQhjQj6Sw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: ^19.0.0
+      solid-js: ^1.9.0
+      svelte: ^5.0.0-0
+      vue: ^3.2.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  '@shikijs/themes@4.3.1':
+    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -2389,6 +2444,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2401,6 +2459,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2800,6 +2861,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   oxc-parser@0.131.0:
     resolution: {integrity: sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3043,6 +3110,15 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -3147,6 +3223,10 @@ packages:
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
+
+  shiki@4.3.1:
+    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -4695,6 +4775,52 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@shikijs/core@4.3.1':
+    dependencies:
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/primitive@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/stream@4.3.1(react@19.2.7)':
+    dependencies:
+      '@shikijs/core': 4.3.1
+    optionalDependencies:
+      react: 19.2.7
+
+  '@shikijs/themes@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/types@4.3.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -5522,6 +5648,20 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -5549,6 +5689,8 @@ snapshots:
   hono@4.12.28: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -6118,6 +6260,14 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   oxc-parser@0.131.0:
     dependencies:
       '@oxc-project/types': 0.131.0
@@ -6382,6 +6532,16 @@ snapshots:
 
   redux@5.0.1: {}
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp-tree@0.1.27: {}
 
   remark-gfm@4.0.1:
@@ -6529,6 +6689,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.4: {}
+
+  shiki@4.3.1:
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/engine-oniguruma': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.1:
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-switch": "^1.3.1",
     "@radix-ui/react-tabs": "^1.1.15",
+    "@shikijs/stream": "^4.3.1",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@uiw/react-codemirror": "^4.25.10",
@@ -62,6 +63,7 @@
     "react-router-dom": "^7.7.0",
     "recharts": "^3.9.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "^4.3.1",
     "tailwind-merge": "^3.6.0",
     "unocss-preset-animations": "^1.3.0"
   },

--- a/web/src/chat-code.css
+++ b/web/src/chat-code.css
@@ -1,0 +1,86 @@
+/* Shared borderless Shiki code surface for both the Claude (Session) and Codex chat
+   threads. Fenced code renders through ShikiStreamCodeBlock; these rules style the
+   container, the streamed tokens, and the plaintext fallbacks. */
+
+.chat-shiki-code {
+  position: relative;
+  margin: 8px 0 12px;
+  min-width: 0;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 0;
+  background: #fff;
+}
+
+.chat-shiki-code__viewport {
+  max-height: 18rem;
+  overflow: auto;
+  padding: 16px;
+  padding-right: 48px;
+}
+
+.chat-shiki-code__copy {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  z-index: 10;
+  display: flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #8a7e72;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.chat-shiki-code__copy:hover { background: #f3f1ec; color: #3d352f; }
+.chat-shiki-code__copy:disabled { cursor: not-allowed; opacity: 0.4; }
+
+.chat-code-plain {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+  color: #3d352f;
+}
+
+.chat-shiki-code .shiki,
+.chat-shiki-code__highlight .shiki {
+  margin: 0;
+  min-height: 100%;
+  /* Shiki writes the theme background inline; force transparent so the white card shows through. */
+  background: transparent !important;
+  color: #3d352f;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+}
+.chat-shiki-code .shiki code { font-family: inherit; }
+
+.chat-shiki-code .shiki-stream-token-new {
+  animation: chat-shiki-stream-token-fade-in 180ms ease-out both;
+}
+
+@keyframes chat-shiki-stream-token-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Inline code keeps the subtle pill; only fenced blocks get the borderless card. */
+.chat-inline-code {
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  background: rgba(0, 0, 0, 0.04);
+  border: 0;
+  padding: 1.5px 6px;
+  border-radius: 4px;
+}

--- a/web/src/chat-code.css
+++ b/web/src/chat-code.css
@@ -2,6 +2,17 @@
    threads. Fenced code renders through ShikiStreamCodeBlock; these rules style the
    container, the streamed tokens, and the plaintext fallbacks. */
 
+/* The two chat surfaces expose different palettes: the Claude thread has --code-bg /
+   --surface-3 / --text / --muted; the Codex thread only has --cx-*. Resolve one set of
+   local semantic vars here so a single rule set themes both without either going empty. */
+.chat-shiki-code,
+.chat-inline-code {
+  --chat-code-bg: var(--code-bg, var(--cx-code));
+  --chat-code-fg: var(--text, var(--cx-text));
+  --chat-code-muted: var(--muted, var(--cx-muted));
+  --chat-code-hover-bg: var(--surface-3, var(--cx-hover));
+}
+
 .chat-shiki-code {
   position: relative;
   margin: 8px 0 12px;
@@ -9,7 +20,7 @@
   overflow: hidden;
   border-radius: 12px;
   border: 0;
-  background: var(--code-bg);
+  background: var(--chat-code-bg);
 }
 
 .chat-shiki-code__viewport {
@@ -31,13 +42,16 @@
   justify-content: center;
   border: 0;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--code-bg) 60%, transparent);
-  color: var(--muted);
+  background: color-mix(in srgb, var(--chat-code-bg) 60%, transparent);
+  color: var(--chat-code-muted);
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
-.chat-shiki-code__copy:hover { background: var(--surface-3); color: var(--text); }
+.chat-shiki-code__copy:hover { background: var(--chat-code-hover-bg); color: var(--chat-code-fg); }
 .chat-shiki-code__copy:disabled { cursor: not-allowed; opacity: 0.4; }
+/* Visible (not just aria) feedback so LAN-HTTP copy failures don't look like a dead button. */
+.chat-shiki-code__copy[data-copy-state="copied"] { color: var(--good, var(--cx-good)); }
+.chat-shiki-code__copy[data-copy-state="error"] { color: var(--bad, var(--cx-bad)); }
 
 .chat-code-plain {
   margin: 0;
@@ -47,7 +61,7 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   font-size: 13px;
   line-height: 1.7;
-  color: var(--text);
+  color: var(--chat-code-fg);
 }
 
 .chat-shiki-code .shiki,
@@ -56,7 +70,7 @@
   min-height: 100%;
   /* Shiki writes the theme background inline; force transparent so the card tint shows through. */
   background: transparent !important;
-  color: var(--text);
+  color: var(--chat-code-fg);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -65,6 +79,19 @@
   line-height: 1.7;
 }
 .chat-shiki-code .shiki code { font-family: inherit; }
+
+/* The chat surfaces still carry legacy `.md pre` / `.cx-msg-text.md pre` rules (bg,
+   padding, margin, radius) that would double up on our inner <pre> — the Shiki output,
+   the streaming <pre>, and the plaintext fallback. Neutralize them so only the card's
+   own viewport padding applies. Match the surface specificity to win. */
+.ti-text.md .chat-shiki-code pre,
+.cx-msg-text.md .chat-shiki-code pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
 
 /* Dual-theme swap: codeToHtml/dualThemes writes the light color inline on each token
    and stashes the dark color in --shiki-dark. Under the dark app theme, promote the
@@ -90,7 +117,8 @@
 .chat-inline-code {
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 12.5px;
-  background: var(--code-bg);
+  background: var(--chat-code-bg);
+  color: var(--chat-code-fg);
   border: 0;
   padding: 1.5px 6px;
   border-radius: 4px;

--- a/web/src/chat-code.css
+++ b/web/src/chat-code.css
@@ -9,7 +9,7 @@
   overflow: hidden;
   border-radius: 12px;
   border: 0;
-  background: #fff;
+  background: var(--code-bg);
 }
 
 .chat-shiki-code__viewport {
@@ -31,12 +31,12 @@
   justify-content: center;
   border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.9);
-  color: #8a7e72;
+  background: color-mix(in srgb, var(--code-bg) 60%, transparent);
+  color: var(--muted);
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
-.chat-shiki-code__copy:hover { background: #f3f1ec; color: #3d352f; }
+.chat-shiki-code__copy:hover { background: var(--surface-3); color: var(--text); }
 .chat-shiki-code__copy:disabled { cursor: not-allowed; opacity: 0.4; }
 
 .chat-code-plain {
@@ -47,16 +47,16 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   font-size: 13px;
   line-height: 1.7;
-  color: #3d352f;
+  color: var(--text);
 }
 
 .chat-shiki-code .shiki,
 .chat-shiki-code__highlight .shiki {
   margin: 0;
   min-height: 100%;
-  /* Shiki writes the theme background inline; force transparent so the white card shows through. */
+  /* Shiki writes the theme background inline; force transparent so the card tint shows through. */
   background: transparent !important;
-  color: #3d352f;
+  color: var(--text);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -65,6 +65,17 @@
   line-height: 1.7;
 }
 .chat-shiki-code .shiki code { font-family: inherit; }
+
+/* Dual-theme swap: codeToHtml/dualThemes writes the light color inline on each token
+   and stashes the dark color in --shiki-dark. Under the dark app theme, promote the
+   dark vars so the same DOM re-colors without a re-highlight. */
+:root[data-theme="dark"] .chat-shiki-code .shiki,
+:root[data-theme="dark"] .chat-shiki-code .shiki span {
+  color: var(--shiki-dark, inherit) !important;
+  font-style: var(--shiki-dark-font-style, inherit) !important;
+  font-weight: var(--shiki-dark-font-weight, inherit) !important;
+  text-decoration: var(--shiki-dark-text-decoration, inherit) !important;
+}
 
 .chat-shiki-code .shiki-stream-token-new {
   animation: chat-shiki-stream-token-fade-in 180ms ease-out both;
@@ -79,7 +90,7 @@
 .chat-inline-code {
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 12.5px;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--code-bg);
   border: 0;
   padding: 1.5px 6px;
   border-radius: 4px;

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -7,6 +7,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
 import type { SessionDetail, Message, Block, CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
 import { codexApi } from './api';
 import type { CodexRuntimeOverride } from './api';
@@ -318,7 +319,9 @@ function ApprovalCard({ it, onDecide }: { it: Extract<Item, { kind: 'approval' }
   );
 }
 
-function MessageRow({ it, onDecide }: { it: Item; onDecide?: (id: string, decision: CodexDecision) => void }) {
+const CODEX_MARKDOWN_COMPONENTS = { code: MarkdownCode, pre: MarkdownPre } as const;
+
+function MessageRow({ it, streaming = false, onDecide }: { it: Item; streaming?: boolean; onDecide?: (id: string, decision: CodexDecision) => void }) {
   if (it.kind === 'reasoning') return <Reasoning text={it.text} />;
   if (it.kind === 'tool') return <ToolCard it={it} />;
   if (it.kind === 'genui') return <GenuiCard it={it} />;
@@ -341,7 +344,9 @@ function MessageRow({ it, onDecide }: { it: Item; onDecide?: (id: string, decisi
           <div className="cx-msg-text">{it.text}</div>
         ) : (
           <div className="cx-msg-text md">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{it.text}</ReactMarkdown>
+            <MarkdownCodeStreamingProvider content={it.text} streaming={streaming}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={CODEX_MARKDOWN_COMPONENTS}>{it.text}</ReactMarkdown>
+            </MarkdownCodeStreamingProvider>
           </div>
         )}
       </div>
@@ -638,7 +643,14 @@ export function CodexChat(props: CodexChatProps = {}) {
           </div>
         ) : (
           <div className="cx-thread-body">
-            {items.map((it) => <MessageRow key={it.id} it={it} onDecide={decideApproval} />)}
+            {items.map((it, i) => (
+              <MessageRow
+                key={it.id}
+                it={it}
+                streaming={sending && i === items.length - 1 && it.kind === 'assistant'}
+                onDecide={decideApproval}
+              />
+            ))}
             {/* Show the thinking spinner at the tail of the thread while a
                 turn is in flight. Hide it once the last item is a live
                 assistant message that has actually started emitting text —

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -15,6 +15,7 @@ import { ConfirmProvider } from '../components/Confirm';
 import { consumeTokenFromUrl } from '../lib/auth';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
+import '../chat-code.css';
 
 // Pick up a ?token=... bootstrap from a shared link before anything fetches.
 consumeTokenFromUrl();

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -388,7 +388,7 @@ body {
 .cx-msg-text.md li > p { margin: 0; }
 .cx-msg-text.md pre {
   background: var(--cx-code);
-  border: 1px solid var(--cx-border);
+  border: 0;
   border-radius: 8px;
   padding: 10px 12px;
   margin: 8px 0 12px;

--- a/web/src/components/MarkdownCode.tsx
+++ b/web/src/components/MarkdownCode.tsx
@@ -89,7 +89,10 @@ export function MarkdownPre({ node: _node, children }: MarkdownPreProps) {
 
   if (!codeElement) return <pre className="chat-code-plain">{children}</pre>;
 
-  const code = extractText(codeElement.props.children).replace(/\n+$/, '');
+  // Strip only the single trailing newline mdast appends to fenced code — not every
+  // trailing blank line, which would silently drop meaningful empty lines the user wrote
+  // (rendered and copied content must equal the fenced source).
+  const code = extractText(codeElement.props.children).replace(/\n$/, '');
   const language = getLanguage(codeElement.props.className);
   const shouldStream = streaming && isMarkdownCodeFenceIncomplete(content, codeElement.props.node);
 

--- a/web/src/components/MarkdownCode.tsx
+++ b/web/src/components/MarkdownCode.tsx
@@ -1,0 +1,113 @@
+import {
+  createContext,
+  isValidElement,
+  lazy,
+  Suspense,
+  useContext,
+  type ComponentProps,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import type { ExtraProps } from 'react-markdown';
+import type { ShikiStreamCodeBlockProps } from './ShikiStreamCodeBlock';
+
+type MarkdownCodeProps = ComponentProps<'code'> & ExtraProps;
+type MarkdownPreProps = ComponentProps<'pre'> & ExtraProps;
+type PositionedNode = { position?: { start?: { offset?: number }; end?: { offset?: number } } };
+type ShikiCodeBlockModule = { default: ComponentType<ShikiStreamCodeBlockProps> };
+
+function PlainShikiCodeBlock({ code }: ShikiStreamCodeBlockProps) {
+  return <PlainCodeFallback code={code} />;
+}
+
+// Keep the heavy Shiki bundle out of the default chunk, and degrade to readable
+// plaintext (never a crash) if the lazy chunk can't load.
+export function loadShikiStreamCodeBlock(
+  importer: () => Promise<ShikiCodeBlockModule> = () => import('./ShikiStreamCodeBlock'),
+) {
+  return importer().catch(() => ({ default: PlainShikiCodeBlock }));
+}
+
+const LazyShikiStreamCodeBlock = lazy(loadShikiStreamCodeBlock);
+const MarkdownStreamingContext = createContext<{ content: string; streaming: boolean }>({ content: '', streaming: false });
+
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join('');
+  if (isValidElement<{ children?: ReactNode }>(node)) return extractText(node.props.children);
+  return '';
+}
+
+function getLanguage(className?: string) {
+  return className?.match(/language-([^\s]+)/)?.[1];
+}
+
+function stripMarkdownContainerPrefix(line: string) {
+  return line.replace(/^(?:[\t ]*>[\t ]?)*/, '').trim();
+}
+
+// True while a fenced block at the tail of the streamed markdown has no matching
+// closing fence yet — that block (and only that one) should stream token-by-token.
+export function isMarkdownCodeFenceIncomplete(markdown: string, node?: PositionedNode) {
+  const startOffset = node?.position?.start?.offset;
+  const endOffset = node?.position?.end?.offset;
+  if (typeof startOffset !== 'number' || typeof endOffset !== 'number') return false;
+  if (markdown.slice(endOffset).trim()) return false;
+
+  const rawCodeNode = markdown.slice(startOffset, endOffset).trimEnd();
+  const lines = rawCodeNode.split(/\r?\n/);
+  const openingFence = stripMarkdownContainerPrefix(lines[0] ?? '').match(/^(`{3,}|~{3,})/)?.[1];
+  if (!openingFence) return false;
+
+  const closingFence = stripMarkdownContainerPrefix(lines[lines.length - 1] ?? '').match(/^(`+|~+)$/)?.[1];
+  return !(closingFence && closingFence[0] === openingFence[0] && closingFence.length >= openingFence.length);
+}
+
+function PlainCodeFallback({ code }: { code: string }) {
+  return (
+    <div data-testid="chat-code-block" data-shiki-loading="true" className="chat-shiki-code">
+      <div className="chat-shiki-code__viewport">
+        <pre className="chat-code-plain">{code}</pre>
+      </div>
+    </div>
+  );
+}
+
+export function MarkdownCode({ node: _node, className, children, ...props }: MarkdownCodeProps) {
+  return (
+    <code className={[className, 'chat-inline-code'].filter(Boolean).join(' ')} {...props}>
+      {children}
+    </code>
+  );
+}
+
+export function MarkdownPre({ node: _node, children }: MarkdownPreProps) {
+  const { content, streaming } = useContext(MarkdownStreamingContext);
+  const codeElement = isValidElement<{ className?: string; children?: ReactNode; node?: PositionedNode }>(children)
+    ? children
+    : null;
+
+  if (!codeElement) return <pre className="chat-code-plain">{children}</pre>;
+
+  const code = extractText(codeElement.props.children).replace(/\n+$/, '');
+  const language = getLanguage(codeElement.props.className);
+  const shouldStream = streaming && isMarkdownCodeFenceIncomplete(content, codeElement.props.node);
+
+  return (
+    <Suspense fallback={<PlainCodeFallback code={code} />}>
+      <LazyShikiStreamCodeBlock code={code} language={language} streaming={shouldStream} />
+    </Suspense>
+  );
+}
+
+export function MarkdownCodeStreamingProvider({
+  streaming,
+  content,
+  children,
+}: {
+  streaming: boolean;
+  content: string;
+  children: ReactNode;
+}) {
+  return <MarkdownStreamingContext.Provider value={{ content, streaming }}>{children}</MarkdownStreamingContext.Provider>;
+}

--- a/web/src/components/ShikiStreamCodeBlock.tsx
+++ b/web/src/components/ShikiStreamCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, X } from 'lucide-react';
 import { memo, useEffect, useRef, useState, type CSSProperties } from 'react';
 import { getTokenStyleObject } from 'shiki/core';
 import type { RecallToken } from '@shikijs/stream';
@@ -21,6 +21,26 @@ export interface ShikiStreamCodeBlockProps {
 
 function PlainCode({ code }: { code: string }) {
   return <pre className="chat-code-plain">{code}</pre>;
+}
+
+// Copy that also works on the LAN-over-HTTP surfaces (phones opening a dev box by IP),
+// where the page isn't a secure context and navigator.clipboard is absent. Falls back to
+// a hidden textarea + execCommand; throws if neither path succeeds so the button can flag it.
+async function copyChatCode(text: string) {
+  if (navigator.clipboard?.writeText && window.isSecureContext) return navigator.clipboard.writeText(text);
+  if (typeof document === 'undefined') throw new Error('Clipboard unavailable');
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  document.body.append(textarea);
+  textarea.focus();
+  textarea.select();
+  const copied = (document as unknown as { execCommand(id: string): boolean }).execCommand('copy');
+  textarea.remove();
+  if (!copied) throw new Error('Clipboard copy failed');
 }
 
 function StaticHighlightedCode({ code, language }: { code: string; language: ReturnType<typeof resolveChatCodeLanguage> }) {
@@ -166,6 +186,7 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const shouldStickToBottomRef = useRef(true);
+  const programmaticScrollRef = useRef(false);
 
   useEffect(() => { setCopyState('idle'); }, [code]);
 
@@ -175,19 +196,26 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
     return () => window.clearTimeout(timeoutId);
   }, [copyState]);
 
+  // Auto-follow the tail. Mark the scroll as programmatic so the `scroll` listener below
+  // doesn't misread our own smooth-scroll as the user scrolling and drop stickiness.
+  const stickToBottom = (viewport: HTMLDivElement) => {
+    if (typeof viewport.scrollTo !== 'function') return;
+    programmaticScrollRef.current = true;
+    viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+    window.setTimeout(() => { programmaticScrollRef.current = false; }, 120);
+  };
+
   useEffect(() => {
     const viewport = viewportRef.current;
-    if (!streaming || !viewport || !shouldStickToBottomRef.current || typeof viewport.scrollTo !== 'function') return;
-    viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+    if (!streaming || !viewport || !shouldStickToBottomRef.current) return;
+    stickToBottom(viewport);
   }, [code, streaming]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
     if (!streaming || !viewport || typeof MutationObserver === 'undefined') return;
     const observer = new MutationObserver(() => {
-      if (shouldStickToBottomRef.current && typeof viewport.scrollTo === 'function') {
-        viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
-      }
+      if (shouldStickToBottomRef.current) stickToBottom(viewport);
     });
     observer.observe(viewport, { childList: true, subtree: true, characterData: true });
     return () => observer.disconnect();
@@ -195,8 +223,7 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
 
   const handleCopy = async () => {
     try {
-      if (!navigator.clipboard?.writeText) throw new Error('Clipboard unavailable');
-      await navigator.clipboard.writeText(code);
+      await copyChatCode(code);
       setCopyState('copied');
     } catch {
       setCopyState('error');
@@ -208,6 +235,21 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
     if (!viewport) return;
     shouldStickToBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 72;
   };
+
+  // Sample stickiness from the actual `scroll` event, not just wheel/touch: this also
+  // catches scrollbar drags and keyboard scrolling, so reading upward mid-stream isn't
+  // yanked back to the bottom by the next token. `programmaticScrollRef` suppresses the
+  // scroll events our own auto-follow scrollTo emits, which would otherwise re-stick.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!streaming || !viewport) return;
+    const onScroll = () => {
+      if (programmaticScrollRef.current) return;
+      updateStickToBottom();
+    };
+    viewport.addEventListener('scroll', onScroll, { passive: true });
+    return () => viewport.removeEventListener('scroll', onScroll);
+  }, [streaming]);
 
   const copyLabel = copyState === 'copied' ? 'Code copied' : copyState === 'error' ? 'Copy code failed, try again' : 'Copy code';
 
@@ -223,12 +265,13 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
         aria-label={copyLabel}
         title={copyLabel}
         className="chat-shiki-code__copy"
+        data-copy-state={copyState}
         disabled={!code.trim()}
         onClick={() => void handleCopy()}
       >
-        {copyState === 'copied' ? <Check size={16} aria-hidden /> : <Copy size={16} aria-hidden />}
+        {copyState === 'copied' ? <Check size={16} aria-hidden /> : copyState === 'error' ? <X size={16} aria-hidden /> : <Copy size={16} aria-hidden />}
       </button>
-      <div ref={viewportRef} onWheel={updateStickToBottom} onTouchMove={updateStickToBottom} className="chat-shiki-code__viewport">
+      <div ref={viewportRef} className="chat-shiki-code__viewport">
         {streaming ? (
           <StreamingHighlightedCode code={code} language={resolvedLanguage} />
         ) : (

--- a/web/src/components/ShikiStreamCodeBlock.tsx
+++ b/web/src/components/ShikiStreamCodeBlock.tsx
@@ -1,0 +1,242 @@
+import { Check, Copy } from 'lucide-react';
+import { memo, useEffect, useRef, useState, type CSSProperties } from 'react';
+import { getTokenStyleObject } from 'shiki/core';
+import type { RecallToken } from '@shikijs/stream';
+import type { ThemedToken } from 'shiki';
+import {
+  createChatCodeDeltaStream,
+  renderChatCodeToHtml,
+  resolveChatCodeLanguage,
+  type ChatCodeTokenStream,
+} from '../lib/chatCodeHighlighter';
+
+type CodeTokenSegment = { key: string; content: string; style?: CSSProperties; animate: boolean };
+type CodeTokenItem = { key: string; segments: CodeTokenSegment[] };
+
+export interface ShikiStreamCodeBlockProps {
+  code: string;
+  language?: string;
+  streaming: boolean;
+}
+
+function PlainCode({ code }: { code: string }) {
+  return <pre className="chat-code-plain">{code}</pre>;
+}
+
+function StaticHighlightedCode({ code, language }: { code: string; language: ReturnType<typeof resolveChatCodeLanguage> }) {
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setHtml('');
+    if (!code) return () => undefined;
+    void renderChatCodeToHtml(code, language).then(
+      (next) => { if (!cancelled) setHtml(next); },
+      () => { if (!cancelled) setHtml(''); },
+    );
+    return () => { cancelled = true; };
+  }, [code, language]);
+
+  if (!html) return <PlainCode code={code} />;
+  return <div className="chat-shiki-code__highlight" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+function StreamingHighlightedCode({ code, language }: { code: string; language: ReturnType<typeof resolveChatCodeLanguage> }) {
+  const [tokenStream, setTokenStream] = useState<ChatCodeTokenStream | null>(null);
+  const [tokenItems, setTokenItems] = useState<CodeTokenItem[]>([]);
+  const [failed, setFailed] = useState(false);
+  const codeStreamRef = useRef<ReturnType<typeof createChatCodeDeltaStream> | null>(null);
+  const previousCodeRef = useRef('');
+  const segmentSequenceRef = useRef(0);
+  const tokenSequenceRef = useRef(0);
+  const animatedCharWatermarkRef = useRef(0);
+
+  useEffect(() => {
+    const codeStream = createChatCodeDeltaStream(language);
+    codeStreamRef.current = codeStream;
+    previousCodeRef.current = '';
+    segmentSequenceRef.current = 0;
+    tokenSequenceRef.current = 0;
+    animatedCharWatermarkRef.current = 0;
+    setTokenItems([]);
+    setFailed(false);
+    setTokenStream(codeStream.stream);
+    return () => {
+      codeStreamRef.current?.close();
+      codeStreamRef.current = null;
+    };
+  }, [language]);
+
+  useEffect(() => {
+    let codeStream = codeStreamRef.current;
+    if (!codeStream) return;
+
+    const previousCode = previousCodeRef.current;
+    if (code.startsWith(previousCode)) {
+      codeStream.push(code.slice(previousCode.length));
+      previousCodeRef.current = code;
+      return;
+    }
+
+    // Non-append edit (resend / rewind): tear the stream down and replay from scratch.
+    codeStream.close();
+    codeStream = createChatCodeDeltaStream(language);
+    codeStreamRef.current = codeStream;
+    previousCodeRef.current = code;
+    segmentSequenceRef.current = 0;
+    tokenSequenceRef.current = 0;
+    animatedCharWatermarkRef.current = 0;
+    setTokenItems([]);
+    setFailed(false);
+    setTokenStream(codeStream.stream);
+    codeStream.push(code);
+  }, [code, language]);
+
+  useEffect(() => {
+    if (!tokenStream) return;
+
+    let cancelled = false;
+    const reader = tokenStream.getReader();
+    const nextSegmentKey = () => `segment-${++segmentSequenceRef.current}`;
+    const nextTokenKey = () => `token-${++tokenSequenceRef.current}`;
+
+    void (async () => {
+      while (!cancelled) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        if ('recall' in (value as RecallToken)) {
+          setTokenItems((current) => current.slice(0, Math.max(0, current.length - (value as RecallToken).recall)));
+          continue;
+        }
+
+        const token = value as ThemedToken;
+        const style = (token.htmlStyle || getTokenStyleObject(token)) as CSSProperties;
+        setTokenItems((current) => {
+          const visibleLength = current.reduce(
+            (length, item) => length + item.segments.reduce((itemLength, segment) => itemLength + segment.content.length, 0),
+            0,
+          );
+          // Only fade in characters past the high-water mark so re-tokenized prefixes don't re-animate.
+          const stableLength = Math.min(animatedCharWatermarkRef.current, visibleLength + token.content.length);
+          const existingLength = Math.max(0, stableLength - visibleLength);
+          const stableContent = token.content.slice(0, existingLength);
+          const freshContent = token.content.slice(existingLength);
+          animatedCharWatermarkRef.current = Math.max(animatedCharWatermarkRef.current, visibleLength + token.content.length);
+
+          return [
+            ...current,
+            {
+              key: nextTokenKey(),
+              segments: [
+                ...(stableContent ? [{ key: nextSegmentKey(), content: stableContent, style, animate: false }] : []),
+                ...(freshContent ? [{ key: nextSegmentKey(), content: freshContent, style, animate: true }] : []),
+              ],
+            },
+          ];
+        });
+      }
+    })().catch(() => { if (!cancelled) setFailed(true); });
+
+    return () => {
+      cancelled = true;
+      void reader.cancel();
+    };
+  }, [tokenStream]);
+
+  if (failed || !tokenStream || tokenItems.length === 0) return <PlainCode code={code} />;
+
+  return (
+    <pre className="shiki shiki-stream">
+      <code>
+        {tokenItems.flatMap((item) =>
+          item.segments.map((segment) => (
+            <span key={segment.key} className={segment.animate ? 'shiki-stream-token-new' : undefined} style={segment.style}>
+              {segment.content}
+            </span>
+          )),
+        )}
+      </code>
+    </pre>
+  );
+}
+
+const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language, streaming }: ShikiStreamCodeBlockProps) {
+  const resolvedLanguage = resolveChatCodeLanguage(language);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const shouldStickToBottomRef = useRef(true);
+
+  useEffect(() => { setCopyState('idle'); }, [code]);
+
+  useEffect(() => {
+    if (copyState === 'idle') return;
+    const timeoutId = window.setTimeout(() => setCopyState('idle'), 1200);
+    return () => window.clearTimeout(timeoutId);
+  }, [copyState]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!streaming || !viewport || !shouldStickToBottomRef.current || typeof viewport.scrollTo !== 'function') return;
+    viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+  }, [code, streaming]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!streaming || !viewport || typeof MutationObserver === 'undefined') return;
+    const observer = new MutationObserver(() => {
+      if (shouldStickToBottomRef.current && typeof viewport.scrollTo === 'function') {
+        viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+      }
+    });
+    observer.observe(viewport, { childList: true, subtree: true, characterData: true });
+    return () => observer.disconnect();
+  }, [streaming]);
+
+  const handleCopy = async () => {
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('Clipboard unavailable');
+      await navigator.clipboard.writeText(code);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+  };
+
+  const updateStickToBottom = () => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    shouldStickToBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 72;
+  };
+
+  const copyLabel = copyState === 'copied' ? 'Code copied' : copyState === 'error' ? 'Copy code failed, try again' : 'Copy code';
+
+  return (
+    <div
+      data-testid="chat-code-block"
+      data-code-language={resolvedLanguage}
+      data-shiki-streaming={streaming ? 'true' : 'false'}
+      className="chat-shiki-code"
+    >
+      <button
+        type="button"
+        aria-label={copyLabel}
+        title={copyLabel}
+        className="chat-shiki-code__copy"
+        disabled={!code.trim()}
+        onClick={() => void handleCopy()}
+      >
+        {copyState === 'copied' ? <Check size={16} aria-hidden /> : <Copy size={16} aria-hidden />}
+      </button>
+      <div ref={viewportRef} onWheel={updateStickToBottom} onTouchMove={updateStickToBottom} className="chat-shiki-code__viewport">
+        {streaming ? (
+          <StreamingHighlightedCode code={code} language={resolvedLanguage} />
+        ) : (
+          <StaticHighlightedCode code={code} language={resolvedLanguage} />
+        )}
+      </div>
+    </div>
+  );
+});
+
+export default ShikiStreamCodeBlock;

--- a/web/src/components/ShikiStreamCodeBlock.tsx
+++ b/web/src/components/ShikiStreamCodeBlock.tsx
@@ -9,6 +9,7 @@ import {
   resolveChatCodeLanguage,
   type ChatCodeTokenStream,
 } from '../lib/chatCodeHighlighter';
+import { nextScrollStickiness } from '../lib/chatCodeScroll';
 
 type CodeTokenSegment = { key: string; content: string; style?: CSSProperties; animate: boolean };
 type CodeTokenItem = { key: string; segments: CodeTokenSegment[] };
@@ -186,7 +187,7 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const shouldStickToBottomRef = useRef(true);
-  const programmaticScrollRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
 
   useEffect(() => { setCopyState('idle'); }, [code]);
 
@@ -196,13 +197,11 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
     return () => window.clearTimeout(timeoutId);
   }, [copyState]);
 
-  // Auto-follow the tail. Mark the scroll as programmatic so the `scroll` listener below
-  // doesn't misread our own smooth-scroll as the user scrolling and drop stickiness.
+  // Auto-follow the tail. Only ever scrolls downward, so the `scroll` handler can treat any
+  // upward delta as the user taking ownership — no timed suppression window needed.
   const stickToBottom = (viewport: HTMLDivElement) => {
     if (typeof viewport.scrollTo !== 'function') return;
-    programmaticScrollRef.current = true;
     viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
-    window.setTimeout(() => { programmaticScrollRef.current = false; }, 120);
   };
 
   useEffect(() => {
@@ -230,22 +229,22 @@ const ShikiStreamCodeBlock = memo(function ShikiStreamCodeBlock({ code, language
     }
   };
 
-  const updateStickToBottom = () => {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-    shouldStickToBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 72;
-  };
-
-  // Sample stickiness from the actual `scroll` event, not just wheel/touch: this also
-  // catches scrollbar drags and keyboard scrolling, so reading upward mid-stream isn't
-  // yanked back to the bottom by the next token. `programmaticScrollRef` suppresses the
-  // scroll events our own auto-follow scrollTo emits, which would otherwise re-stick.
+  // Sample stickiness on every `scroll` (covers wheel, touch, scrollbar drag, keyboard).
+  // Direction-based ownership: an upward scroll — impossible from our downward-only
+  // auto-follow — immediately hands control to the user; scrolling back to the bottom
+  // re-arms follow. No timer window, so a real scroll is never swallowed.
   useEffect(() => {
     const viewport = viewportRef.current;
     if (!streaming || !viewport) return;
+    lastScrollTopRef.current = viewport.scrollTop;
     const onScroll = () => {
-      if (programmaticScrollRef.current) return;
-      updateStickToBottom();
+      shouldStickToBottomRef.current = nextScrollStickiness(shouldStickToBottomRef.current, {
+        scrollTop: viewport.scrollTop,
+        lastScrollTop: lastScrollTopRef.current,
+        scrollHeight: viewport.scrollHeight,
+        clientHeight: viewport.clientHeight,
+      });
+      lastScrollTopRef.current = viewport.scrollTop;
     };
     viewport.addEventListener('scroll', onScroll, { passive: true });
     return () => viewport.removeEventListener('scroll', onScroll);

--- a/web/src/lib/chatCodeHighlighter.ts
+++ b/web/src/lib/chatCodeHighlighter.ts
@@ -1,0 +1,108 @@
+import { CodeToTokenTransformStream, type RecallToken } from '@shikijs/stream';
+import { bundledLanguages, bundledLanguagesInfo, createHighlighter, type BundledLanguage } from 'shiki/bundle/web';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import type { ThemedToken } from 'shiki';
+
+export type ChatCodeLanguage = BundledLanguage | 'text';
+export type ChatCodeToken = ThemedToken | RecallToken;
+export type ChatCodeTokenStream = ReadableStream<ChatCodeToken>;
+
+type ChatCodeDeltaController = { stream: ChatCodeTokenStream; push: (delta: string) => void; close: () => void };
+
+const CHAT_CODE_THEME = 'vitesse-light';
+const CODE_HTML_CACHE_LIMIT = 24;
+
+// Map every bundled language id + its aliases to a canonical id so `resolveChatCodeLanguage`
+// can accept the loose fence hints models emit ("js", "shell", "golang") and fall back to plain text.
+const chatCodeLanguageAliases = new Map<string, BundledLanguage>();
+for (const language of bundledLanguagesInfo) {
+  if (!(language.id in bundledLanguages)) continue;
+  const languageId = language.id as BundledLanguage;
+  chatCodeLanguageAliases.set(languageId, languageId);
+  for (const alias of language.aliases ?? []) chatCodeLanguageAliases.set(alias, languageId);
+}
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
+const languageLoadPromises = new Map<BundledLanguage, Promise<void>>();
+const codeHtmlCache = new Map<string, string>();
+
+const getHighlighter = () =>
+  (highlighterPromise ??= createHighlighter({ langs: [], themes: [CHAT_CODE_THEME], engine: createJavaScriptRegexEngine() }));
+
+async function getHighlighterForLanguage(language: ChatCodeLanguage) {
+  const highlighter = await getHighlighter();
+  if (language === 'text' || highlighter.getLoadedLanguages().includes(language)) return highlighter;
+
+  let loadPromise = languageLoadPromises.get(language);
+  if (!loadPromise) {
+    loadPromise = highlighter.loadLanguage(bundledLanguages[language]).then(() => undefined);
+    languageLoadPromises.set(language, loadPromise);
+  }
+  await loadPromise;
+  return highlighter;
+}
+
+export function resolveChatCodeLanguage(language?: string): ChatCodeLanguage {
+  const normalized = language?.trim().toLowerCase();
+  if (!normalized) return 'text';
+  return chatCodeLanguageAliases.get(normalized) ?? 'text';
+}
+
+function getCodeHtmlCacheKey(code: string, language: ChatCodeLanguage) {
+  return `${CHAT_CODE_THEME}\0${language}\0${code}`;
+}
+
+export async function renderChatCodeToHtml(code: string, language: ChatCodeLanguage) {
+  const cacheKey = getCodeHtmlCacheKey(code, language);
+  const cached = codeHtmlCache.get(cacheKey);
+  if (cached) {
+    codeHtmlCache.delete(cacheKey);
+    codeHtmlCache.set(cacheKey, cached);
+    return cached;
+  }
+
+  const highlighter = await getHighlighterForLanguage(language);
+  const html = highlighter.codeToHtml(code, { lang: language, theme: CHAT_CODE_THEME });
+  codeHtmlCache.set(cacheKey, html);
+  if (codeHtmlCache.size > CODE_HTML_CACHE_LIMIT) {
+    const oldestKey = codeHtmlCache.keys().next().value;
+    if (oldestKey) codeHtmlCache.delete(oldestKey);
+  }
+  return html;
+}
+
+export function createChatCodeDeltaStream(language: ChatCodeLanguage): ChatCodeDeltaController {
+  let sourceController: ReadableStreamDefaultController<string> | null = null;
+  const source = new ReadableStream<string>({ start(controller) { sourceController = controller; } });
+
+  const stream = new ReadableStream<ChatCodeToken>({
+    async start(controller) {
+      try {
+        const highlighter = await getHighlighterForLanguage(language);
+        // The source buffers deltas immediately, so chunks pushed before Shiki boots still replay in order.
+        const tokenStream = source.pipeThrough(
+          new CodeToTokenTransformStream({ highlighter, lang: language, theme: CHAT_CODE_THEME, allowRecalls: true }),
+        );
+        const reader = tokenStream.getReader();
+        let next = await reader.read();
+        while (!next.done) {
+          controller.enqueue(next.value);
+          next = await reader.read();
+        }
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+
+  return {
+    stream,
+    push(delta) { if (sourceController && delta) sourceController.enqueue(delta); },
+    close() {
+      if (!sourceController) return;
+      sourceController.close();
+      sourceController = null;
+    },
+  };
+}

--- a/web/src/lib/chatCodeHighlighter.ts
+++ b/web/src/lib/chatCodeHighlighter.ts
@@ -1,55 +1,122 @@
 import { CodeToTokenTransformStream, type RecallToken } from '@shikijs/stream';
-import { bundledLanguages, bundledLanguagesInfo, createHighlighter, type BundledLanguage } from 'shiki/bundle/web';
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
-import type { ThemedToken } from 'shiki';
+import type { LanguageRegistration, ThemedToken } from 'shiki';
+import vitesseLight from 'shiki/themes/vitesse-light.mjs';
+import vitesseDark from 'shiki/themes/vitesse-dark.mjs';
 
-export type ChatCodeLanguage = BundledLanguage | 'text';
+export type ChatCodeLanguage = string;
 export type ChatCodeToken = ThemedToken | RecallToken;
 export type ChatCodeTokenStream = ReadableStream<ChatCodeToken>;
 
 type ChatCodeDeltaController = { stream: ChatCodeTokenStream; push: (delta: string) => void; close: () => void };
+type LanguageModule = { default: LanguageRegistration[] };
 
 // Dual themes so code blocks follow the app's light/dark toggle. Shiki emits the
 // default (light) color inline plus a `--shiki-dark` CSS var per token; chat-code.css
 // swaps to the dark var under :root[data-theme="dark"].
 const CHAT_CODE_THEMES = { light: 'vitesse-light', dark: 'vitesse-dark' } as const;
-const CHAT_CODE_THEME_KEY = Object.values(CHAT_CODE_THEMES).join('|');
+const CHAT_CODE_THEME_KEY = `${CHAT_CODE_THEMES.light}|${CHAT_CODE_THEMES.dark}`;
 const CODE_HTML_CACHE_LIMIT = 24;
 
-// Map every bundled language id + its aliases to a canonical id so `resolveChatCodeLanguage`
-// can accept the loose fence hints models emit ("js", "shell", "golang") and fall back to plain text.
-const chatCodeLanguageAliases = new Map<string, BundledLanguage>();
-for (const language of bundledLanguagesInfo) {
-  if (!(language.id in bundledLanguages)) continue;
-  const languageId = language.id as BundledLanguage;
-  chatCodeLanguageAliases.set(languageId, languageId);
-  for (const alias of language.aliases ?? []) chatCodeLanguageAliases.set(alias, languageId);
-}
+// Curated allowlist: only these grammars ship, each as its own lazily-imported chunk.
+// Switching off `shiki/bundle/web` drops the full registry + Oniguruma WASM from the
+// build; the JS regex engine covers everything here. Add a language by dropping one
+// `shiki/langs/<id>.mjs` loader in — unknown fence hints fall back to plain text.
+const CHAT_CODE_LANGUAGE_LOADERS: Record<string, () => Promise<LanguageModule>> = {
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  typescript: () => import('shiki/langs/typescript.mjs'),
+  jsx: () => import('shiki/langs/jsx.mjs'),
+  tsx: () => import('shiki/langs/tsx.mjs'),
+  json: () => import('shiki/langs/json.mjs'),
+  jsonc: () => import('shiki/langs/jsonc.mjs'),
+  yaml: () => import('shiki/langs/yaml.mjs'),
+  toml: () => import('shiki/langs/toml.mjs'),
+  markdown: () => import('shiki/langs/markdown.mjs'),
+  html: () => import('shiki/langs/html.mjs'),
+  css: () => import('shiki/langs/css.mjs'),
+  scss: () => import('shiki/langs/scss.mjs'),
+  less: () => import('shiki/langs/less.mjs'),
+  xml: () => import('shiki/langs/xml.mjs'),
+  bash: () => import('shiki/langs/bash.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+  sql: () => import('shiki/langs/sql.mjs'),
+  go: () => import('shiki/langs/go.mjs'),
+  rust: () => import('shiki/langs/rust.mjs'),
+  java: () => import('shiki/langs/java.mjs'),
+  kotlin: () => import('shiki/langs/kotlin.mjs'),
+  swift: () => import('shiki/langs/swift.mjs'),
+  c: () => import('shiki/langs/c.mjs'),
+  cpp: () => import('shiki/langs/cpp.mjs'),
+  csharp: () => import('shiki/langs/csharp.mjs'),
+  php: () => import('shiki/langs/php.mjs'),
+  ruby: () => import('shiki/langs/ruby.mjs'),
+  dart: () => import('shiki/langs/dart.mjs'),
+  lua: () => import('shiki/langs/lua.mjs'),
+  dockerfile: () => import('shiki/langs/dockerfile.mjs'),
+  diff: () => import('shiki/langs/diff.mjs'),
+  ini: () => import('shiki/langs/ini.mjs'),
+  graphql: () => import('shiki/langs/graphql.mjs'),
+  vue: () => import('shiki/langs/vue.mjs'),
+  svelte: () => import('shiki/langs/svelte.mjs'),
+  astro: () => import('shiki/langs/astro.mjs'),
+  makefile: () => import('shiki/langs/makefile.mjs'),
+  proto: () => import('shiki/langs/proto.mjs'),
+};
 
-let highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
-const languageLoadPromises = new Map<BundledLanguage, Promise<void>>();
+// Loose fence hints models emit ("js", "shell", "golang", "c++") → canonical loader id.
+const CHAT_CODE_LANGUAGE_ALIASES: Record<string, string> = {
+  js: 'javascript', mjs: 'javascript', cjs: 'javascript', node: 'javascript',
+  ts: 'typescript', mts: 'typescript', cts: 'typescript',
+  yml: 'yaml',
+  md: 'markdown', markdown: 'markdown',
+  sh: 'bash', shell: 'bash', shellscript: 'bash', zsh: 'bash', console: 'bash',
+  py: 'python', python3: 'python',
+  golang: 'go',
+  rs: 'rust',
+  'c++': 'cpp', 'c#': 'csharp', cs: 'csharp',
+  htm: 'html', xhtml: 'xml', svg: 'xml',
+  rb: 'ruby',
+  dockerfile: 'dockerfile', docker: 'dockerfile',
+  patch: 'diff',
+  kt: 'kotlin', kts: 'kotlin',
+  gql: 'graphql',
+  protobuf: 'proto',
+  make: 'makefile',
+};
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+const languageLoadPromises = new Map<string, Promise<boolean>>();
 const codeHtmlCache = new Map<string, string>();
 
 const getHighlighter = () =>
-  (highlighterPromise ??= createHighlighter({ langs: [], themes: Object.values(CHAT_CODE_THEMES), engine: createJavaScriptRegexEngine() }));
+  (highlighterPromise ??= createHighlighterCore({ langs: [], themes: [vitesseLight, vitesseDark], engine: createJavaScriptRegexEngine() }));
 
-async function getHighlighterForLanguage(language: ChatCodeLanguage) {
-  const highlighter = await getHighlighter();
-  if (language === 'text' || highlighter.getLoadedLanguages().includes(language)) return highlighter;
-
-  let loadPromise = languageLoadPromises.get(language);
-  if (!loadPromise) {
-    loadPromise = highlighter.loadLanguage(bundledLanguages[language]).then(() => undefined);
-    languageLoadPromises.set(language, loadPromise);
-  }
-  await loadPromise;
-  return highlighter;
-}
-
+// Resolve to a loader id we ship a grammar for, or `text` (no highlight). Because
+// callers pass the resolved id straight to Shiki, only ids with a loader survive.
 export function resolveChatCodeLanguage(language?: string): ChatCodeLanguage {
   const normalized = language?.trim().toLowerCase();
   if (!normalized) return 'text';
-  return chatCodeLanguageAliases.get(normalized) ?? 'text';
+  const canonical = CHAT_CODE_LANGUAGE_ALIASES[normalized] ?? normalized;
+  return canonical in CHAT_CODE_LANGUAGE_LOADERS ? canonical : 'text';
+}
+
+// Returns the effective lang to hand Shiki: the requested one once its grammar loads,
+// else `text` so an unknown/failed grammar renders as uncolored plain text instead of throwing.
+async function ensureLanguageLoaded(highlighter: HighlighterCore, language: ChatCodeLanguage): Promise<ChatCodeLanguage> {
+  if (language === 'text' || highlighter.getLoadedLanguages().includes(language)) return language;
+  const loader = CHAT_CODE_LANGUAGE_LOADERS[language];
+  if (!loader) return 'text';
+
+  let loadPromise = languageLoadPromises.get(language);
+  if (!loadPromise) {
+    loadPromise = loader().then(
+      (module) => highlighter.loadLanguage(module.default).then(() => true),
+      () => false,
+    );
+    languageLoadPromises.set(language, loadPromise);
+  }
+  return (await loadPromise) ? language : 'text';
 }
 
 function getCodeHtmlCacheKey(code: string, language: ChatCodeLanguage) {
@@ -65,8 +132,9 @@ export async function renderChatCodeToHtml(code: string, language: ChatCodeLangu
     return cached;
   }
 
-  const highlighter = await getHighlighterForLanguage(language);
-  const html = highlighter.codeToHtml(code, { lang: language, themes: CHAT_CODE_THEMES, defaultColor: 'light' });
+  const highlighter = await getHighlighter();
+  const lang = await ensureLanguageLoaded(highlighter, language);
+  const html = highlighter.codeToHtml(code, { lang, themes: CHAT_CODE_THEMES, defaultColor: 'light' });
   codeHtmlCache.set(cacheKey, html);
   if (codeHtmlCache.size > CODE_HTML_CACHE_LIMIT) {
     const oldestKey = codeHtmlCache.keys().next().value;
@@ -82,10 +150,11 @@ export function createChatCodeDeltaStream(language: ChatCodeLanguage): ChatCodeD
   const stream = new ReadableStream<ChatCodeToken>({
     async start(controller) {
       try {
-        const highlighter = await getHighlighterForLanguage(language);
+        const highlighter = await getHighlighter();
+        const lang = await ensureLanguageLoaded(highlighter, language);
         // The source buffers deltas immediately, so chunks pushed before Shiki boots still replay in order.
         const tokenStream = source.pipeThrough(
-          new CodeToTokenTransformStream({ highlighter, lang: language, themes: CHAT_CODE_THEMES, defaultColor: 'light', allowRecalls: true }),
+          new CodeToTokenTransformStream({ highlighter, lang, themes: CHAT_CODE_THEMES, defaultColor: 'light', allowRecalls: true }),
         );
         const reader = tokenStream.getReader();
         let next = await reader.read();

--- a/web/src/lib/chatCodeHighlighter.ts
+++ b/web/src/lib/chatCodeHighlighter.ts
@@ -9,7 +9,11 @@ export type ChatCodeTokenStream = ReadableStream<ChatCodeToken>;
 
 type ChatCodeDeltaController = { stream: ChatCodeTokenStream; push: (delta: string) => void; close: () => void };
 
-const CHAT_CODE_THEME = 'vitesse-light';
+// Dual themes so code blocks follow the app's light/dark toggle. Shiki emits the
+// default (light) color inline plus a `--shiki-dark` CSS var per token; chat-code.css
+// swaps to the dark var under :root[data-theme="dark"].
+const CHAT_CODE_THEMES = { light: 'vitesse-light', dark: 'vitesse-dark' } as const;
+const CHAT_CODE_THEME_KEY = Object.values(CHAT_CODE_THEMES).join('|');
 const CODE_HTML_CACHE_LIMIT = 24;
 
 // Map every bundled language id + its aliases to a canonical id so `resolveChatCodeLanguage`
@@ -27,7 +31,7 @@ const languageLoadPromises = new Map<BundledLanguage, Promise<void>>();
 const codeHtmlCache = new Map<string, string>();
 
 const getHighlighter = () =>
-  (highlighterPromise ??= createHighlighter({ langs: [], themes: [CHAT_CODE_THEME], engine: createJavaScriptRegexEngine() }));
+  (highlighterPromise ??= createHighlighter({ langs: [], themes: Object.values(CHAT_CODE_THEMES), engine: createJavaScriptRegexEngine() }));
 
 async function getHighlighterForLanguage(language: ChatCodeLanguage) {
   const highlighter = await getHighlighter();
@@ -49,7 +53,7 @@ export function resolveChatCodeLanguage(language?: string): ChatCodeLanguage {
 }
 
 function getCodeHtmlCacheKey(code: string, language: ChatCodeLanguage) {
-  return `${CHAT_CODE_THEME}\0${language}\0${code}`;
+  return `${CHAT_CODE_THEME_KEY}\0${language}\0${code}`;
 }
 
 export async function renderChatCodeToHtml(code: string, language: ChatCodeLanguage) {
@@ -62,7 +66,7 @@ export async function renderChatCodeToHtml(code: string, language: ChatCodeLangu
   }
 
   const highlighter = await getHighlighterForLanguage(language);
-  const html = highlighter.codeToHtml(code, { lang: language, theme: CHAT_CODE_THEME });
+  const html = highlighter.codeToHtml(code, { lang: language, themes: CHAT_CODE_THEMES, defaultColor: 'light' });
   codeHtmlCache.set(cacheKey, html);
   if (codeHtmlCache.size > CODE_HTML_CACHE_LIMIT) {
     const oldestKey = codeHtmlCache.keys().next().value;
@@ -81,7 +85,7 @@ export function createChatCodeDeltaStream(language: ChatCodeLanguage): ChatCodeD
         const highlighter = await getHighlighterForLanguage(language);
         // The source buffers deltas immediately, so chunks pushed before Shiki boots still replay in order.
         const tokenStream = source.pipeThrough(
-          new CodeToTokenTransformStream({ highlighter, lang: language, theme: CHAT_CODE_THEME, allowRecalls: true }),
+          new CodeToTokenTransformStream({ highlighter, lang: language, themes: CHAT_CODE_THEMES, defaultColor: 'light', allowRecalls: true }),
         );
         const reader = tokenStream.getReader();
         let next = await reader.read();

--- a/web/src/lib/chatCodeScroll.ts
+++ b/web/src/lib/chatCodeScroll.ts
@@ -1,0 +1,15 @@
+// Pure scroll-ownership decision for the streaming code viewport, split out so it can be
+// unit-tested without a DOM. Auto-follow only ever scrolls DOWN toward the bottom, so any
+// upward movement is unambiguously the user taking ownership — hand it over immediately,
+// with no timed suppression window that could swallow a real scroll. Scrolling back to the
+// bottom re-arms auto-follow.
+export function nextScrollStickiness(
+  previous: boolean,
+  viewport: { scrollTop: number; lastScrollTop: number; scrollHeight: number; clientHeight: number },
+  bottomThreshold = 72,
+): boolean {
+  // Sub-pixel epsilon so smooth-scroll jitter isn't misread as an upward user scroll.
+  if (viewport.scrollTop < viewport.lastScrollTop - 1) return false;
+  if (viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= bottomThreshold) return true;
+  return previous;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -52,6 +52,7 @@ import { consumeTokenFromUrl } from './lib/auth';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
 import './styles.css';
+import './chat-code.css';
 
 // Pick up a ?token=... bootstrap from a shared link before anything fetches.
 consumeTokenFromUrl();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -629,7 +629,7 @@ textarea:focus, select:focus, input:focus {
   background: var(--surface-2);
   border-radius: 8px;
   padding: 10px 14px;
-  border: 1px solid var(--border);
+  border: 0;
 }
 .ti-user-rewind {
   position: absolute;
@@ -1778,7 +1778,7 @@ textarea:focus, select:focus, input:focus {
   margin: 0 0 10px;
   padding: 12px 14px;
   background: var(--code-bg);
-  border: 1px solid var(--border);
+  border: 0;
   border-radius: 8px;
   overflow-x: auto;
   font-size: 12.5px;

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent }
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -477,10 +478,14 @@ function UserItem({
   );
 }
 
+const CHAT_MARKDOWN_COMPONENTS = { code: MarkdownCode, pre: MarkdownPre } as const;
+
 function AssistantItem({ text }: { text: string }) {
   return (
     <div className="ti-text md">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      <MarkdownCodeStreamingProvider content={text} streaming={false}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={CHAT_MARKDOWN_COMPONENTS}>{text}</ReactMarkdown>
+      </MarkdownCodeStreamingProvider>
     </div>
   );
 }
@@ -488,7 +493,9 @@ function AssistantItem({ text }: { text: string }) {
 function LiveAssistantItem({ text }: { text: string }) {
   return (
     <div className="ti-text md">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      <MarkdownCodeStreamingProvider content={text} streaming>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={CHAT_MARKDOWN_COMPONENTS}>{text}</ReactMarkdown>
+      </MarkdownCodeStreamingProvider>
     </div>
   );
 }

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -490,10 +490,10 @@ function AssistantItem({ text }: { text: string }) {
   );
 }
 
-function LiveAssistantItem({ text }: { text: string }) {
+function LiveAssistantItem({ text, streaming }: { text: string; streaming: boolean }) {
   return (
     <div className="ti-text md">
-      <MarkdownCodeStreamingProvider content={text} streaming>
+      <MarkdownCodeStreamingProvider content={text} streaming={streaming}>
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={CHAT_MARKDOWN_COMPONENTS}>{text}</ReactMarkdown>
       </MarkdownCodeStreamingProvider>
     </div>
@@ -837,6 +837,7 @@ export function ItemView({
   onRewind,
   onFork,
   onPermissionDecide,
+  streaming,
   project,
   sid,
 }: {
@@ -847,6 +848,9 @@ export function ItemView({
   // ('acceptEdits'/'default') from PlanApprovalItem — disjoint value sets, so a single
   // handler serves both. This wider param is assignable to both child onDecide props.
   onPermissionDecide?: (permissionId: string, decision: 'allow' | 'deny', arg?: PermissionMode | 'once' | 'session' | 'always') => void;
+  // True only while the turn is still live; a bare EOF/stop/error flips it off so a
+  // trailing unclosed fence stops streaming and releases its reader/observer.
+  streaming?: boolean;
   project?: string;
   sid?: string;
 }) {
@@ -866,7 +870,7 @@ export function ItemView({
     case 'assistant':
       return <AssistantItem text={it.text} />;
     case 'live-assistant':
-      return <LiveAssistantItem text={it.text} />;
+      return <LiveAssistantItem text={it.text} streaming={streaming ?? true} />;
     case 'thinking':
       return <ThinkingItem text={it.text} />;
     case 'tool': {
@@ -2646,7 +2650,7 @@ export function Session(props: SessionProps = {}) {
             (thread is column-reverse) puts the newest at the visual bottom
             while preserving relative text/tool interleaving. */}
         {[...liveTurn].reverse().map((t) => (
-          <ItemView key={t.id} it={t} onPermissionDecide={handlePermissionDecide} />
+          <ItemView key={t.id} it={t} onPermissionDecide={handlePermissionDecide} streaming={sending} />
         ))}
         {/* Current-turn user message = one card. Images stack ABOVE the
             text (Claude-web ordering: attachments before prose). */}

--- a/web/test/chat-code-fence.test.ts
+++ b/web/test/chat-code-fence.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { isMarkdownCodeFenceIncomplete } from '../src/components/MarkdownCode';
 import { resolveChatCodeLanguage } from '../src/lib/chatCodeHighlighter';
+import { nextScrollStickiness } from '../src/lib/chatCodeScroll';
 
 // Build a positioned node whose offsets frame `fence` inside the full markdown,
 // mirroring what react-markdown/mdast hands the <pre> renderer.
@@ -60,4 +61,37 @@ test('languages outside the curated allowlist fall back to text', () => {
   // These are real Shiki grammars but intentionally not shipped — must degrade, not throw.
   assert.equal(resolveChatCodeLanguage('cobol'), 'text');
   assert.equal(resolveChatCodeLanguage('fortran'), 'text');
+});
+
+// A viewport 300 tall showing the bottom of 1000 of content; `visible` frames it so the
+// bottom-threshold (72) check reads as "at bottom" only when scrollTop is near the end.
+const CLIENT = 300;
+const CONTENT = 1000;
+function at(scrollTop: number, lastScrollTop: number) {
+  return { scrollTop, lastScrollTop, scrollHeight: CONTENT, clientHeight: CLIENT };
+}
+
+test('reading upward during a fast stream immediately takes scroll ownership', () => {
+  // Auto-follow only scrolls down, so any upward delta is the user — hand over at once,
+  // no timed suppression window that a rapid next-token scroll could hide behind.
+  assert.equal(nextScrollStickiness(true, at(400, 700)), false);
+});
+
+test('auto-follow own downward scroll keeps stickiness', () => {
+  // Downward movement that lands at the bottom stays stuck (follow continues)...
+  assert.equal(nextScrollStickiness(true, at(700, 400)), true);
+  // ...and a tiny sub-pixel jitter downward must not be misread as an upward user scroll.
+  assert.equal(nextScrollStickiness(true, at(699.6, 700)), true);
+});
+
+test('scrolling back to the bottom re-arms auto-follow', () => {
+  // User had ownership (previous=false); once they return to within threshold of the
+  // bottom, following resumes without waiting on any timer.
+  assert.equal(nextScrollStickiness(false, at(700, 300)), true);
+});
+
+test('staying scrolled up preserves user ownership as new tokens arrive', () => {
+  // previous=false, no further movement (scrollTop === lastScrollTop) and still far from
+  // the bottom → ownership stays with the user across token mutations.
+  assert.equal(nextScrollStickiness(false, at(200, 200)), false);
 });

--- a/web/test/chat-code-fence.test.ts
+++ b/web/test/chat-code-fence.test.ts
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isMarkdownCodeFenceIncomplete } from '../src/components/MarkdownCode';
+import { resolveChatCodeLanguage } from '../src/lib/chatCodeHighlighter';
+
+// Build a positioned node whose offsets frame `fence` inside the full markdown,
+// mirroring what react-markdown/mdast hands the <pre> renderer.
+function nodeFor(markdown: string, fence: string) {
+  const start = markdown.indexOf(fence);
+  return { position: { start: { offset: start }, end: { offset: start + fence.length } } };
+}
+
+test('an unclosed trailing fence is incomplete (should stream)', () => {
+  const md = '```tsx\nconst value =';
+  assert.equal(isMarkdownCodeFenceIncomplete(md, nodeFor(md, md)), true);
+});
+
+test('a closed fence is complete (should not stream)', () => {
+  const md = '```tsx\nconst value = 42;\n```';
+  assert.equal(isMarkdownCodeFenceIncomplete(md, nodeFor(md, md)), false);
+});
+
+test('a closed fence with trailing prose is complete', () => {
+  const fence = '```tsx\nconst value = 42;\n```';
+  const md = `${fence}\n\nmore text`;
+  assert.equal(isMarkdownCodeFenceIncomplete(md, nodeFor(md, fence)), false);
+});
+
+test('a non-trailing (earlier) fence never streams even if it looks open', () => {
+  const fence = '```js\nconst stable = 1;';
+  const md = `${fence}\n\nsibling paragraph`;
+  assert.equal(isMarkdownCodeFenceIncomplete(md, nodeFor(md, fence)), false);
+});
+
+test('blockquote-prefixed fences are recognized', () => {
+  const md = '> ```ts\n> const active =';
+  assert.equal(isMarkdownCodeFenceIncomplete(md, nodeFor(md, md)), true);
+});
+
+test('missing node position is treated as complete', () => {
+  assert.equal(isMarkdownCodeFenceIncomplete('```ts\nx', undefined), false);
+});
+
+test('language aliases resolve to canonical ids, unknown falls back to text', () => {
+  assert.equal(resolveChatCodeLanguage('js'), 'javascript');
+  assert.equal(resolveChatCodeLanguage('TSX'), 'tsx');
+  assert.equal(resolveChatCodeLanguage('not-a-language'), 'text');
+  assert.equal(resolveChatCodeLanguage(undefined), 'text');
+});

--- a/web/test/chat-code-fence.test.ts
+++ b/web/test/chat-code-fence.test.ts
@@ -47,3 +47,17 @@ test('language aliases resolve to canonical ids, unknown falls back to text', ()
   assert.equal(resolveChatCodeLanguage('not-a-language'), 'text');
   assert.equal(resolveChatCodeLanguage(undefined), 'text');
 });
+
+test('loose fence hints map onto the shipped allowlist', () => {
+  // Aliases models commonly emit should reach a grammar we actually bundle.
+  assert.equal(resolveChatCodeLanguage('shell'), 'bash');
+  assert.equal(resolveChatCodeLanguage('c++'), 'cpp');
+  assert.equal(resolveChatCodeLanguage('py'), 'python');
+  assert.equal(resolveChatCodeLanguage('golang'), 'go');
+});
+
+test('languages outside the curated allowlist fall back to text', () => {
+  // These are real Shiki grammars but intentionally not shipped — must degrade, not throw.
+  assert.equal(resolveChatCodeLanguage('cobol'), 'text');
+  assert.equal(resolveChatCodeLanguage('fortran'), 'text');
+});


### PR DESCRIPTION
## What

Render fenced chat code blocks through a lazy, borderless Shiki-stream surface (matching `macaron-genui-demo`), and drop the outlines/borders from message bubbles and code blocks — for both chat surfaces in the app:

- **Claude thread** (`web/src/views/Session.tsx`) — `AssistantItem` / `LiveAssistantItem`
- **Codex thread** (`web/src/codex/CodexChat.tsx`) — assistant `MessageRow`

## How

- `lib/chatCodeHighlighter.ts` — Shiki highlighter built on `shiki/core` (not `shiki/bundle/web`) with explicit `vitesse-light` + `vitesse-dark` themes and the JS regex engine, so the full grammar registry and Oniguruma WASM stay out of the build. Grammars come from a curated allowlist, each a lazily-imported `shiki/langs/*.mjs` chunk; loose fence hints resolve through an alias map and unknown languages fall back to plain text. Dual-theme render emits the light color inline plus a `--shiki-dark` var per token, and an LRU cache backs the static render.
- `components/ShikiStreamCodeBlock.tsx` — the heavy renderer (code-split, lazy). Streams the trailing incomplete fence with a fade-in per fresh token, settles to static highlight when the fence closes, and has a copy button. Auto-follows the tail while streaming but hands scroll ownership to the user the instant they scroll up (direction-based, no timer window); re-arms when they return to the bottom. Copy uses the Async Clipboard API with an `execCommand` fallback for non-secure LAN-over-HTTP contexts, and surfaces a visible error state. Degrades to `<PlainCode>` on any highlighter failure.
- `lib/chatCodeScroll.ts` — the pure scroll-ownership decision (`nextScrollStickiness`), unit-tested without a DOM.
- `components/MarkdownCode.tsx` — react-markdown `code`/`pre` overrides. Inline code stays an inline pill; fenced code routes to the lazy block. `isMarkdownCodeFenceIncomplete` decides — from the mdast node's `position` offsets — whether the tail fence is still open, so only the actively-streaming block animates. Strips only the single mdast-appended trailing newline, preserving meaningful blank lines. The lazy import falls back to plaintext if the chunk can't load.
- `chat-code.css` — shared borderless code card themed through local semantic vars that resolve from the Claude palette with `--cx-*` fallbacks, so both surfaces get a real background in light and dark. Dual-theme token swap under `:root[data-theme="dark"]`, streamed-token fade keyframes, plaintext fallback, inline-code pill, and a full reset of the legacy `.md pre` / `.cx-msg-text.md pre` padding so the card isn't double-padded. Imported by both entrypoints.
- Removed `1px` borders from `.md pre`, `.cx-msg-text.md pre`, and the `.ti-user` bubble.

## Verification

- `web/test/chat-code-fence.test.ts` — 13 passing unit tests: fence-completeness (open/closed/trailing-prose/non-trailing/blockquote-prefixed/missing-position), language-alias/allowlist resolution, and scroll-ownership regressions (upward read takes ownership immediately, auto-follow keeps stickiness, return-to-bottom re-arms, staying-up preserves ownership across tokens).
- `pnpm build` — both `main` and `codex` entries build; `ShikiStreamCodeBlock` + per-language grammars are lazy chunks (default bundle stays small). Dropping `shiki/bundle/web` shrank the controlled `web/dist` from 23,145,857 B / 137 assets to 20,596,723 B / 54 assets, removing the Oniguruma WASM and unused-theme chunks.
- Visual smoke via a throwaway harness rendering the real component under both surface wrappers: syntax colors, borderless cards, inline-code pill, and copy button verified across Claude/Codex × light/dark; the code card and inline pill keep a real background on the Codex `--cx-*` palette. Non-secure-HTTP copy exercises the `execCommand` fallback with a visible error state.
- Typecheck: no new errors introduced (repo baseline `tsc -b` already fails on vendored `@/*` and `@macaron/shared` resolution, unrelated to this change).

## Notes

- Streaming is gated on the live/last assistant message (`sending` on Codex, `LiveAssistantItem` on Claude), so history renders statically; a bare EOF/stop/error flips streaming off so a trailing unclosed fence stops streaming and releases its reader/observer.
- Code blocks follow the app's `data-theme` light/dark toggle via dual Shiki themes; the Codex thread is light-only today and the card resolves through its `--cx-*` palette.

[MAC-8698](https://multica.macaron.xin/issues/2550ac9b-2895-49da-8d76-d6ccbc63209d "提升对话消息区分度并用 shiki-stream 渲染无边框代码块")