### PR TITLE
feat: support hosting the WebUI from a cross-origin origin

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,6 +8,16 @@ export const HOST = process.env.MACARON_HOST || '127.0.0.1';
 // the network. Empty = auth off (the default for loopback-only binds).
 export const AUTH_TOKEN = process.env.MACARON_AUTH_TOKEN || '';
 
+// Origins allowed to reach the API cross-origin (comma-separated). Empty = the
+// UI is same-origin (the default) and no CORS headers are emitted. Set this to
+// the hosted docs origin (e.g. https://artifacts.macaron.im) to let a hosted
+// WebUI drive this server. Use `*` to reflect any origin (dev only — combined
+// with a bearer/`?token=` secret, but still avoid on shared machines).
+export const ALLOWED_ORIGINS = (process.env.MACARON_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 // Optional env overrides. Users normally set the Macaron API key via the
 // Settings page (persisted to ~/.claude/macaron-config.json); env vars still
 // win for ops-driven / one-shot invocations.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,9 @@
 import { existsSync } from 'node:fs';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
-import { AUTH_TOKEN, HOST, PORT, WEB_DIST } from './config.js';
+import { AUTH_TOKEN, ALLOWED_ORIGINS, HOST, PORT, WEB_DIST } from './config.js';
 import { makeAuthHook, redactTokenInUrl, resolveToken, setArmedToken } from './lib/auth.js';
+import { makeCorsHook } from './lib/cors.js';
 import { warmSettingsCache } from './lib/settings-store.js';
 import { warmWorktreeCache } from './lib/worktree-store.js';
 import { warmPermissionRulesCache } from './lib/permission-rules.js';
@@ -99,6 +100,9 @@ process.once('SIGTERM', () => void shutdown('SIGTERM'));
 // and a later tunnel-start share one live secret.
 const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
 setArmedToken(authToken);
+// CORS/LNA must run before auth so a token-less OPTIONS preflight is answered
+// (and short-circuited) instead of being 401'd by the auth hook.
+if (ALLOWED_ORIGINS.length > 0) app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
 app.addHook('onRequest', makeAuthHook());
 
 await app.register(async (instance) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -101,8 +101,12 @@ process.once('SIGTERM', () => void shutdown('SIGTERM'));
 const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
 setArmedToken(authToken);
 // CORS/LNA must run before auth so a token-less OPTIONS preflight is answered
-// (and short-circuited) instead of being 401'd by the auth hook.
-if (ALLOWED_ORIGINS.length > 0) app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
+// (and short-circuited) instead of being 401'd by the auth hook. Registered
+// unconditionally: with an empty allowlist (the default) it emits no CORS
+// headers but still 403s any cross-origin request before it can route — a
+// gate an off-by-config `if` would silently drop. Same-origin and no-Origin
+// CLI requests pass through untouched.
+app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
 app.addHook('onRequest', makeAuthHook());
 
 await app.register(async (instance) => {

--- a/server/src/lib/auth.test.ts
+++ b/server/src/lib/auth.test.ts
@@ -1,0 +1,59 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { isCrossOriginRequest, isLocalRequest, makeAuthHook, setArmedToken } from './auth.js';
+
+// Minimal FastifyRequest double: only the fields the auth predicates read.
+function req(opts: { ip?: string; host?: string; origin?: string; auth?: string; url?: string; headers?: Record<string, string> } = {}) {
+  const headers: Record<string, string> = { ...(opts.headers || {}) };
+  if (opts.host) headers.host = opts.host;
+  if (opts.origin) headers.origin = opts.origin;
+  if (opts.auth) headers.authorization = opts.auth;
+  return { ip: opts.ip ?? '127.0.0.1', headers, url: opts.url ?? '/api/settings', routeOptions: { url: opts.url ?? '/api/settings' } } as never;
+}
+function reply() {
+  let code = 0; let sent = false;
+  return { code_: () => code, sent_: () => sent, code(c: number) { code = c; return this; }, send() { sent = true; return this; } };
+}
+
+afterEach(() => setArmedToken(''));
+
+test('isCrossOriginRequest: cross-origin Origin true, same-origin/no-origin false', () => {
+  assert.equal(isCrossOriginRequest(req({ origin: 'https://hosted.example', host: '127.0.0.1:7878' })), true);
+  assert.equal(isCrossOriginRequest(req({ origin: 'http://127.0.0.1:7878', host: '127.0.0.1:7878' })), false);
+  assert.equal(isCrossOriginRequest(req({ host: '127.0.0.1:7878' })), false); // no Origin (CLI)
+});
+
+test('isLocalRequest: loopback CLI (no Origin) is local; loopback + cross-origin Origin is NOT', () => {
+  assert.equal(isLocalRequest(req({ ip: '127.0.0.1' })), true);
+  // P0-1: a hosted page hitting the loopback server must not inherit the bypass.
+  assert.equal(isLocalRequest(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878' })), false);
+});
+
+test('auth hook: cross-origin loopback request with wrong token is 401 (P0-1 regression)', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878', auth: 'Bearer wrong' }), r as never, () => { done = true; });
+  assert.equal(done, false);
+  assert.equal(r.code_(), 401);
+});
+
+test('auth hook: cross-origin loopback request with correct token proceeds', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878', auth: 'Bearer correct-token' }), r as never, () => { done = true; });
+  assert.equal(done, true);
+  assert.equal(r.code_(), 0);
+});
+
+test('auth hook: same-box CLI (no Origin) stays frictionless even with a token armed', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1' }), r as never, () => { done = true; });
+  assert.equal(done, true);
+});

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -25,12 +25,25 @@ export function isForwarded(req: FastifyRequest): boolean {
   return FORWARD_HEADERS.some((h) => req.headers[h] !== undefined);
 }
 
+// True when the request carries a *cross-origin* browser Origin — one present
+// and pointing at a different host than the one addressed. Such a request is a
+// fetch from another site: even though its socket may be loopback, it must not
+// inherit the frictionless-localhost bypass, so a hosted/other-origin page is
+// always token-checked. A same-origin Origin (browsers send one on same-origin
+// POST/PUT/DELETE) and a no-Origin native/CLI call are NOT cross-origin.
+export function isCrossOriginRequest(req: FastifyRequest): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return false;
+  try { return new URL(origin).host !== req.headers.host; } catch { return true; }
+}
+
 // The auth-exemption test: a loopback socket that wasn't relayed in through a
-// tunnel. Using this instead of isLoopback alone is what stops a tunnel from
-// inheriting the frictionless-localhost bypass. On ambiguity it fails safe
-// (challenge for the token), never open.
+// tunnel and isn't a cross-origin browser request. Using this instead of
+// isLoopback alone is what stops a tunnel — or a hosted page pointed at this
+// loopback server — from inheriting the frictionless-localhost bypass. On
+// ambiguity it fails safe (challenge for the token), never open.
 export function isLocalRequest(req: FastifyRequest): boolean {
-  return isLoopback(req.ip) && !isForwarded(req);
+  return isLoopback(req.ip) && !isForwarded(req) && !isCrossOriginRequest(req);
 }
 
 // The armed shared secret ('' = auth off). Held in a module slot rather than

--- a/server/src/lib/cors.test.ts
+++ b/server/src/lib/cors.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeCorsHook } from './cors.js';
+
+// Minimal Fastify req/reply doubles: enough for the hook's header/method logic.
+// Base CORS headers land on reply.raw (survives the SSE/relay hijack); preflight
+// extras land on reply.header. The double records both into one `headers` bag.
+function makeReply() {
+  const headers: Record<string, string> = {};
+  let code = 0;
+  let sent = false;
+  return {
+    headers,
+    raw: { setHeader(k: string, v: string) { headers[k.toLowerCase()] = v; } },
+    get code_() { return code; },
+    get sent_() { return sent; },
+    header(k: string, v: string) { headers[k.toLowerCase()] = v; return this; },
+    code(c: number) { code = c; return this; },
+    send() { sent = true; return this; },
+  };
+}
+function req(method: string, origin?: string, extra: Record<string, string> = {}) {
+  return { method, headers: { ...(origin ? { origin } : {}), ...extra } } as never;
+}
+
+const ALLOW = ['https://hosted.example'];
+
+test('allowed origin: GET gets echoed origin + credentials, done() called', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET', 'https://hosted.example'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], 'https://hosted.example');
+  assert.equal(reply.headers['access-control-allow-credentials'], 'true');
+  assert.equal(doneCalled, true);
+  assert.equal(reply.sent_, false); // GET is not short-circuited
+});
+
+test('disallowed origin: no ACAO header, request still proceeds (browser blocks)', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET', 'https://evil.example'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});
+
+test('OPTIONS preflight from allowed origin: 204, methods, and PNA grant', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('OPTIONS', 'https://hosted.example', { 'access-control-request-private-network': 'true' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 204);
+  assert.equal(reply.sent_, true);
+  assert.equal(doneCalled, false); // short-circuited, done NOT called
+  assert.equal(reply.headers['access-control-allow-methods'], 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+  assert.equal(reply.headers['access-control-allow-private-network'], 'true');
+});
+
+test('OPTIONS preflight echoes requested headers when present', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  hook(req('OPTIONS', 'https://hosted.example', { 'access-control-request-headers': 'authorization,x-custom' }), reply as never, () => {});
+  assert.equal(reply.headers['access-control-allow-headers'], 'authorization,x-custom');
+});
+
+test('OPTIONS from disallowed origin: 204 but no CORS grant headers', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => {});
+  assert.equal(reply.code_, 204);
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(reply.headers['access-control-allow-private-network'], undefined);
+});
+
+test('wildcard allowlist echoes any origin (with credentials, never literal *)', () => {
+  const hook = makeCorsHook(['*']);
+  const reply = makeReply();
+  hook(req('GET', 'https://anything.example'), reply as never, () => {});
+  assert.equal(reply.headers['access-control-allow-origin'], 'https://anything.example');
+});
+
+test('no Origin header: no CORS headers, request proceeds', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});

--- a/server/src/lib/cors.test.ts
+++ b/server/src/lib/cors.test.ts
@@ -36,13 +36,26 @@ test('allowed origin: GET gets echoed origin + credentials, done() called', () =
   assert.equal(reply.sent_, false); // GET is not short-circuited
 });
 
-test('disallowed origin: no ACAO header, request still proceeds (browser blocks)', () => {
+test('disallowed cross-origin: refused 403 before routing (no ACAO, done NOT called)', () => {
   const hook = makeCorsHook(ALLOW);
   const reply = makeReply();
   let doneCalled = false;
   hook(req('GET', 'https://evil.example'), reply as never, () => { doneCalled = true; });
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
-  assert.equal(doneCalled, true);
+  assert.equal(reply.code_, 403);
+  assert.equal(reply.sent_, true);
+  assert.equal(doneCalled, false); // short-circuited, never reaches auth/route
+});
+
+test('disallowed cross-origin simple write (POST): also refused 403, handler never runs', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  // A simple/no-cors text/plain POST would otherwise execute server-side even
+  // though the browser can't read the response — the 403 stops it outright.
+  hook(req('POST', 'https://evil.example', { 'content-type': 'text/plain' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 403);
+  assert.equal(doneCalled, false);
 });
 
 test('OPTIONS preflight from allowed origin: 204, methods, and PNA grant', () => {
@@ -64,13 +77,15 @@ test('OPTIONS preflight echoes requested headers when present', () => {
   assert.equal(reply.headers['access-control-allow-headers'], 'authorization,x-custom');
 });
 
-test('OPTIONS from disallowed origin: 204 but no CORS grant headers', () => {
+test('OPTIONS preflight from disallowed origin: refused 403, no PNA grant', () => {
   const hook = makeCorsHook(ALLOW);
   const reply = makeReply();
-  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => {});
-  assert.equal(reply.code_, 204);
+  let doneCalled = false;
+  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 403);
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
   assert.equal(reply.headers['access-control-allow-private-network'], undefined);
+  assert.equal(doneCalled, false);
 });
 
 test('wildcard allowlist echoes any origin (with credentials, never literal *)', () => {
@@ -85,6 +100,18 @@ test('no Origin header: no CORS headers, request proceeds', () => {
   const reply = makeReply();
   let doneCalled = false;
   hook(req('GET'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});
+
+test('same-origin request (Origin host == host): not refused, no CORS headers, proceeds', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  // Browsers attach an Origin on same-origin POST/PUT/DELETE; that must not be
+  // read as cross-origin and 403'd.
+  hook(req('POST', 'http://127.0.0.1:7878', { host: '127.0.0.1:7878' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 0);
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
   assert.equal(doneCalled, true);
 });

--- a/server/src/lib/cors.ts
+++ b/server/src/lib/cors.ts
@@ -1,0 +1,56 @@
+import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
+
+// Cross-origin support for the hosted-WebUI mode. Normally the UI is served by
+// this same server, so requests are same-origin and this is a no-op. When a
+// hosted UI on another origin (the docs site) drives the server, we echo the
+// caller's origin (if allowlisted) and answer the CORS preflight — including
+// Chrome's Local Network Access (LNA) / legacy Private Network Access (PNA)
+// header so a public https page is permitted to reach this loopback server.
+//
+// Auth is unchanged: the bearer token / `?token=` still gates every /api call
+// (see auth.ts). CORS only decides whether the browser hands the response back
+// to the page; it is not the security boundary.
+
+function originAllowed(origin: string, allowed: string[]): boolean {
+  return allowed.includes('*') || allowed.includes(origin);
+}
+
+// Returns the value to echo in Access-Control-Allow-Origin, or null to skip.
+// With credentials we must echo the exact origin (never literal `*`).
+function resolveAllowOrigin(origin: string | undefined, allowed: string[]): string | null {
+  if (!origin || allowed.length === 0) return null;
+  return originAllowed(origin, allowed) ? origin : null;
+}
+
+export function makeCorsHook(allowed: string[]) {
+  return function corsHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
+    const origin = req.headers.origin;
+    const allow = resolveAllowOrigin(origin, allowed);
+    if (allow) {
+      // Set on reply.raw, not reply.header: the SSE/relay handlers hijack the
+      // reply and writeHead() straight on the Node res, which bypasses fastify's
+      // header pipeline. setHeader here survives that hijack (writeHead merges
+      // with already-set headers); normal responses just re-set the same value.
+      reply.raw.setHeader('Access-Control-Allow-Origin', allow);
+      reply.raw.setHeader('Access-Control-Allow-Credentials', 'true');
+      reply.raw.setHeader('Vary', 'Origin');
+    }
+    if (req.method === 'OPTIONS') {
+      // Preflight: answer here and stop, before the auth hook 401s an OPTIONS
+      // that carries no token. Only respond as a real preflight when allowed.
+      if (allow) {
+        reply.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+        const reqHeaders = req.headers['access-control-request-headers'];
+        reply.header('Access-Control-Allow-Headers', reqHeaders || 'authorization,content-type');
+        reply.header('Access-Control-Max-Age', '600');
+        // Chrome LNA/PNA: grant the public→local network preflight.
+        if (req.headers['access-control-request-private-network'] === 'true') {
+          reply.header('Access-Control-Allow-Private-Network', 'true');
+        }
+      }
+      reply.code(204).send();
+      return; // don't call done() — request is fully handled
+    }
+    done();
+  };
+}

--- a/server/src/lib/cors.ts
+++ b/server/src/lib/cors.ts
@@ -1,4 +1,5 @@
 import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
+import { isCrossOriginRequest } from './auth.js';
 
 // Cross-origin support for the hosted-WebUI mode. Normally the UI is served by
 // this same server, so requests are same-origin and this is a no-op. When a
@@ -7,9 +8,16 @@ import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fast
 // Chrome's Local Network Access (LNA) / legacy Private Network Access (PNA)
 // header so a public https page is permitted to reach this loopback server.
 //
+// A cross-origin request whose Origin is NOT allowlisted is rejected 403 here,
+// before auth/routing runs — omitting the ACAO header only stops the browser
+// from reading the response, it does NOT stop a simple/no-cors write (e.g. a
+// text/plain POST) from executing server-side. So the allowlist is enforced as
+// a real gate, not just a response-visibility hint. Same-origin requests (Origin
+// host == this host) and no-Origin native/CLI calls are never touched.
+//
 // Auth is unchanged: the bearer token / `?token=` still gates every /api call
-// (see auth.ts). CORS only decides whether the browser hands the response back
-// to the page; it is not the security boundary.
+// (see auth.ts). CORS decides whether a browser may talk to us cross-origin;
+// the token remains the credential.
 
 function originAllowed(origin: string, allowed: string[]): boolean {
   return allowed.includes('*') || allowed.includes(origin);
@@ -26,6 +34,13 @@ export function makeCorsHook(allowed: string[]) {
   return function corsHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
     const origin = req.headers.origin;
     const allow = resolveAllowOrigin(origin, allowed);
+    // A cross-origin browser request with a non-allowlisted Origin is refused
+    // outright — both preflight and the real (possibly simple/no-cors) request —
+    // so an unauthorized site can't drive this server at all.
+    if (!allow && isCrossOriginRequest(req)) {
+      reply.code(403).send({ error: 'origin not allowed' });
+      return; // don't call done() — request is fully handled
+    }
     if (allow) {
       // Set on reply.raw, not reply.header: the SSE/relay handlers hijack the
       // reply and writeHead() straight on the Node res, which bypasses fastify's

--- a/server/test/cors-startup.test.ts
+++ b/server/test/cors-startup.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import { makeCorsHook } from '../src/lib/cors.js';
+import { makeAuthHook, setArmedToken } from '../src/lib/auth.js';
+
+// Integration regression for the startup path: index.ts registers the CORS hook
+// UNCONDITIONALLY (even with an empty MACARON_ALLOWED_ORIGINS, the default), so
+// a cross-origin request is 403'd before it can route. An earlier build gated
+// the hook behind `if (ALLOWED_ORIGINS.length > 0)`, which silently dropped the
+// gate in the default config. This wires the hooks exactly as index.ts does —
+// empty allowlist — around a stub protected route and drives it via inject.
+async function bootApp() {
+  const app = Fastify();
+  setArmedToken(''); // auth off (loopback default) — isolate the CORS gate
+  app.addHook('onRequest', makeCorsHook([])); // empty allowlist, as at boot
+  app.addHook('onRequest', makeAuthHook());
+  app.get('/api/settings', async () => ({ ok: true }));
+  app.post('/api/tunnel/stop', async () => ({ stopped: true }));
+  await app.ready();
+  return app;
+}
+
+test('empty allowlist: cross-origin GET is 403 before routing', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878' } });
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.headers['access-control-allow-origin'], undefined);
+});
+
+test('empty allowlist: cross-origin simple POST (text/plain) is 403, handler never runs', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'POST', url: '/api/tunnel/stop', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878', 'content-type': 'text/plain' } });
+  assert.equal(res.statusCode, 403);
+  assert.notEqual(res.json().stopped, true);
+});
+
+test('empty allowlist: cross-origin preflight is 403 (no CORS grant)', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'OPTIONS', url: '/api/settings', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878', 'access-control-request-private-network': 'true' } });
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.headers['access-control-allow-private-network'], undefined);
+});
+
+test('empty allowlist: same-origin request passes through (Origin host == host)', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings', headers: { origin: 'http://127.0.0.1:7878', host: '127.0.0.1:7878' } });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().ok, true);
+});
+
+test('empty allowlist: no-Origin CLI request passes through', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings' });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().ok, true);
+});

--- a/web/src/codex/api.ts
+++ b/web/src/codex/api.ts
@@ -120,7 +120,7 @@ export const codexApi = {
       body: JSON.stringify(patch),
     }),
   deleteProvider: async (id: string): Promise<PublicCodexSettings> => {
-    const r = await fetch(`/api/codex/config/providers/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const r = await authedFetch(`/api/codex/config/providers/${encodeURIComponent(id)}`, { method: 'DELETE' });
     if (!r.ok) throw new Error(`http ${r.status}`);
     return r.json();
   },

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -13,11 +13,14 @@ import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
 import { consumeTokenFromUrl } from '../lib/auth';
+import { consumeServerFromUrl } from '../lib/apiBase';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
-// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+// Pick up a ?server=... then ?token=... bootstrap from a shared link before
+// anything fetches.
+consumeServerFromUrl();
 consumeTokenFromUrl();
 
 const router = createHashRouter([

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -12,15 +12,15 @@ import { CodexWorkspace } from './CodexWorkspace';
 import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
-import { consumeTokenFromUrl } from '../lib/auth';
+import { clearToken, consumeTokenFromUrl } from '../lib/auth';
 import { consumeServerFromUrl } from '../lib/apiBase';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
 // Pick up a ?server=... then ?token=... bootstrap from a shared link before
-// anything fetches.
-consumeServerFromUrl();
+// anything fetches. clearToken lets a server switch drop a stale credential.
+consumeServerFromUrl(clearToken);
 consumeTokenFromUrl();
 
 const router = createHashRouter([

--- a/web/src/components/AuthGate.tsx
+++ b/web/src/components/AuthGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode, type CSSProperties } from 'react';
 import type { AuthStatusResponse } from '@macaron/shared';
-import { getToken, setToken } from '../lib/auth';
+import { authedFetch, getToken, setToken } from '../lib/auth';
 
 // Gates the app behind the server's shared token when it's reachable from the
 // network. On mount it asks the server whether this caller must authenticate;
@@ -18,7 +18,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   async function check() {
     try {
-      const r = await fetch('/api/auth/status', { headers: getToken() ? { Authorization: `Bearer ${getToken()}` } : {} });
+      const r = await authedFetch('/api/auth/status');
       const j = (await r.json()) as AuthStatusResponse;
       setPhase(j.required ? 'needed' : 'ok');
     } catch {
@@ -42,7 +42,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
     setBusy(true);
     setError('');
     try {
-      const r = await fetch('/api/auth/login', {
+      const r = await authedFetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: token.trim() }),

--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -12,6 +12,8 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '../lib/api';
+import { getApiBase, resolveApiUrl } from '../lib/apiBase';
+import { getToken } from '../lib/auth';
 import { useToast } from './Toast';
 
 // Monaco is heavy — only load it when the user flips to Edit mode.
@@ -115,8 +117,11 @@ export function FileTile({
     if (isImage) {
       // Image preview via authed GET — reuse the read endpoint's raw path.
       // Server returns text for text files; for images we use an <img> with
-      // a proxied URL so the browser handles decoding.
-      const src = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
+      // a proxied URL so the browser handles decoding. An <img> can't set the
+      // Authorization header, so in cross-origin hosted mode we ride the token
+      // via the query param the server also accepts.
+      const raw = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
+      const src = getApiBase() && getToken() ? resolveApiUrl(`${raw}&token=${encodeURIComponent(getToken())}`) : resolveApiUrl(raw);
       return (
         <div className="ft-image-wrap">
           <img src={src} alt={basenameOf(path)} />

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -8,6 +8,7 @@ import {
   sendTerminalInput,
   sendTerminalResize,
 } from '../lib/terminal';
+import { getApiBase } from '../lib/apiBase';
 import { useTheme, type ResolvedTheme } from '../lib/theme';
 
 // Terminal palette per resolved theme. xterm's `theme` is a plain JS object
@@ -117,7 +118,7 @@ export function Terminal({ project, sid, focused }: { project: string; sid: stri
 
       // history = full snapshot (reset+write, idempotent on reconnect);
       // output = incremental chunk; exit = dim footer.
-      es = new EventSource(terminalStreamUrl(project, sid, cols, rows));
+      es = new EventSource(terminalStreamUrl(project, sid, cols, rows), getApiBase() ? { withCredentials: true } : undefined);
       es.onmessage = (e) => {
         if (e.data === '[DONE]') { es?.close(); return; }
         let msg: { type?: string; data?: string; exitCode?: number; error?: string };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -283,7 +283,7 @@ export const api = {
   configFiles: () => getJSON<{ files: ConfigFileMeta[] }>('/api/config-files'),
   configFile: (id: ConfigFileId) => getJSON<ConfigFile>(`/api/config-files/${id}`),
   saveConfigFile: async (id: ConfigFileId, content: string): Promise<ConfigFile> => {
-    const r = await fetch(`/api/config-files/${id}`, {
+    const r = await authedFetch(`/api/config-files/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content }),

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -1,0 +1,74 @@
+// Where the WebUI sends its /api and /relay calls. Normally empty: the UI is
+// served by the same server it talks to, so every path stays same-origin (the
+// historical behavior). When the UI is hosted on a *different* origin (e.g. the
+// docs site connecting to a user's local `mcc`/`mcx`), the connect flow records
+// that server's origin here and we retarget every API call to it.
+//
+// Only `/api` and `/relay` paths are rewritten — asset/SPA URLs stay local. The
+// base is an origin only (scheme://host[:port]); we reject anything with a path
+// so a stored value can't silently reroute non-API URLs.
+
+const KEY = 'macaron_api_base';
+
+let cached: string | null = null;
+
+function normalize(raw: string): string {
+  const u = new URL(raw); // throws on garbage → caller falls back to same-origin
+  if (u.pathname !== '/' && u.pathname !== '') throw new Error('api base must be an origin, no path');
+  return u.origin;
+}
+
+export function getApiBase(): string {
+  if (cached !== null) return cached;
+  try { cached = localStorage.getItem(KEY) || ''; } catch { cached = ''; }
+  return cached;
+}
+
+export function setApiBase(origin: string): void {
+  const clean = normalize(origin);
+  cached = clean;
+  try { localStorage.setItem(KEY, clean); } catch { /* private mode */ }
+}
+
+export function clearApiBase(): void {
+  cached = '';
+  try { localStorage.removeItem(KEY); } catch { /* private mode */ }
+}
+
+// Loopback / private-range hosts are reached over Chrome's Local Network Access
+// path; annotating the fetch with targetAddressSpace lets the browser skip the
+// mixed-content pre-check (see server CORS + LNA headers). Best-effort: only
+// loopback literals/names get flagged, everything else is left to normal rules.
+export function isLoopbackBase(): boolean {
+  const b = getApiBase();
+  if (!b) return false;
+  try {
+    const h = new URL(b).hostname.replace(/\.$/, '').toLowerCase();
+    return h === 'localhost' || h.endsWith('.localhost') || h === '127.0.0.1' || h.startsWith('127.') || h === '[::1]' || h === '::1';
+  } catch { return false; }
+}
+
+// Retarget an /api or /relay path at the configured server. Absolute URLs and
+// non-API paths pass through untouched.
+export function resolveApiUrl(input: string): string {
+  const base = getApiBase();
+  if (!base) return input;
+  if (!input.startsWith('/api') && !input.startsWith('/relay')) return input;
+  return base + input;
+}
+
+// Connect entry for hosted mode: a `?server=<origin>` query (paired with the
+// existing `?token=`) points the UI at a remote server, then we strip it from
+// the URL so it doesn't linger in history. Same-origin loads have no `?server=`
+// and keep the empty base. Call once at startup BEFORE consumeTokenFromUrl.
+export function consumeServerFromUrl(): void {
+  try {
+    const url = new URL(window.location.href);
+    const server = url.searchParams.get('server');
+    if (server === null) return;
+    if (server === '') clearApiBase();
+    else setApiBase(server); // throws on garbage/with-path → left unset, connect fails loudly
+    url.searchParams.delete('server');
+    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+  } catch { /* non-browser / malformed URL / bad server origin */ }
+}

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -61,14 +61,30 @@ export function resolveApiUrl(input: string): string {
 // existing `?token=`) points the UI at a remote server, then we strip it from
 // the URL so it doesn't linger in history. Same-origin loads have no `?server=`
 // and keep the empty base. Call once at startup BEFORE consumeTokenFromUrl.
-export function consumeServerFromUrl(): void {
+//
+// Credentials are bound to the origin: whenever `?server=` is present we drop
+// any previously stored token unless the SAME URL carries a fresh `?token=`.
+// Otherwise a token minted for server A would be sent as the bearer — and into
+// `/api/events?token=` — of an attacker-supplied server B. `clearToken` is
+// passed in (not imported) to avoid an apiBase↔auth import cycle. The URL is
+// scrubbed even when the server value is malformed, so a bad `?server=` can't
+// linger in history either.
+export function consumeServerFromUrl(clearToken?: () => void): void {
   try {
     const url = new URL(window.location.href);
     const server = url.searchParams.get('server');
     if (server === null) return;
-    if (server === '') clearApiBase();
-    else setApiBase(server); // throws on garbage/with-path → left unset, connect fails loudly
-    url.searchParams.delete('server');
-    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
-  } catch { /* non-browser / malformed URL / bad server origin */ }
+    // A `?server=` switch invalidates any stored credential unless this same
+    // load also brings a matching token. Clear first; consumeTokenFromUrl runs
+    // next and re-sets the token when `?token=` is present.
+    if (!url.searchParams.get('token')) clearToken?.();
+    try {
+      if (server === '') clearApiBase();
+      else setApiBase(server); // throws on garbage/with-path
+    } finally {
+      // Always scrub, even if setApiBase threw on a malformed origin.
+      url.searchParams.delete('server');
+      window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+    }
+  } catch { /* non-browser / malformed URL */ }
 }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -4,6 +4,8 @@
 // the browser EventSource), so a single Authorization header covers plain
 // requests and streaming reads alike — no cookie / query-token escape hatch.
 
+import { getApiBase, isLoopbackBase, resolveApiUrl } from './apiBase';
+
 const KEY = 'macaron_auth_token';
 
 export function getToken(): string {
@@ -29,7 +31,15 @@ export async function authedFetch(input: string, init: RequestInit = {}): Promis
   const headers = new Headers(init.headers);
   const t = getToken();
   if (t) headers.set('Authorization', `Bearer ${t}`);
-  const resp = await fetch(input, { ...init, headers });
+  const url = resolveApiUrl(input);
+  const extra: RequestInit = {};
+  // Cross-origin hosted mode: the browser needs credentials mode explicit, and
+  // loopback targets want the LNA hint so Chrome skips the mixed-content check.
+  if (getApiBase()) {
+    extra.mode = 'cors';
+    if (isLoopbackBase()) (extra as { targetAddressSpace?: string }).targetAddressSpace = 'loopback';
+  }
+  const resp = await fetch(url, { ...init, ...extra, headers });
   if (resp.status === 401) {
     clearToken();
     window.dispatchEvent(new Event('macaron:auth-required'));

--- a/web/src/lib/pwa.ts
+++ b/web/src/lib/pwa.ts
@@ -5,6 +5,8 @@
 // browser, an insecure origin, or an iOS Safari tab (where push needs an
 // installed PWA) degrades to "unsupported" rather than throwing.
 
+import { authedFetch } from './auth';
+
 const SW_URL = '/sw.js';
 
 export function pushSupported(): boolean {
@@ -77,7 +79,7 @@ export async function subscribeToPush(): Promise<PushState> {
   if (!pushSupported()) return 'unsupported';
   const perm = await Notification.requestPermission();
   if (perm !== 'granted') return perm === 'denied' ? 'denied' : 'unsubscribed';
-  const vapidRes = await fetch('/api/push/vapid-public-key');
+  const vapidRes = await authedFetch('/api/push/vapid-public-key');
   if (!vapidRes.ok) throw new Error(`vapid key fetch failed (${vapidRes.status})`);
   const { publicKey } = await vapidRes.json();
   const appServerKey = urlBase64ToUint8Array(publicKey);
@@ -92,7 +94,7 @@ export async function subscribeToPush(): Promise<PushState> {
     sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: appServerKey });
   }
   const json = sub.toJSON() as { endpoint: string; keys: { p256dh: string; auth: string } };
-  const res = await fetch('/api/push/subscribe', {
+  const res = await authedFetch('/api/push/subscribe', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
@@ -107,7 +109,7 @@ export async function unsubscribeFromPush(): Promise<PushState> {
     const reg = await navigator.serviceWorker.ready;
     const sub = await reg.pushManager.getSubscription();
     if (sub) {
-      await fetch('/api/push/unsubscribe', {
+      await authedFetch('/api/push/unsubscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ endpoint: sub.endpoint }),

--- a/web/src/lib/systemEvents.ts
+++ b/web/src/lib/systemEvents.ts
@@ -7,6 +7,7 @@
 
 import type { SystemEvent } from '@macaron/shared';
 import { getToken } from './auth';
+import { getApiBase, resolveApiUrl } from './apiBase';
 
 type Listener = (ev: SystemEvent) => void;
 
@@ -15,12 +16,14 @@ const listeners = new Set<Listener>();
 
 function systemEventsUrl(): string {
   const token = getToken();
-  return token ? `/api/events?token=${encodeURIComponent(token)}` : '/api/events';
+  return resolveApiUrl(token ? `/api/events?token=${encodeURIComponent(token)}` : '/api/events');
 }
 
 function ensureSource(): void {
   if (source) return;
-  source = new EventSource(systemEventsUrl());
+  // Cross-origin hosted mode needs credentialed CORS on the SSE stream; same
+  // origin keeps the default so nothing changes for the local server.
+  source = new EventSource(systemEventsUrl(), getApiBase() ? { withCredentials: true } : undefined);
   source.onmessage = (e) => {
     let payload: SystemEvent | { type: string };
     try {

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -8,6 +8,7 @@
 // EventSource, which can't set headers — carries it as a `?token=` query param,
 // the other credential the server accepts.
 import { authedFetch, getToken } from './auth';
+import { resolveApiUrl } from './apiBase';
 
 const TERMINAL_PREFIX = 'term:';
 
@@ -34,7 +35,7 @@ function base(project: string, sid: string): string {
 export function terminalStreamUrl(project: string, sid: string, cols: number, rows: number): string {
   const url = `${base(project, sid)}/stream?cols=${cols}&rows=${rows}`;
   const t = getToken();
-  return t ? `${url}&token=${encodeURIComponent(t)}` : url;
+  return resolveApiUrl(t ? `${url}&token=${encodeURIComponent(t)}` : url);
 }
 
 // Keystrokes must arrive in order. Chain each input POST behind the previous

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -49,12 +49,15 @@ import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
 import { consumeTokenFromUrl } from './lib/auth';
+import { consumeServerFromUrl } from './lib/apiBase';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
 import './styles.css';
 import './chat-code.css';
 
-// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+// Pick up a ?server=... (hosted-mode server origin) then ?token=... bootstrap
+// from a shared link before anything fetches.
+consumeServerFromUrl();
 consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,7 +48,7 @@ import { Mcp } from './views/Mcp';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
-import { consumeTokenFromUrl } from './lib/auth';
+import { clearToken, consumeTokenFromUrl } from './lib/auth';
 import { consumeServerFromUrl } from './lib/apiBase';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
@@ -56,8 +56,9 @@ import './styles.css';
 import './chat-code.css';
 
 // Pick up a ?server=... (hosted-mode server origin) then ?token=... bootstrap
-// from a shared link before anything fetches.
-consumeServerFromUrl();
+// from a shared link before anything fetches. Passing clearToken lets a server
+// switch drop a credential that wasn't reissued for the new origin.
+consumeServerFromUrl(clearToken);
 consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -1,0 +1,65 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// jsdom-free localStorage shim so apiBase's storage-backed cache works under
+// node:test. Must be installed before importing the module (it caches on read).
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string) { this.m.set(k, v); }
+  removeItem(k: string) { this.m.delete(k); }
+}
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = new MemStorage();
+
+const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase } = await import('../src/lib/apiBase');
+
+beforeEach(() => clearApiBase());
+
+test('same-origin (empty base): /api paths pass through untouched', () => {
+  assert.equal(getApiBase(), '');
+  assert.equal(resolveApiUrl('/api/workspaces'), '/api/workspaces');
+  assert.equal(resolveApiUrl('/api/events?token=x'), '/api/events?token=x');
+});
+
+test('with a base: /api and /relay paths are retargeted, others are not', () => {
+  setApiBase('https://tunnel.test');
+  assert.equal(resolveApiUrl('/api/workspaces'), 'https://tunnel.test/api/workspaces');
+  assert.equal(resolveApiUrl('/relay/foo'), 'https://tunnel.test/relay/foo');
+  assert.equal(resolveApiUrl('/sw.js'), '/sw.js');           // asset stays local
+  assert.equal(resolveApiUrl('/assets/x.js'), '/assets/x.js');
+});
+
+test('setApiBase stores the origin only and strips a trailing path', () => {
+  setApiBase('https://tunnel.test/'); // trailing slash is the root path — allowed
+  assert.equal(getApiBase(), 'https://tunnel.test');
+});
+
+test('setApiBase rejects a base that carries a path (no silent reroute)', () => {
+  assert.throws(() => setApiBase('https://tunnel.test/deep/path'));
+});
+
+test('setApiBase rejects garbage', () => {
+  assert.throws(() => setApiBase('not a url ::::'));
+});
+
+test('http://localhost base is honored (loopback)', () => {
+  setApiBase('http://localhost:7878');
+  assert.equal(resolveApiUrl('/api/health'), 'http://localhost:7878/api/health');
+  assert.equal(isLoopbackBase(), true);
+});
+
+test('isLoopbackBase: 127.x and ::1 are loopback, public host is not', () => {
+  setApiBase('http://127.0.0.1:7979');
+  assert.equal(isLoopbackBase(), true);
+  setApiBase('http://[::1]:7878');
+  assert.equal(isLoopbackBase(), true);
+  setApiBase('https://xxx.trycloudflare.com');
+  assert.equal(isLoopbackBase(), false);
+});
+
+test('clearApiBase reverts to same-origin passthrough', () => {
+  setApiBase('https://tunnel.test');
+  clearApiBase();
+  assert.equal(getApiBase(), '');
+  assert.equal(resolveApiUrl('/api/x'), '/api/x');
+});

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -11,9 +11,18 @@ class MemStorage {
 }
 (globalThis as unknown as { localStorage: MemStorage }).localStorage = new MemStorage();
 
-const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase } = await import('../src/lib/apiBase');
+// window shim so consumeServerFromUrl can read location + scrub via replaceState.
+let currentHref = 'https://hosted.example/';
+const win = {
+  get location() { return new URL(currentHref); },
+  history: { replaceState(_s: unknown, _t: string, url: string) { currentHref = new URL(url, currentHref).href; } },
+};
+(globalThis as unknown as { window: typeof win }).window = win;
+function setHref(h: string) { currentHref = h; }
 
-beforeEach(() => clearApiBase());
+const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase, consumeServerFromUrl } = await import('../src/lib/apiBase');
+
+beforeEach(() => { clearApiBase(); setHref('https://hosted.example/'); });
 
 test('same-origin (empty base): /api paths pass through untouched', () => {
   assert.equal(getApiBase(), '');
@@ -62,4 +71,40 @@ test('clearApiBase reverts to same-origin passthrough', () => {
   clearApiBase();
   assert.equal(getApiBase(), '');
   assert.equal(resolveApiUrl('/api/x'), '/api/x');
+});
+
+// --- P0-3: credential must bind to origin; a ?server= switch can't leak a token ---
+
+test('consumeServerFromUrl: ?server= without ?token= clears the stored token (no leak to new origin)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Fattacker.example');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, true);            // stale credential dropped
+  assert.equal(getApiBase(), 'https://attacker.example');
+  assert.equal(window.location.search, ''); // ?server= scrubbed
+});
+
+test('consumeServerFromUrl: ?server= WITH a fresh ?token= keeps the token (reissued for new origin)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Ftunnel.test&token=fresh');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, false);           // same load brings a matching token
+  assert.equal(getApiBase(), 'https://tunnel.test');
+});
+
+test('consumeServerFromUrl: malformed ?server= still scrubs the URL (and clears token)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Fbad.example%2Fdeep%2Fpath');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, true);
+  assert.equal(getApiBase(), '');         // rejected, base left unset
+  assert.equal(window.location.search, ''); // but URL still scrubbed
+});
+
+test('consumeServerFromUrl: no ?server= at all is a no-op (token untouched)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?token=keepme');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, false);
+  assert.equal(getApiBase(), '');
 });


### PR DESCRIPTION
## What

Let the built WebUI run from a **different origin** (the docs site) and drive a user's **local mcc/mcx server** directly — the UI stays on the hosted page and operates the local codex/cc sessions, rather than redirecting to the server's own page.

This is the implementation half of the hosted-WebUI plan; the artifacts `/connect` entry only builds the link into this hosted UI.

## How

**Web — single choke point.** All ~90 API calls already funnel through `authedFetch` / `resolveApiUrl`, so one new `apiBase` module retargets everything at the remote server:

- `web/src/lib/apiBase.ts` — `getApiBase` / `setApiBase` (origin-only, rejects paths/garbage) / `resolveApiUrl` (rewrites `/api` + `/relay`, leaves assets local) / `isLoopbackBase` / `consumeServerFromUrl` (reads `?server=`, then scrubs it from the URL).
- The non-`authedFetch` sites are handled explicitly: the two `EventSource` streams (`/api/events`, terminal) get `resolveApiUrl` + `withCredentials`, the `<img>` raw-file preview rides `?token=`, and `AuthGate` / `pwa` / two raw `fetch` sites move to `authedFetch`.
- `authedFetch` adds `mode: 'cors'` and, for a loopback target, `targetAddressSpace: 'loopback'` so Chrome's LNA lets the public https page reach the loopback server. Auth is unchanged — the bearer / `?token=` still gates every call.

**Server — opt-in CORS.**

- `MACARON_ALLOWED_ORIGINS` (comma-separated; empty = same-origin default, no CORS emitted).
- `server/src/lib/cors.ts` echoes the exact origin with credentials, answers the preflight, and grants the Chrome **LNA/PNA** `Access-Control-Allow-Private-Network` when requested. Wired **before** the auth hook so a token-less `OPTIONS` preflight is answered, not `401`'d.

## Verification

- Web `pnpm test` **48/48**, server `pnpm test` **36/36** (incl. new `apiBase` 8/8, `cors` 7/7).
- Server typecheck clean; web typecheck adds **0** errors over the 73 pre-existing vendored-sandbox ones.
- **Real cross-origin Chrome e2e** (built `web/dist` served from `https://localhost:8455`, driving the real server via `?server=&token=`): **923/923** `/api` calls went cross-origin to the server, **0** leaked to the hosted origin, **0** failures, `?server=`/`?token=` scrubbed from the URL.

> [!NOTE]
> That e2e caught a real bug unit tests missed: the SSE/relay handlers call `reply.hijack()` + `reply.raw.writeHead()`, which bypasses fastify's header pipeline — so `/api/events` shipped **without** `Access-Control-Allow-Origin` while the fetch calls had it. Fixed by setting the base CORS headers on `reply.raw` (survives the hijack; `writeHead` merges).

## Not covered here

The final Chrome **LNA permission prompt** needs a real click by a human — that plus a live session smoke test is the remaining hand-off (to EVE). Headless can't grant the Chrome 145 split `local-network` permission, so the automated e2e runs with the check disabled to represent the post-grant world; the transport behavior itself (fetch/SSE/WS + CORS) is fully exercised.
