### PR TITLE
fix(web): vertically center inline icons

### DIFF
--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -259,7 +259,7 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
 }
 
 function PlanCard({ it }: { it: Extract<Item, { kind: 'plan' }> }) {
-  const glyph = (s: CodexPlanStatus): ReactNode => (s === 'completed' ? <CheckSquare size={14} aria-hidden="true" /> : s === 'inProgress' ? <CircleDot size={14} aria-hidden="true" /> : <Square size={14} aria-hidden="true" />);
+  const glyph = (s: CodexPlanStatus): ReactNode => (s === 'completed' ? <CheckSquare size={13} aria-hidden="true" /> : s === 'inProgress' ? <CircleDot size={13} aria-hidden="true" /> : <Square size={13} aria-hidden="true" />);
   const statusLabel = (s: CodexPlanStatus): string => (s === 'completed' ? 'completed' : s === 'inProgress' ? 'in progress' : 'pending');
   return (
     <div className="cx-plan">

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1488,6 +1488,7 @@ body {
   color: var(--cx-text);
 }
 .cx-plan-step-glyph { font-family: ui-monospace, Menlo, monospace; }
+.cx-plan-step-glyph > svg { display: block; }
 .cx-plan-step.completed { color: var(--cx-muted); text-decoration: line-through; }
 .cx-plan-step.inProgress { font-weight: 600; }
 .cx-plan-step.inProgress .cx-plan-step-glyph { color: var(--cx-code-strong); }

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1488,7 +1488,11 @@ body {
   color: var(--cx-text);
 }
 .cx-plan-step-glyph { font-family: ui-monospace, Menlo, monospace; }
-.cx-plan-step-glyph > svg { display: block; }
+.cx-plan-step-glyph > svg {
+  display: block;
+  position: relative;
+  top: 1px;
+}
 .cx-plan-step.completed { color: var(--cx-muted); text-decoration: line-through; }
 .cx-plan-step.inProgress { font-weight: 600; }
 .cx-plan-step.inProgress .cx-plan-step-glyph { color: var(--cx-code-strong); }

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1491,6 +1491,8 @@ body {
 .cx-plan-step-glyph > svg {
   display: block;
 }
+.cx-plan-step.completed .cx-plan-step-glyph,
+.cx-plan-step.inProgress .cx-plan-step-glyph { position: relative; top: -1px; }
 .cx-plan-step.completed { color: var(--cx-muted); text-decoration: line-through; }
 .cx-plan-step.inProgress { font-weight: 600; }
 .cx-plan-step.inProgress .cx-plan-step-glyph { color: var(--cx-code-strong); }

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1482,7 +1482,7 @@ body {
 .cx-plan-steps { padding: 6px 0; }
 .cx-plan-step {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   padding: 4px 12px;
   color: var(--cx-text);

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -1490,8 +1490,6 @@ body {
 .cx-plan-step-glyph { font-family: ui-monospace, Menlo, monospace; }
 .cx-plan-step-glyph > svg {
   display: block;
-  position: relative;
-  top: 1px;
 }
 .cx-plan-step.completed { color: var(--cx-muted); text-decoration: line-through; }
 .cx-plan-step.inProgress { font-weight: 600; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4941,6 +4941,7 @@ textarea:focus, select:focus, input:focus {
 .ti-collapsed-head:hover { color: var(--text); }
 .ti-collapsed-head.err { color: var(--bad, #c5392f); }
 .ti-collapsed-dot { color: var(--good, #4d8f5b); font-size: 11px; flex-shrink: 0; }
+.ti-collapsed-head:not(.err) > .ti-collapsed-dot > svg { position: relative; top: -1px; }
 .ti-collapsed-head.err .ti-collapsed-dot { color: var(--bad, #c5392f); }
 .ti-collapsed-summary { font-weight: 500; }
 .ti-collapsed-hint {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -739,6 +739,9 @@ textarea:focus, select:focus, input:focus {
   padding-left: 10px;
   white-space: pre-wrap;
 }
+/* Fractional transforms intentionally change SVG raster parity; relative
+   positioning leaves a 0.5px visible-ink center mismatch. */
+.ti-thinking > svg { transform: translateY(0.5px); }
 
 /* tool call entry — original inline ● + └ layout */
 .ti-tool {
@@ -754,6 +757,7 @@ textarea:focus, select:focus, input:focus {
   flex-wrap: wrap;
   word-break: break-word;
 }
+.ti-tool-head:not(.ti-subagent-head) > .ti-dot > svg { position: relative; top: -1px; }
 .ti-dot {
   color: var(--good);
   flex-shrink: 0;
@@ -851,6 +855,7 @@ textarea:focus, select:focus, input:focus {
   border-bottom: 1px solid var(--border);
   background: var(--surface-2);
 }
+.ti-diff-head > .ti-dot > svg { position: relative; top: -1px; }
 .ti-diff-path {
   color: var(--text-2);
   word-break: break-all;
@@ -946,6 +951,9 @@ textarea:focus, select:focus, input:focus {
 .ti-todo-in_progress .ti-todo-text { color: var(--text); font-weight: 500; }
 .ti-todo-pending .ti-todo-icon { color: var(--muted-2); }
 .ti-todo-pending .ti-todo-text { color: var(--text-2); }
+.ti-todo-in_progress .ti-todo-icon > svg { transform: translateY(1.5px); }
+.ti-todo-pending .ti-todo-icon > svg { transform: translateY(0.5px); }
+.ti-todo-completed .ti-todo-icon > svg { position: relative; top: 2px; }
 
 /* ---------- system event (※ recap / resume) ---------- */
 .ti-sysevent {
@@ -964,6 +972,7 @@ textarea:focus, select:focus, input:focus {
   font-style: normal;
   margin-right: 6px;
 }
+.ti-sysevent-mark > svg { position: relative; top: 1px; }
 .ti-sysevent-label {
   color: var(--text-2);
   font-weight: 600;
@@ -2463,6 +2472,7 @@ textarea:focus, select:focus, input:focus {
   flex-wrap: wrap;
 }
 .ti-plan-icon { flex-shrink: 0; }
+.ti-plan-icon > svg { transform: translateY(-0.5px); }
 .ti-plan-title { color: var(--text); font-weight: 600; }
 .ti-plan-sub { color: var(--text-2); font-size: 12.5px; }
 .ti-plan-body {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -739,9 +739,7 @@ textarea:focus, select:focus, input:focus {
   padding-left: 10px;
   white-space: pre-wrap;
 }
-/* Fractional transforms intentionally change SVG raster parity; relative
-   positioning leaves a 0.5px visible-ink center mismatch. */
-.ti-thinking > svg { transform: translateY(0.5px); }
+.ti-thinking > svg { transform: translateY(-0.5px); }
 
 /* tool call entry — original inline ● + └ layout */
 .ti-tool {
@@ -757,7 +755,6 @@ textarea:focus, select:focus, input:focus {
   flex-wrap: wrap;
   word-break: break-word;
 }
-.ti-tool-head:not(.ti-subagent-head) > .ti-dot > svg { position: relative; top: -1px; }
 .ti-dot {
   color: var(--good);
   flex-shrink: 0;
@@ -951,9 +948,6 @@ textarea:focus, select:focus, input:focus {
 .ti-todo-in_progress .ti-todo-text { color: var(--text); font-weight: 500; }
 .ti-todo-pending .ti-todo-icon { color: var(--muted-2); }
 .ti-todo-pending .ti-todo-text { color: var(--text-2); }
-.ti-todo-in_progress .ti-todo-icon > svg { transform: translateY(1.5px); }
-.ti-todo-pending .ti-todo-icon > svg { transform: translateY(0.5px); }
-.ti-todo-completed .ti-todo-icon > svg { position: relative; top: 2px; }
 
 /* ---------- system event (※ recap / resume) ---------- */
 .ti-sysevent {
@@ -972,7 +966,6 @@ textarea:focus, select:focus, input:focus {
   font-style: normal;
   margin-right: 6px;
 }
-.ti-sysevent-mark > svg { position: relative; top: 1px; }
 .ti-sysevent-label {
   color: var(--text-2);
   font-weight: 600;
@@ -2472,7 +2465,7 @@ textarea:focus, select:focus, input:focus {
   flex-wrap: wrap;
 }
 .ti-plan-icon { flex-shrink: 0; }
-.ti-plan-icon > svg { transform: translateY(-0.5px); }
+.ti-plan-icon > svg { position: relative; top: -1px; }
 .ti-plan-title { color: var(--text); font-weight: 600; }
 .ti-plan-sub { color: var(--text-2); font-size: 12.5px; }
 .ti-plan-body {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -727,6 +727,9 @@ textarea:focus, select:focus, input:focus {
 
 /* thinking */
 .ti-thinking {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   color: var(--muted);
   font-style: italic;
   font-size: 12.5px;
@@ -747,7 +750,7 @@ textarea:focus, select:focus, input:focus {
 .ti-tool-head {
   display: flex;
   gap: 6px;
-  align-items: baseline;
+  align-items: center;
   flex-wrap: wrap;
   word-break: break-word;
 }
@@ -841,7 +844,7 @@ textarea:focus, select:focus, input:focus {
 }
 .ti-diff-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 6px;
   padding: 6px 10px;
   font-size: 12.5px;
@@ -922,7 +925,7 @@ textarea:focus, select:focus, input:focus {
 }
 .ti-todo-li {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   font-size: 13px;
   line-height: 1.5;
@@ -955,6 +958,8 @@ textarea:focus, select:focus, input:focus {
   padding: 4px 2px;
 }
 .ti-sysevent-mark {
+  display: inline-flex;
+  vertical-align: middle;
   color: var(--muted-2);
   font-style: normal;
   margin-right: 6px;
@@ -2453,7 +2458,7 @@ textarea:focus, select:focus, input:focus {
 }
 .ti-plan-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
 }
@@ -4918,7 +4923,7 @@ textarea:focus, select:focus, input:focus {
 .ti-collapsed { margin: 4px 0 6px; }
 .ti-collapsed-head {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   width: 100%;
   padding: 4px 0;

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -381,7 +381,7 @@ function TodoItem({ id, todos }: { id?: string; todos: TodoEntry[] }) {
           return (
             <li key={idx} className={`ti-todo-li ti-todo-${t.status}`}>
               <span className="ti-todo-icon" role="img" aria-label={t.status.replace('_', ' ')}>
-                {t.status === 'completed' ? <Check size={12} aria-hidden="true" /> : t.status === 'in_progress' ? <CircleDot size={12} aria-hidden="true" /> : <Square size={12} aria-hidden="true" />}
+                {t.status === 'completed' ? <Check size={11} aria-hidden="true" /> : t.status === 'in_progress' ? <CircleDot size={11} aria-hidden="true" /> : <Square size={11} aria-hidden="true" />}
               </span>
               <span className="ti-todo-text">{label}</span>
             </li>
@@ -413,7 +413,7 @@ function SystemEventItem({ eventType, text }: { eventType: string; text: string 
   const shown = open || !isLong ? text : text.slice(0, 200) + '…';
   return (
     <div className="ti-sysevent">
-      <span className="ti-sysevent-mark"><Info size={12} aria-hidden="true" /></span>
+      <span className="ti-sysevent-mark"><Info size={13} aria-hidden="true" /></span>
       <span className="ti-sysevent-label">{label}:</span> {shown}
       {isLong && (
         <button className="ti-expand ti-sysevent-toggle" onClick={() => setOpen((v) => !v)}>
@@ -502,7 +502,7 @@ function LiveAssistantItem({ text, streaming }: { text: string; streaming: boole
 }
 
 function ThinkingItem({ text }: { text: string }) {
-  return <div className="ti-thinking"><MessageCircle size={14} aria-hidden="true" /> {text}</div>;
+  return <div className="ti-thinking"><MessageCircle size={12} aria-hidden="true" /> {text}</div>;
 }
 
 // Assistant-side inline image (rare — some models emit vision output).
@@ -596,7 +596,7 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
   return (
     <div className="ti-tool" data-item-id={id}>
       <div className="ti-tool-head">
-        <span className={`ti-dot${isError ? ' ti-dot-error' : ''}`}><Circle size={8} fill="currentColor" aria-hidden="true" /></span>
+        <span className={`ti-dot${isError ? ' ti-dot-error' : ''}`}><Circle size={9} fill="currentColor" strokeWidth={0} aria-hidden="true" /></span>
         <span className="ti-tool-name">{name}</span>
         {header && (
           <span className="ti-tool-args" title={header}>
@@ -809,7 +809,7 @@ function PlanApprovalItem({
   return (
     <div className="ti-plan">
       <div className="ti-plan-head">
-        <span className="ti-plan-icon"><ClipboardList size={14} aria-hidden="true" /></span>
+        <span className="ti-plan-icon"><ClipboardList size={13} aria-hidden="true" /></span>
         <span className="ti-plan-title">Ready to code?</span>
         <span className="ti-plan-sub">Here is the plan — choose how to proceed.</span>
       </div>
@@ -927,9 +927,9 @@ function CollapsedGroupItem({
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
       >
-        <span className="ti-collapsed-dot"><Circle size={8} fill="currentColor" aria-hidden="true" /></span>
+        <span className="ti-collapsed-dot"><Circle size={9} fill="currentColor" strokeWidth={0} aria-hidden="true" /></span>
         <span className="ti-collapsed-summary">{summary || `${it.ids.length} operations`}</span>
-        <span className="ti-collapsed-caret">{open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
+        <span className="ti-collapsed-caret">{open ? <ChevronDown size={12} aria-hidden="true" /> : <ChevronRight size={12} aria-hidden="true" />}</span>
       </button>
       {open && (
         <div className="ti-collapsed-body">


### PR DESCRIPTION
Follow-up to #156. Vertically centers Lucide icons that share a row with text in the Claude transcript and Codex plan UI, per [MAC-8750](https://multica.macaron.xin/issues/f63cdaba-d5bd-4b8d-baa4-30820a614479 "将 macaron artifacts 图标全部替换为 Lucide 图标").

## Changes

- Center icon/text flex rows for tool and diff headers, todo items, plan headers, collapsed groups, and Codex plan steps.
- Give the Claude thinking row an explicit centered flex layout.
- Vertically center the inline system-event icon without changing the surrounding text flow.

## Verification

- `pnpm --filter @macaron/web test` (40/40)
- `pnpm build:web`
- `git diff --check`
