### PR TITLE
feat(web): migrate first-party UI icons to lucide-react

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { Menu } from 'lucide-react';
 import { Sidebar } from './components/Sidebar';
 import { Toast } from './components/Toast';
 import { NotifyStack } from './components/NotifyStack';
@@ -15,7 +16,7 @@ export function App() {
   return (
     <>
       <button className="mobile-nav-toggle" aria-label="Toggle navigation" onClick={() => setNavOpen((v) => !v)}>
-        ☰
+        <Menu size={20} aria-hidden="true" />
       </button>
       <div className={`sb-drawer${navOpen ? ' open' : ''}`}>
         <Sidebar />

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -3,7 +3,8 @@
 // look. Every visual detail — background, borders, tool cards, code
 // blocks — is tuned to match the claude WebUI's palette (see styles.css).
 
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Terminal, Pencil, Search, Hexagon, ListTodo, Settings, ChevronDown, ChevronRight, Sparkles, Diamond, CheckSquare, CircleDot, Square, Flag, GitBranch } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -188,7 +189,7 @@ function Reasoning({ text }: { text: string }) {  const [open, setOpen] = useSta
   return (
     <div className="cx-reasoning">
       <div className="cx-reasoning-head" onClick={() => setOpen((v) => !v)}>
-        <span className="cx-reasoning-caret">{open ? '▾' : '▸'}</span>
+        <span className="cx-reasoning-caret">{open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
         <span>Reasoning</span>
       </div>
       {open && <div className="cx-reasoning-body">{text}</div>}
@@ -196,13 +197,13 @@ function Reasoning({ text }: { text: string }) {  const [open, setOpen] = useSta
   );
 }
 
-function toolGlyph(name: string): string {
-  if (name === 'Bash') return '$';
-  if (name === 'Edit') return '△';
-  if (name === 'WebSearch') return '⌕';
-  if (name.startsWith('mcp:')) return '⬡';
-  if (name === 'TodoWrite') return '☰';
-  return '⚙';
+function toolGlyph(name: string): ReactNode {
+  if (name === 'Bash') return <Terminal size={14} aria-hidden="true" />;
+  if (name === 'Edit') return <Pencil size={14} aria-hidden="true" />;
+  if (name === 'WebSearch') return <Search size={14} aria-hidden="true" />;
+  if (name.startsWith('mcp:')) return <Hexagon size={14} aria-hidden="true" />;
+  if (name === 'TodoWrite') return <ListTodo size={14} aria-hidden="true" />;
+  return <Settings size={14} aria-hidden="true" />;
 }
 
 function ToolCard({ it }: { it: Extract<Item, { kind: 'tool' }> }) {
@@ -240,7 +241,7 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
   return (
     <div className="cx-genui">
       <div className="cx-genui-head">
-        <span className="cx-genui-glyph">◈</span>
+        <span className="cx-genui-glyph"><Sparkles size={14} aria-hidden="true" /></span>
         <span className="cx-genui-name">Rendered UI</span>
         {it.status === 'error' && <span className="cx-genui-status err">diagnostics failed</span>}
       </div>
@@ -258,11 +259,11 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
 }
 
 function PlanCard({ it }: { it: Extract<Item, { kind: 'plan' }> }) {
-  const glyph = (s: CodexPlanStatus) => (s === 'completed' ? '☑' : s === 'inProgress' ? '◐' : '☐');
+  const glyph = (s: CodexPlanStatus): ReactNode => (s === 'completed' ? <CheckSquare size={14} aria-hidden="true" /> : s === 'inProgress' ? <CircleDot size={14} aria-hidden="true" /> : <Square size={14} aria-hidden="true" />);
   return (
     <div className="cx-plan">
       <div className="cx-plan-head">
-        <span className="cx-plan-glyph">◇</span>
+        <span className="cx-plan-glyph"><Diamond size={14} aria-hidden="true" /></span>
         <span className="cx-plan-name">Plan</span>
       </div>
       {it.explanation && <div className="cx-plan-explanation">{it.explanation}</div>}
@@ -291,7 +292,7 @@ function ApprovalCard({ it, onDecide }: { it: Extract<Item, { kind: 'approval' }
   return (
     <div className={'cx-approval' + (resolved ? ' resolved' : '')}>
       <div className="cx-approval-head">
-        <span className="cx-approval-glyph">⚑</span>
+        <span className="cx-approval-glyph"><Flag size={14} aria-hidden="true" /></span>
         <span className="cx-approval-name">{title}</span>
         {resolved && <span className="cx-approval-status">{it.decision === 'stale' ? 'expired' : it.decision}</span>}
       </div>
@@ -623,7 +624,7 @@ export function CodexChat(props: CodexChatProps = {}) {
               {detail?.gitBranch && (
                 <>
                   <span className="cx-main-head-dot">·</span>
-                  <span className="cx-main-head-branch">⌥ {detail.gitBranch}</span>
+                  <span className="cx-main-head-branch"><GitBranch size={13} aria-hidden="true" /> {detail.gitBranch}</span>
                 </>
               )}
             </>

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -260,6 +260,7 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
 
 function PlanCard({ it }: { it: Extract<Item, { kind: 'plan' }> }) {
   const glyph = (s: CodexPlanStatus): ReactNode => (s === 'completed' ? <CheckSquare size={14} aria-hidden="true" /> : s === 'inProgress' ? <CircleDot size={14} aria-hidden="true" /> : <Square size={14} aria-hidden="true" />);
+  const statusLabel = (s: CodexPlanStatus): string => (s === 'completed' ? 'completed' : s === 'inProgress' ? 'in progress' : 'pending');
   return (
     <div className="cx-plan">
       <div className="cx-plan-head">
@@ -270,7 +271,7 @@ function PlanCard({ it }: { it: Extract<Item, { kind: 'plan' }> }) {
       <div className="cx-plan-steps">
         {it.steps.map((s, i) => (
           <div key={i} className={'cx-plan-step ' + s.status}>
-            <span className="cx-plan-step-glyph">{glyph(s.status)}</span>
+            <span className="cx-plan-step-glyph" role="img" aria-label={statusLabel(s.status)}>{glyph(s.status)}</span>
             <span className="cx-plan-step-text">{s.step}</span>
           </div>
         ))}

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -4,7 +4,7 @@
 // blocks — is tuned to match the claude WebUI's palette (see styles.css).
 
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Terminal, Pencil, Search, Hexagon, ListTodo, Settings, ChevronDown, ChevronRight, Sparkles, Diamond, CheckSquare, CircleDot, Square, Flag, GitBranch } from 'lucide-react';
+import { Terminal, Pencil, Search, Hexagon, ListTodo, Settings, ChevronDown, ChevronRight, Sparkles, Diamond, CheckSquare, CircleDot, Square, Flag, GitBranch, AlertTriangle } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -666,7 +666,7 @@ export function CodexChat(props: CodexChatProps = {}) {
             {error && (
               <div className="cx-tool err">
                 <div className="cx-tool-head">
-                  <span className="cx-tool-glyph">!</span>
+                  <span className="cx-tool-glyph"><AlertTriangle size={14} aria-hidden="true" /></span>
                   <span className="cx-tool-name">Error</span>
                 </div>
                 <div className="cx-tool-out err">{error}</div>

--- a/web/src/codex/CodexComposer.tsx
+++ b/web/src/codex/CodexComposer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Paperclip, X, Square, ArrowUp } from 'lucide-react';
 import { CodexProviderPicker } from './CodexProviderPicker';
 import { CodexRuntimePicker } from './CodexRuntimePicker';
 import type { CodexRuntimeOverride } from './api';
@@ -86,7 +87,7 @@ export function CodexComposer({
                   className="cx-img-chip-x"
                   onClick={() => onImagesChange(images.filter((c) => c.id !== img.id))}
                   aria-label="Remove image"
-                >×</button>
+                ><X size={14} aria-hidden="true" /></button>
               </div>
             ))}
           </div>
@@ -107,9 +108,7 @@ export function CodexComposer({
             title="Attach image"
             aria-label="Attach image"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-            </svg>
+            <Paperclip size={16} strokeWidth={2} aria-hidden="true" />
           </button>
           <textarea
             ref={ref}
@@ -130,7 +129,7 @@ export function CodexComposer({
             rows={1}
           />
           {running && onStop ? (
-            <button className="cx-send stop" onClick={onStop} title="Stop">■</button>
+            <button className="cx-send stop" onClick={onStop} title="Stop"><Square size={14} fill="currentColor" aria-hidden="true" /></button>
           ) : (
             <button
               className="cx-send"
@@ -138,7 +137,7 @@ export function CodexComposer({
               onClick={onSubmit}
               title="Send (Enter)"
               aria-label="Send"
-            >↑</button>
+            ><ArrowUp size={16} aria-hidden="true" /></button>
           )}
         </div>
       </div>

--- a/web/src/codex/CodexProviderPicker.tsx
+++ b/web/src/codex/CodexProviderPicker.tsx
@@ -3,6 +3,7 @@
 // Adding / editing providers still lives on the Settings page — this chip
 // only exposes the "which one runs the next turn" switch.
 
+import { ChevronDown, Monitor } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { codexApi, type PublicCodexSettings } from './api';
 
@@ -53,33 +54,9 @@ export function CodexProviderPicker() {
 
   return (
     <div className={'cx-provider-chip' + (busy ? ' busy' : '')} title={err ? `Switch failed: ${err}` : `Provider · ${activeLabel}`}>
-      <svg
-        width="13"
-        height="13"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect x="3" y="4" width="18" height="12" rx="2" />
-        <path d="M8 20h8M12 16v4" />
-      </svg>
+      <Monitor size={13} strokeWidth={2} aria-hidden="true" />
       <span className="cx-provider-chip-label">{activeLabel}</span>
-      <svg
-        className="cx-provider-chip-caret"
-        width="9"
-        height="9"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <polyline points="6 9 12 15 18 9" />
-      </svg>
+      <ChevronDown className="cx-provider-chip-caret" size={9} strokeWidth={2.5} aria-hidden="true" />
       <select
         className="cx-provider-chip-select"
         value={activeId}

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, Check, Plus, X, Settings } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { codexApi, type CodexThread, type CodexWorkspace } from './api';
 import {
@@ -164,7 +165,7 @@ export function CodexSidebar() {
                   navigate(`/w/${encodeURIComponent(w.project)}`);
                 }}
               >
-                <span className="cx-sb-ws-arrow">{isExpanded ? '▾' : '▸'}</span>
+                <span className="cx-sb-ws-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
                 <span className="cx-sb-ws-name">{name}</span>
                 <span className="cx-sb-ws-count">{w.sessionCount}</span>
               </div>
@@ -200,12 +201,12 @@ export function CodexSidebar() {
                             }
                           }}
                           title={pinned ? 'Remove from canvas' : 'Add to canvas'}
-                        >{pinned ? '✓' : '+'}</button>
+                        >{pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}</button>
                         <button
                           className="cx-sb-thread-del"
                           onClick={(e) => del(e, s.sessionId)}
                           title="Delete"
-                        >×</button>
+                        ><X size={14} aria-hidden="true" /></button>
                       </div>
                     );
                   })}
@@ -222,7 +223,7 @@ export function CodexSidebar() {
       <div className="cx-sb-grow" />
 
       <Link className="cx-sb-settings" to="/settings">
-        <span>⚙</span>
+        <span><Settings size={16} aria-hidden="true" /></span>
         <span>Settings</span>
       </Link>
 

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -143,7 +143,7 @@ export function CodexSidebar() {
       </Link>
 
       <button className="cx-sb-new" onClick={() => navigate('/')}>
-        <span>＋</span>
+        <Plus size={14} aria-hidden="true" />
         <span>New thread</span>
       </button>
 

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { ChevronDown, ChevronRight, Check, Plus, X, Settings } from 'lucide-react';
+import { ChevronDown, ChevronRight, Check, Circle, Plus, X, Settings } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { codexApi, type CodexThread, type CodexWorkspace } from './api';
 import {
@@ -229,6 +229,7 @@ export function CodexSidebar() {
 
       <footer className="cx-sb-foot">
         <div className={'cx-sb-status cx-sb-status-' + status}>
+          <Circle className="cx-sb-status-dot" size={8} fill="currentColor" strokeWidth={0} aria-hidden="true" />
           {status === 'ok' ? providerLabel || 'online' : status === 'bad' ? 'config missing' : 'connecting…'}
         </div>
       </footer>

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -307,6 +307,9 @@ body {
   font-size: 12px;
 }
 .cx-main-head-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--cx-muted);
   font-size: 12px;
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -253,16 +253,14 @@ body {
   color: var(--cx-muted);
   font-size: 11.5px;
 }
-.cx-sb-status::before {
-  content: '●';
-  display: inline-block;
-  margin-right: 6px;
-  color: var(--cx-muted-2);
-  font-size: 8px;
-  vertical-align: 2px;
+.cx-sb-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
-.cx-sb-status-ok::before { color: var(--cx-good); }
-.cx-sb-status-bad::before { color: var(--cx-bad); }
+.cx-sb-status-dot { color: var(--cx-muted-2); flex-shrink: 0; }
+.cx-sb-status-ok .cx-sb-status-dot { color: var(--cx-good); }
+.cx-sb-status-bad .cx-sb-status-dot { color: var(--cx-bad); }
 
 /* ---------- Main ---------- */
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,3 +1,4 @@
+import { LayoutGrid, MessageSquare, Pencil, Zap } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { SEARCH_HL_CLOSE, SEARCH_HL_OPEN } from '@macaron/shared';
@@ -350,7 +351,7 @@ export function CommandPalette() {
                   onClick={() => runItem(it)}
                 >
                   <span className={'cmdk-kind cmdk-kind-' + it.kind}>
-                    {it.kind === 'command' ? '⚡' : it.kind === 'session' ? '◈' : it.kind === 'workspace' ? '▤' : '✎'}
+                    {it.kind === 'command' ? <Zap size={14} aria-hidden="true" /> : it.kind === 'session' ? <MessageSquare size={14} aria-hidden="true" /> : it.kind === 'workspace' ? <LayoutGrid size={14} aria-hidden="true" /> : <Pencil size={14} aria-hidden="true" />}
                   </span>
                   <span className="cmdk-text">
                     <span className="cmdk-title">{it.title}</span>

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -1,8 +1,8 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 export type MenuItem =
-  | { icon?: string; label: string; danger?: boolean; onClick: () => void }
+  | { icon?: ReactNode; label: string; danger?: boolean; onClick: () => void }
   | 'separator';
 
 type Props = {

--- a/web/src/components/DiffCard.tsx
+++ b/web/src/components/DiffCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ArrowUp, Circle } from 'lucide-react';
 
 // Inline diff card for Claude's file-editing tools. Everything needed is
 // already in the tool_use `input` (old/new strings), so this renders straight
@@ -76,7 +77,7 @@ export function DiffCard({ name, diff, result, isError }: { name: string; diff: 
   return (
     <div className={'ti-diff' + (failed ? ' err' : '')}>
       <div className="ti-diff-head">
-        <span className="ti-dot">●</span>
+        <span className="ti-dot"><Circle size={8} fill="currentColor" aria-hidden="true" /></span>
         <span className="ti-tool-name">{name}</span>
         {diff.filePath && (
           <span className="ti-diff-path" title={diff.filePath}>{shortPath(diff.filePath)}</span>
@@ -98,7 +99,7 @@ export function DiffCard({ name, diff, result, isError }: { name: string; diff: 
       )}
       {canCollapse && (
         <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
-          {open ? '↑ collapse' : `… expand diff (+${plus} −${minus})`}
+          {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : `… expand diff (+${plus} −${minus})`}
         </button>
       )}
     </div>

--- a/web/src/components/DirPicker.tsx
+++ b/web/src/components/DirPicker.tsx
@@ -1,3 +1,4 @@
+import { CornerLeftUp, Folder } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { api, type DirListing } from '../lib/api';
 
@@ -40,7 +41,7 @@ export function DirPicker({ onPick, onClose }: { onPick: (cwd: string) => void; 
         <div className="dir-picker-list">
           {listing?.parent && (
             <button type="button" className="dir-picker-row dir-picker-up" onClick={() => browse(listing.parent!)}>
-              <span className="dir-picker-icon">↰</span>
+              <span className="dir-picker-icon"><CornerLeftUp size={13} aria-hidden="true"/></span>
               <span className="dir-picker-name">..</span>
             </button>
           )}
@@ -53,7 +54,7 @@ export function DirPicker({ onPick, onClose }: { onPick: (cwd: string) => void; 
               onDoubleClick={() => onPick(d.path)}
               title={d.name}
             >
-              <span className="dir-picker-icon">📁</span>
+              <span className="dir-picker-icon"><Folder size={13} aria-hidden="true"/></span>
               <span className="dir-picker-name">{d.name}</span>
             </button>
           ))}

--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -7,6 +7,7 @@
 // api.writeFile; unsaved changes are indicated by a dot and confirmed
 // before switching files.
 
+import { Circle } from 'lucide-react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -188,7 +189,7 @@ export function FileTile({
                 onClick={() => setMode('edit')}
               >
                 Edit
-                {dirty && <span className="ft-dirty" title="Unsaved changes">●</span>}
+                {dirty && <span className="ft-dirty" role="img" aria-label="Unsaved changes" title="Unsaved changes"><Circle size={8} fill="currentColor" strokeWidth={0} aria-hidden="true" /></span>}
               </button>
             </div>
             {mode !== 'preview' && (

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -6,6 +6,7 @@
 // Mirrors GitPanel's slide-in shell (fixed backdrop + right-side panel
 // via the .above-modal escape hatch so it stacks over the composer).
 
+import { ChevronDown, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api, type FileEntry, type FileContentSearchResponse } from '../lib/api';
 
@@ -56,7 +57,7 @@ function TreeRow({
         onClick={toggle}
         title={entry.path}
       >
-        <span className="fp-caret">{isDir ? (open ? '▾' : '▸') : ' '}</span>
+        <span className="fp-caret">{isDir ? (open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />) : ' '}</span>
         <span className="fp-name">{entry.name}</span>
       </button>
       {isDir && open && (
@@ -151,7 +152,7 @@ export function FilesPanel({
     <aside className="fp-panel" aria-label="Files panel">
         <div className="fp-head">
           <div className="fp-title">Files</div>
-          <button className="fp-close" onClick={onClose} title="Close" aria-label="Close">×</button>
+          <button className="fp-close" onClick={onClose} title="Close" aria-label="Close"><X size={14} aria-hidden="true" /></button>
         </div>
         <div className="fp-search">
           <input

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -57,7 +57,7 @@ function TreeRow({
         onClick={toggle}
         title={entry.path}
       >
-        <span className="fp-caret">{isDir ? (open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />) : ' '}</span>
+        <span className="fp-caret">{isDir ? (open ? <ChevronDown size={10} aria-hidden="true" /> : <ChevronRight size={10} aria-hidden="true" />) : ' '}</span>
         <span className="fp-name">{entry.name}</span>
       </button>
       {isDir && open && (

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1,3 +1,4 @@
+import { ArrowDown, ArrowUp, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api, type GitFileStatus } from '../lib/api';
 
@@ -109,7 +110,7 @@ export function GitPanel({ project, onClose }: { project: string; onClose: () =>
       <aside className="git-panel" onClick={(e) => e.stopPropagation()}>
         <header className="git-panel-head">
           <div className="git-panel-title">Source Control</div>
-          <button className="git-panel-x" onClick={onClose} aria-label="Close git panel" title="Close">×</button>
+          <button className="git-panel-x" onClick={onClose} aria-label="Close git panel" title="Close"><X size={14} aria-hidden="true" /></button>
         </header>
 
         {status && !status.isRepo ? (
@@ -128,8 +129,8 @@ export function GitPanel({ project, onClose }: { project: string; onClose: () =>
               </select>
               {status && (status.ahead > 0 || status.behind > 0) && (
                 <span className="git-aheadbehind" title="ahead / behind upstream">
-                  {status.ahead > 0 && <>↑{status.ahead}</>}
-                  {status.behind > 0 && <>↓{status.behind}</>}
+                  {status.ahead > 0 && <><ArrowUp size={12} aria-hidden="true" />{status.ahead}</>}
+                  {status.behind > 0 && <><ArrowDown size={12} aria-hidden="true" />{status.behind}</>}
                 </span>
               )}
               <button className="git-icon-btn" title="Refresh" onClick={() => { loadStatus(); loadBranches(); }}>⟳</button>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Plus, RefreshCw, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api, type GitFileStatus } from '../lib/api';
 
@@ -133,8 +133,8 @@ export function GitPanel({ project, onClose }: { project: string; onClose: () =>
                   {status.behind > 0 && <><ArrowDown size={12} aria-hidden="true" />{status.behind}</>}
                 </span>
               )}
-              <button className="git-icon-btn" title="Refresh" onClick={() => { loadStatus(); loadBranches(); }}>⟳</button>
-              <button className="git-icon-btn" title="New branch" onClick={() => setCreating((v) => !v)}>＋</button>
+              <button className="git-icon-btn" title="Refresh" onClick={() => { loadStatus(); loadBranches(); }}><RefreshCw size={14} aria-hidden="true" /></button>
+              <button className="git-icon-btn" title="New branch" onClick={() => setCreating((v) => !v)}><Plus size={14} aria-hidden="true" /></button>
             </div>
 
             {creating && (

--- a/web/src/components/NotifyStack.tsx
+++ b/web/src/components/NotifyStack.tsx
@@ -1,3 +1,4 @@
+import { X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -111,7 +112,7 @@ export function NotifyStack() {
             }}
             aria-label="dismiss"
           >
-            ×
+            <X size={14} aria-hidden="true" />
           </span>
           <div className="notify-card-title">{it.title}</div>
           {it.body ? <div className="notify-card-body">{it.body}</div> : null}

--- a/web/src/components/ProviderPicker.tsx
+++ b/web/src/components/ProviderPicker.tsx
@@ -6,6 +6,7 @@
 // default, plus any custom provider whose key is configured. If the user
 // wants to add/edit/delete providers they still go to the Settings page.
 
+import { ChevronDown, Monitor } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { api, type PublicSettings } from '../lib/api';
 import { useToast } from './Toast';
@@ -47,34 +48,9 @@ export function ProviderPicker() {
 
   return (
     <div className="provider-chip" title={`Provider · ${activeLabel}`}>
-      <svg
-        className="provider-chip-icon"
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect x="3" y="4" width="18" height="12" rx="2" />
-        <path d="M8 20h8M12 16v4" />
-      </svg>
+      <Monitor className="provider-chip-icon" size={14} strokeWidth={2} aria-hidden="true" />
       <span className="provider-chip-label">{activeLabel}</span>
-      <svg
-        className="provider-chip-caret"
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <polyline points="6 9 12 15 18 9" />
-      </svg>
+      <ChevronDown className="provider-chip-caret" size={10} strokeWidth={2.5} aria-hidden="true" />
       <select
         className="provider-chip-select"
         value={activeId}

--- a/web/src/components/SessionCard.tsx
+++ b/web/src/components/SessionCard.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { api, fmtAgo, type SessionDetail, type Message } from '../lib/api';
 
@@ -112,7 +113,7 @@ export function SessionCard({
           if (m.kind === 'user') {
             return (
               <div key={m.id} className="sc-user-row">
-                <span className="sc-user-chevron">❯</span>
+                <span className="sc-user-chevron"><ChevronRight size={14} aria-hidden="true" /></span>
                 <span className="sc-user-text">{m.text}</span>
               </div>
             );

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,5 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Clipboard,
+  CopyPlus,
+  Crosshair,
+  GitMerge,
+  Link as LinkIcon,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  Unlink,
+  X,
+} from 'lucide-react';
 import { api, basename, HttpError, type Workspace, type SessionListItem, type WorktreeInfo } from '../lib/api';
 import { useToast } from './Toast';
 import { useConfirm } from './Confirm';
@@ -150,12 +166,12 @@ export function Sidebar() {
       y: e.clientY,
       items: [
         {
-          icon: '+',
+          icon: <Plus size={14} aria-hidden="true" />,
           label: 'New Session',
           onClick: () => navigate(`/w/${encodeURIComponent(w.project)}`),
         },
         {
-          icon: '📋',
+          icon: <Clipboard size={14} aria-hidden="true" />,
           label: 'Copy Path',
           onClick: () => {
             navigator.clipboard.writeText(w.cwd || w.project);
@@ -164,7 +180,7 @@ export function Sidebar() {
         },
         'separator',
         {
-          icon: '✕',
+          icon: <X size={14} aria-hidden="true" />,
           label: 'Delete Workspace',
           danger: true,
           onClick: () => toast('delete not yet implemented'),
@@ -198,7 +214,7 @@ export function Sidebar() {
     const wt = worktrees[s.sessionId];
     const items: MenuItem[] = [
         {
-          icon: '◎',
+          icon: <Crosshair size={14} aria-hidden="true" />,
           label: 'Focus Session',
           onClick: () =>
             navigate(
@@ -206,12 +222,12 @@ export function Sidebar() {
             ),
         },
         {
-          icon: '✎',
+          icon: <Pencil size={14} aria-hidden="true" />,
           label: 'Rename',
           onClick: () => startRename(s),
         },
         {
-          icon: '⊕',
+          icon: <CopyPlus size={14} aria-hidden="true" />,
           label: 'Duplicate',
           onClick: async () => {
             try {
@@ -227,7 +243,7 @@ export function Sidebar() {
           },
         },
         {
-          icon: '🔗',
+          icon: <LinkIcon size={14} aria-hidden="true" />,
           label: 'Copy share link',
           onClick: async () => {
             try {
@@ -243,7 +259,7 @@ export function Sidebar() {
           },
         },
         {
-          icon: '🚫',
+          icon: <Unlink size={14} aria-hidden="true" />,
           label: 'Unshare',
           onClick: async () => {
             try {
@@ -257,7 +273,7 @@ export function Sidebar() {
     ];
     if (wt) {
       items.push('separator', {
-        icon: '⭱',
+        icon: <GitMerge size={14} aria-hidden="true" />,
         label: wt.dirty ? 'Merge worktree (commit first)' : 'Merge worktree → base',
         onClick: async () => {
           try {
@@ -269,7 +285,7 @@ export function Sidebar() {
           }
         },
       }, {
-        icon: '🗑',
+        icon: <Trash2 size={14} aria-hidden="true" />,
         label: 'Discard worktree',
         danger: true,
         onClick: async () => {
@@ -303,7 +319,7 @@ export function Sidebar() {
       });
     }
     items.push('separator', {
-          icon: '✕',
+          icon: <X size={14} aria-hidden="true" />,
           label: 'Delete Session',
           danger: true,
           onClick: async () => {
@@ -339,7 +355,7 @@ export function Sidebar() {
         onClick={() => window.dispatchEvent(new CustomEvent('macaron:open-search'))}
         title="Search Claude sessions"
       >
-        <span className="sb-search-icon">⌕</span>
+        <span className="sb-search-icon"><Search size={16} aria-hidden="true" /></span>
         <span className="sb-search-label">Search sessions</span>
       </button>
       <Link className={'sb-nav-link' + (location.pathname === '/examples' ? ' active' : '')} to="/examples">
@@ -378,7 +394,7 @@ export function Sidebar() {
                 }}
                 onContextMenu={(e) => wsMenu(w, e)}
               >
-                <span className="sb-arrow">{isExpanded ? '▾' : '▸'}</span>
+                <span className="sb-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
                 <span className="sb-ws-name">{name}</span>
                 <span className="sb-spacer" />
                 {runCount > 0 && !isExpanded && (
@@ -458,7 +474,7 @@ export function Sidebar() {
                           title={pinned ? 'Remove from canvas' : 'Add to canvas'}
                           aria-label={pinned ? 'Remove from canvas' : 'Add to canvas'}
                         >
-                          {pinned ? '✓' : '+'}
+                          {pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
                         </button>
                       </div>
                     );

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -12,6 +12,7 @@
 //   Row 6: [Permission chip] shift+tab to cycle    (permission)
 
 import { useEffect, useState } from 'react';
+import { ChevronRight, ChevronsRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { ProviderPicker } from './ProviderPicker';
 import { api, type PublicSettings } from '../lib/api';
@@ -194,7 +195,7 @@ export function StatusBar({
 
       {currentTodo && (
         <div className="status-row status-todo">
-          <span className="status-todo-arrow">▸</span>
+          <span className="status-todo-arrow"><ChevronRight size={12} aria-hidden="true" /></span>
           <span className="status-todo-text">{currentTodo.text}</span>
           <span className="status-todo-progress">
             ({currentTodo.done}/{currentTodo.total})
@@ -203,7 +204,7 @@ export function StatusBar({
       )}
 
       <div className="status-row status-perm">
-        <span className="status-perm-arrow">▸▸</span>
+        <span className="status-perm-arrow"><ChevronsRight size={12} aria-hidden="true" /></span>
         <PermissionChip value={permissionMode} onChange={onPermissionChange} disabled={sending} />
         <span className="status-perm-hint">shift+tab to cycle</span>
       </div>

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -12,7 +12,7 @@
 //   Row 6: [Permission chip] shift+tab to cycle    (permission)
 
 import { useEffect, useState } from 'react';
-import { ChevronRight, ChevronsRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, ChevronsRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { ProviderPicker } from './ProviderPicker';
 import { api, type PublicSettings } from '../lib/api';
@@ -53,13 +53,7 @@ function PermissionChip({
   return (
     <div className={`provider-chip${disabled ? ' disabled' : ''}`} title={`Permission · ${active?.label ?? value}`}>
       <span className="provider-chip-label">{active?.label ?? value}</span>
-      <svg
-        className="provider-chip-caret"
-        width="8" height="8" viewBox="0 0 24 24"
-        fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-      >
-        <polyline points="6 9 12 15 18 9" />
-      </svg>
+      <ChevronDown className="provider-chip-caret" size={8} strokeWidth={2.5} aria-hidden="true" />
       <select
         className="provider-chip-select"
         value={value}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -261,6 +261,7 @@ button { font: inherit; cursor: pointer; }
   font-size: 13px;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
+.fx-head .ghost { display: inline-flex; align-items: center; gap: 5px; }
 .ghost:hover:not(:disabled) { background: var(--surface-2); border-color: var(--border-strong); }
 .ghost:disabled { opacity: 0.45; cursor: not-allowed; }
 .small { padding: 5px 10px; font-size: 12px; }
@@ -635,6 +636,9 @@ textarea:focus, select:focus, input:focus {
   position: absolute;
   top: 6px;
   right: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 2px 8px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -658,6 +662,9 @@ textarea:focus, select:focus, input:focus {
   position: absolute;
   top: 6px;
   right: 82px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 2px 8px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -789,6 +796,9 @@ textarea:focus, select:focus, input:focus {
   padding: 2px 0;
   font-family: var(--font-mono);
   font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
 }
 .ti-expand:hover { color: var(--accent); }
 
@@ -4712,6 +4722,9 @@ textarea:focus, select:focus, input:focus {
 }
 .example-card-try {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   padding: 6px 12px;
   background: var(--accent);
   color: #fff;

--- a/web/src/views/Examples.tsx
+++ b/web/src/views/Examples.tsx
@@ -4,15 +4,16 @@
 // on /w/<project>, where Workspace's auto-draft picks the seed up and
 // Session's isNew branch auto-sends it.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { AlertTriangle, ArrowRight, BarChart3, Calendar, Compass, FolderTree, Moon, Palette, PenLine, Settings } from 'lucide-react';
 import { api } from '../lib/api';
 import type { Workspace } from '@macaron/shared';
 import { setPendingPrompt } from '../lib/newSession';
 
 type Example = {
   id: string;
-  emoji: string;
+  icon: ReactNode;
   title: string;
   blurb: string;
   category: 'interactive' | 'preview' | 'data';
@@ -23,7 +24,7 @@ const EXAMPLES: Example[] = [
   // ---- Interactive (asks the user something → click to answer) ----
   {
     id: 'framework-picker',
-    emoji: '🧭',
+    icon: <Compass size={20} aria-hidden="true" />,
     title: 'Pick a framework',
     blurb: 'A/B/C decision as clickable cards — no typing back.',
     category: 'interactive',
@@ -36,7 +37,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'config-wizard',
-    emoji: '⚙️',
+    icon: <Settings size={20} aria-hidden="true" />,
     title: 'Service config wizard',
     blurb: 'Structured form → posts a JSON payload back.',
     category: 'interactive',
@@ -49,7 +50,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'destructive-confirm',
-    emoji: '⚠️',
+    icon: <AlertTriangle size={20} aria-hidden="true" />,
     title: 'Destructive confirm',
     blurb: 'Diff summary + Apply / Cancel buttons.',
     category: 'interactive',
@@ -63,7 +64,7 @@ const EXAMPLES: Example[] = [
   // ---- UI Change Previews (ui-preview skill in action) ----
   {
     id: 'redesign-statusbar',
-    emoji: '🎨',
+    icon: <Palette size={20} aria-hidden="true" />,
     title: 'Redesign StatusBar',
     blurb: 'Read source → preview redesign → Apply writes files.',
     category: 'preview',
@@ -75,7 +76,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'copy-variants',
-    emoji: '✍️',
+    icon: <PenLine size={20} aria-hidden="true" />,
     title: 'Landing copy A/B/C',
     blurb: 'Three hero variants side-by-side; click your favorite.',
     category: 'preview',
@@ -87,7 +88,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'dark-mode-preview',
-    emoji: '🌙',
+    icon: <Moon size={20} aria-hidden="true" />,
     title: 'Dark mode preview',
     blurb: 'Toggle-driven color scheme preview with Apply.',
     category: 'preview',
@@ -102,7 +103,7 @@ const EXAMPLES: Example[] = [
   // ---- Data & status ----
   {
     id: 'csv-visualize',
-    emoji: '📊',
+    icon: <BarChart3 size={20} aria-hidden="true" />,
     title: 'Visualize this CSV',
     blurb: 'Paste tabular data, get a chart + summary.',
     category: 'data',
@@ -114,7 +115,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'git-summary',
-    emoji: '📅',
+    icon: <Calendar size={20} aria-hidden="true" />,
     title: 'This week in commits',
     blurb: 'git log → dashboard: commits, files, contributors.',
     category: 'data',
@@ -128,7 +129,7 @@ const EXAMPLES: Example[] = [
   },
   {
     id: 'file-explorer',
-    emoji: '🗂',
+    icon: <FolderTree size={20} aria-hidden="true" />,
     title: 'Project file map',
     blurb: 'Read the workspace tree into a visual explorer.',
     category: 'data',
@@ -199,7 +200,7 @@ export function Examples() {
             <div className="examples-grid">
               {items.map((ex) => (
                 <article className="example-card" key={ex.id}>
-                  <div className="example-card-emoji">{ex.emoji}</div>
+                  <div className="example-card-emoji">{ex.icon}</div>
                   <div className="example-card-body">
                     <h3 className="example-card-title">{ex.title}</h3>
                     <p className="example-card-blurb">{ex.blurb}</p>
@@ -214,7 +215,7 @@ export function Examples() {
                     disabled={!target}
                     title={target ? `Try in ${target}` : 'Pick a workspace first'}
                   >
-                    Try →
+                    Try <ArrowRight size={14} aria-hidden="true" />
                   </button>
                 </article>
               ))}

--- a/web/src/views/FileExplorer.tsx
+++ b/web/src/views/FileExplorer.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, ChevronDown, ChevronRight, Circle, File, Folder } from 'lucide-react';
 import { api, type FileEntry } from '../lib/api';
 import { useToast } from '../components/Toast';
 import { useConfirm } from '../components/Confirm';
@@ -51,8 +52,8 @@ function TreeNode({
         onClick={toggle}
         title={entry.path}
       >
-        <span className="fx-caret">{isDir ? (open ? '▾' : '▸') : ''}</span>
-        <span className="fx-icon">{isDir ? '📁' : '📄'}</span>
+        <span className="fx-caret">{isDir ? (open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />) : ''}</span>
+        <span className="fx-icon">{isDir ? <Folder size={14} aria-hidden="true" /> : <File size={14} aria-hidden="true" />}</span>
         <span className="fx-name">{entry.name}</span>
       </button>
       {isDir && open && (
@@ -164,10 +165,10 @@ export function FileExplorer() {
     <section className="fx">
       <header className="fx-head">
         <Link className="ghost small" to={`/w/${encodeURIComponent(project)}`}>
-          ← Workspace
+          <ArrowLeft size={14} aria-hidden="true" /> Workspace
         </Link>
         <span className="fx-path">{openPath || 'Files'}</span>
-        {dirty && <span className="fx-dirty" title="Unsaved changes">●</span>}
+        {dirty && <span className="fx-dirty" title="Unsaved changes"><Circle size={8} fill="currentColor" aria-hidden="true" /></span>}
         <div className="fx-head-actions">
           <button className="ghost small" disabled={!dirty || saving} onClick={save}>
             {saving ? 'Saving…' : 'Save'}

--- a/web/src/views/FileExplorer.tsx
+++ b/web/src/views/FileExplorer.tsx
@@ -52,7 +52,7 @@ function TreeNode({
         onClick={toggle}
         title={entry.path}
       >
-        <span className="fx-caret">{isDir ? (open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />) : ''}</span>
+        <span className="fx-caret">{isDir ? (open ? <ChevronDown size={12} aria-hidden="true" /> : <ChevronRight size={12} aria-hidden="true" />) : ''}</span>
         <span className="fx-icon">{isDir ? <Folder size={14} aria-hidden="true" /> : <File size={14} aria-hidden="true" />}</span>
         <span className="fx-name">{entry.name}</span>
       </button>

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent }
 import { useNavigate } from 'react-router-dom';
 import { api, type SlashCommand } from '../lib/api';
 import type { Workspace } from '@macaron/shared';
+import { ArrowUp, X } from 'lucide-react';
 import { setPendingPrompt, type PendingImage } from '../lib/newSession';
 import { startNewSession } from '../lib/liveStore';
 import { SlashPalette } from '../components/SlashPalette';
@@ -290,7 +291,9 @@ export function Home() {
                     className="img-chip-x"
                     onClick={() => setImages((cur) => cur.filter((c) => c.id !== img.id))}
                     aria-label="Remove image"
-                  >×</button>
+                  >
+                    <X size={14} aria-hidden="true" />
+                  </button>
                 </div>
               ))}
             </div>
@@ -391,10 +394,7 @@ export function Home() {
               aria-label={sending ? 'Opening…' : 'Send'}
               title={sending ? 'Opening…' : 'Send (Enter)'}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 19V5" />
-                <path d="m5 12 7-7 7 7" />
-              </svg>
+              <ArrowUp size={14} strokeWidth={2.4} aria-hidden="true" />
             </button>
           </div>
         </form>

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent }
 import { useNavigate } from 'react-router-dom';
 import { api, type SlashCommand } from '../lib/api';
 import type { Workspace } from '@macaron/shared';
-import { ArrowUp, X } from 'lucide-react';
+import { ArrowUp, ChevronDown, Paperclip, X } from 'lucide-react';
 import { setPendingPrompt, type PendingImage } from '../lib/newSession';
 import { startNewSession } from '../lib/liveStore';
 import { SlashPalette } from '../components/SlashPalette';
@@ -356,9 +356,7 @@ export function Home() {
               aria-label="Attach image"
               onClick={() => fileInputRef.current?.click()}
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-              </svg>
+              <Paperclip size={16} strokeWidth={2} aria-hidden="true" />
             </button>
             {/* Workspace switcher styled as a provider-chip pill — same visual
                 vocabulary as the permission chip in the StatusBar so the two
@@ -366,13 +364,7 @@ export function Home() {
                 is enough context. */}
             <div className="provider-chip home-ws-chip" title={`Workspace · ${projectName || 'none'}`}>
               <span className="provider-chip-label">{projectName || 'No workspaces yet'}</span>
-              <svg
-                className="provider-chip-caret"
-                width="8" height="8" viewBox="0 0 24 24"
-                fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-              >
-                <polyline points="6 9 12 15 18 9" />
-              </svg>
+              <ChevronDown className="provider-chip-caret" size={8} strokeWidth={2.5} aria-hidden="true" />
               <select
                 className="provider-chip-select"
                 value={project}

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
+import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, ClipboardList, GitFork, Lock, MessageCircle, Undo2, X } from 'lucide-react';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -380,7 +381,7 @@ function TodoItem({ id, todos }: { id?: string; todos: TodoEntry[] }) {
           return (
             <li key={idx} className={`ti-todo-li ti-todo-${t.status}`}>
               <span className="ti-todo-icon">
-                {t.status === 'completed' ? '✓' : t.status === 'in_progress' ? '▪' : '☐'}
+                {t.status === 'completed' ? <Check size={12} aria-hidden="true" /> : t.status === 'in_progress' ? '▪' : '☐'}
               </span>
               <span className="ti-todo-text">{label}</span>
             </li>
@@ -389,7 +390,7 @@ function TodoItem({ id, todos }: { id?: string; todos: TodoEntry[] }) {
       </ul>
       {hiddenCompleted > 0 && (
         <button className="ti-expand" onClick={() => setExpanded((v) => !v)}>
-          {expanded ? '↑ collapse' : `… +${hiddenCompleted} completed`}
+          {expanded ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : `… +${hiddenCompleted} completed`}
         </button>
       )}
     </div>
@@ -416,7 +417,7 @@ function SystemEventItem({ eventType, text }: { eventType: string; text: string 
       <span className="ti-sysevent-label">{label}:</span> {shown}
       {isLong && (
         <button className="ti-expand ti-sysevent-toggle" onClick={() => setOpen((v) => !v)}>
-          {open ? ' ↑ collapse' : ' expand'}
+          {open ? <> <ArrowUp size={12} aria-hidden="true" /> collapse</> : ' expand'}
         </button>
       )}
     </div>
@@ -440,7 +441,7 @@ function UserItem({
   if (!hasNonEmptyText && !hasImage) return null;
   return (
     <div className="ti-user">
-      <span className="ti-chev">❯</span>
+      <span className="ti-chev"><ChevronRight size={14} aria-hidden="true" /></span>
       <div className="ti-user-body">
         {parts.map((p, idx) =>
           p.kind === 'text' ? (
@@ -460,7 +461,7 @@ function UserItem({
           title="Fork a new session from before this message"
           aria-label="Fork"
         >
-          ⑂ fork
+          <GitFork size={13} aria-hidden="true" /> fork
         </button>
       )}
       {onRewind && (
@@ -471,7 +472,7 @@ function UserItem({
           title="Rewind to before this message"
           aria-label="Rewind"
         >
-          ↩ rewind
+          <Undo2 size={13} aria-hidden="true" /> rewind
         </button>
       )}
     </div>
@@ -501,7 +502,7 @@ function LiveAssistantItem({ text, streaming }: { text: string; streaming: boole
 }
 
 function ThinkingItem({ text }: { text: string }) {
-  return <div className="ti-thinking">💭 {text}</div>;
+  return <div className="ti-thinking"><MessageCircle size={14} aria-hidden="true" /> {text}</div>;
 }
 
 // Assistant-side inline image (rare — some models emit vision output).
@@ -559,14 +560,14 @@ function SubagentItem({
   return (
     <div className="ti-tool ti-subagent">
       <button type="button" className="ti-tool-head ti-subagent-head" onClick={toggle}>
-        <span className="ti-dot">🤖</span>
+        <span className="ti-dot"><Bot size={14} aria-hidden="true" /></span>
         <span className="ti-tool-name">{label}</span>
         {it.description && (
           <span className="ti-tool-args" title={it.description}>
             ({it.description})
           </span>
         )}
-        <span className="ti-subagent-toggle">{open ? '▾' : '▸'}</span>
+        <span className="ti-subagent-toggle">{open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
       </button>
       {open && (
         <div className="ti-subagent-body">
@@ -595,7 +596,7 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
   return (
     <div className="ti-tool" data-item-id={id}>
       <div className="ti-tool-head">
-        <span className={`ti-dot${isError ? ' ti-dot-error' : ''}`}>●</span>
+        <span className={`ti-dot${isError ? ' ti-dot-error' : ''}`}><Circle size={8} fill="currentColor" aria-hidden="true" /></span>
         <span className="ti-tool-name">{name}</span>
         {header && (
           <span className="ti-tool-args" title={header}>
@@ -611,7 +612,7 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
             {previewLines.length > 0 && <pre>{previewLines.join('\n')}</pre>}
             {extra > 0 && (
               <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
-                {open ? '↑ collapse' : `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)`}
+                {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)`}
               </button>
             )}
           </div>
@@ -742,7 +743,7 @@ function PermissionItem({
   const remember = it.suggestion?.label;
   return (
     <div className="ti-perm">
-      <span className="ti-perm-icon">🔒</span>
+      <span className="ti-perm-icon"><Lock size={14} aria-hidden="true" /></span>
       <span className="ti-perm-title">
         Run <strong>{it.toolName}</strong>?
       </span>
@@ -808,7 +809,7 @@ function PlanApprovalItem({
   return (
     <div className="ti-plan">
       <div className="ti-plan-head">
-        <span className="ti-plan-icon">📋</span>
+        <span className="ti-plan-icon"><ClipboardList size={14} aria-hidden="true" /></span>
         <span className="ti-plan-title">Ready to code?</span>
         <span className="ti-plan-sub">Here is the plan — choose how to proceed.</span>
       </div>
@@ -926,9 +927,9 @@ function CollapsedGroupItem({
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
       >
-        <span className="ti-collapsed-dot">●</span>
+        <span className="ti-collapsed-dot"><Circle size={8} fill="currentColor" aria-hidden="true" /></span>
         <span className="ti-collapsed-summary">{summary || `${it.ids.length} operations`}</span>
-        <span className="ti-collapsed-caret">{open ? '▾' : '▸'}</span>
+        <span className="ti-collapsed-caret">{open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
       </button>
       {open && (
         <div className="ti-collapsed-body">
@@ -1089,7 +1090,7 @@ function PendingQueue({
               aria-label="Move up"
               disabled={idx === 0}
               onClick={() => onMove(q.id, -1)}
-            >↑</button>
+            ><ArrowUp size={14} aria-hidden="true" /></button>
             <button
               type="button"
               className="icon-btn pending-item-btn"
@@ -1097,14 +1098,14 @@ function PendingQueue({
               aria-label="Move down"
               disabled={idx === queue.length - 1}
               onClick={() => onMove(q.id, 1)}
-            >↓</button>
+            ><ArrowDown size={14} aria-hidden="true" /></button>
             <button
               type="button"
               className="icon-btn pending-item-btn"
               title="Remove"
               aria-label="Remove"
               onClick={() => onRemove(q.id)}
-            >×</button>
+            ><X size={14} aria-hidden="true" /></button>
           </span>
         </div>
       ))}
@@ -2748,7 +2749,9 @@ export function Session(props: SessionProps = {}) {
                   className="img-chip-x"
                   onClick={() => setImages((cur) => cur.filter((c) => c.id !== img.id))}
                   aria-label="Remove image"
-                >×</button>
+                >
+                  <X size={14} aria-hidden="true" />
+                </button>
               </div>
             ))}
           </div>

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
-import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, ClipboardList, GitFork, Lock, MessageCircle, Undo2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -380,8 +380,8 @@ function TodoItem({ id, todos }: { id?: string; todos: TodoEntry[] }) {
             t.status === 'in_progress' && t.activeForm ? t.activeForm : t.content;
           return (
             <li key={idx} className={`ti-todo-li ti-todo-${t.status}`}>
-              <span className="ti-todo-icon">
-                {t.status === 'completed' ? <Check size={12} aria-hidden="true" /> : t.status === 'in_progress' ? '▪' : '☐'}
+              <span className="ti-todo-icon" role="img" aria-label={t.status.replace('_', ' ')}>
+                {t.status === 'completed' ? <Check size={12} aria-hidden="true" /> : t.status === 'in_progress' ? <CircleDot size={12} aria-hidden="true" /> : <Square size={12} aria-hidden="true" />}
               </span>
               <span className="ti-todo-text">{label}</span>
             </li>
@@ -988,11 +988,7 @@ function SessionActionsMenu({
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="5" cy="12" r="1.4" fill="currentColor" />
-          <circle cx="12" cy="12" r="1.4" fill="currentColor" />
-          <circle cx="19" cy="12" r="1.4" fill="currentColor" />
-        </svg>
+        <MoreHorizontal size={16} strokeWidth={2} aria-hidden="true" />
       </button>
       {open && (
         <div className="actions-menu">
@@ -2606,12 +2602,7 @@ export function Session(props: SessionProps = {}) {
               aria-label="Refresh"
               disabled={isNew || sending || polling || handoffPending}
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" />
-                <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" />
-                <polyline points="21 3 21 8 16 8" />
-                <polyline points="3 21 3 16 8 16" />
-              </svg>
+              <RefreshCw size={16} strokeWidth={2} aria-hidden="true" />
             </button>
           </div>
         </div>
@@ -2823,9 +2814,7 @@ export function Session(props: SessionProps = {}) {
             aria-label="Attach image"
             onClick={() => fileInputRef.current?.click()}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-            </svg>
+            <Paperclip size={16} strokeWidth={2} aria-hidden="true" />
           </button>
           <SessionActionsMenu
             disabled={isNew || sending}
@@ -2844,13 +2833,7 @@ export function Session(props: SessionProps = {}) {
               aria-pressed={isolate}
               onClick={() => setIsolate((v) => !v)}
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="6" cy="6" r="3" />
-                <circle cx="6" cy="18" r="3" />
-                <circle cx="18" cy="9" r="3" />
-                <path d="M6 9v6" />
-                <path d="M18 12a6 6 0 0 1-6 6H9" />
-              </svg>
+              <GitBranch size={16} strokeWidth={2} aria-hidden="true" />
             </button>
           )}
           <div className="session-input-spacer" />
@@ -2873,10 +2856,7 @@ export function Session(props: SessionProps = {}) {
                     title="Queue — sends after the current turn finishes"
                     aria-label="Queue message"
                   >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M12 5v14" />
-                      <path d="M5 12h14" />
-                    </svg>
+                    <Plus size={14} strokeWidth={2.4} aria-hidden="true" />
                   </button>
                 </>
               )}
@@ -2888,9 +2868,7 @@ export function Session(props: SessionProps = {}) {
                 title="Stop generation"
                 aria-label="Stop"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                  <rect x="6" y="6" width="12" height="12" rx="1.5" />
-                </svg>
+                <Square size={12} fill="currentColor" strokeWidth={0} aria-hidden="true" />
               </button>
             </>
           ) : (
@@ -2900,10 +2878,7 @@ export function Session(props: SessionProps = {}) {
               disabled={!input.trim() && images.length === 0}
               aria-label="Send"
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 19V5" />
-                <path d="m5 12 7-7 7 7" />
-              </svg>
+              <ArrowUp size={14} strokeWidth={2.4} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
-import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -413,7 +413,7 @@ function SystemEventItem({ eventType, text }: { eventType: string; text: string 
   const shown = open || !isLong ? text : text.slice(0, 200) + '…';
   return (
     <div className="ti-sysevent">
-      <span className="ti-sysevent-mark">※</span>
+      <span className="ti-sysevent-mark"><Info size={12} aria-hidden="true" /></span>
       <span className="ti-sysevent-label">{label}:</span> {shown}
       {isLong && (
         <button className="ti-expand ti-sysevent-toggle" onClick={() => setOpen((v) => !v)}>

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { api, type PublicSettings, type PublicCustomProvider, type ProviderInput, type TunnelProvider, type TunnelState, type ConfigFileMeta, type DefaultPermissionMode } from '../lib/api';
@@ -363,13 +364,7 @@ export function Settings() {
                       picker, so the two controls read as siblings. */}
                   <div className={`provider-chip${busy ? ' disabled' : ''}`} title={`Default · ${active.label}`}>
                     <span className="provider-chip-label">{active.label}</span>
-                    <svg
-                      className="provider-chip-caret"
-                      width="8" height="8" viewBox="0 0 24 24"
-                      fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                    >
-                      <polyline points="6 9 12 15 18 9" />
-                    </svg>
+                    <ChevronDown className="provider-chip-caret" size={8} strokeWidth={2.5} aria-hidden="true" />
                     <select
                       className="provider-chip-select"
                       value={settings.defaultPermissionMode}

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -14,6 +14,7 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Copy, RefreshCw, Trash2, X } from 'lucide-react';
 import { api, basename, type SessionListItem, type Workspace as Wk } from '../lib/api';
 import {
   useCanvas,
@@ -502,10 +503,7 @@ function SortableTile({
           title="Copy claude --resume command"
           aria-label="Copy resume command"
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-          </svg>
+          <Copy size={13} strokeWidth={2} aria-hidden="true" />
         </button>
         )}
         {!isDraft && !isTerminal && !isFile && (
@@ -521,12 +519,7 @@ function SortableTile({
           aria-label="Refresh"
           disabled={isRunning}
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" />
-            <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" />
-            <polyline points="21 3 21 8 16 8" />
-            <polyline points="3 21 3 16 8 16" />
-          </svg>
+          <RefreshCw size={13} strokeWidth={2} aria-hidden="true" />
         </button>
         )}
         {onDelete && (
@@ -552,13 +545,7 @@ function SortableTile({
             title="Delete session (removes jsonl on disk)"
             aria-label="Delete session"
           >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="3 6 5 6 21 6" />
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-              <path d="M10 11v6" />
-              <path d="M14 11v6" />
-              <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
-            </svg>
+            <Trash2 size={13} strokeWidth={2} aria-hidden="true" />
           </button>
         )}
         <button
@@ -571,7 +558,7 @@ function SortableTile({
           title="Remove from canvas (does not delete the session)"
           aria-label="Remove from canvas"
         >
-          ×
+          <X size={13} aria-hidden="true" />
         </button>
       </div>
       <div className="ws-tile-body">


### PR DESCRIPTION
Migrates the first-party Claude + Codex WebUI (`web/`) from hand-written Unicode glyphs, emoji, and inline `<svg>` markup to [`lucide-react`](https://lucide.dev) components, per [MAC-8750](https://multica.macaron.xin/issues/f63cdaba-d5bd-4b8d-baa4-30820a614479 "将 macaron artifacts 图标全部替换为 Lucide 图标").

## Scope

Replaced functional/semantic iconography across:

- **Chrome & nav** — mobile nav toggle (`☰`), sidebar search / expand carets / pin toggles, context-menu items (copy path, rename, duplicate, share/unshare, merge/discard worktree, delete).
- **Canvas tiles** — Claude (`Workspace.tsx`) copy/refresh/trash inline SVGs + remove `×`; Codex reuses the pattern already landed in #137.
- **Panels** — files (`FilesPanel`/`FileExplorer`/`DirPicker`), git (close, ahead/behind), diff cards, status bar, notify stack.
- **Command palette** kind glyphs, **Session** transcript (chevrons, fork/rewind, thinking/agent/permission/plan markers, collapse toggles, pending-queue up/down/remove), **Examples** cards (9 emoji → Lucide), **Home** composer.
- **Codex** — `CodexChat` tool/reasoning/genui/plan/approval headers + branch, `CodexComposer` attach/stop/send, `CodexSidebar` toggles/settings.

## Explicitly excluded (per requirement)

Brand logos, charts / dataviz SVGs, generated GenUI content, `web/src/macaron-vendor/**` canonical widgets, and non-icon text (keyboard `<kbd>` symbols, diff `＋－△`, progress bars, password dots, ellipses).

## Notes

- `lucide-react` was already a dependency; icon style follows the existing convention (`size` + `strokeWidth` + `aria-hidden`).
- A few `.css` tweaks add `inline-flex` alignment where a button now mixes an icon with a text label (`Try →`, fork/rewind, back link, ahead/behind, collapse toggles).
- Minimal diff: wrappers and `className`s preserved; only the glyph child swapped.

## Verification

- `pnpm build` ✅ and `pnpm test` (10/10) ✅
- No new `tsc` errors on any changed file (pre-existing baseline errors are unrelated implicit-any / unbuilt `@macaron/shared`).
- Visually verified via production `preview` in Chromium (light + dark): icons render, layout intact.