### PR TITLE
feat: host the WebUI in the docs site instead of redirecting

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,6 +8,16 @@ export const HOST = process.env.MACARON_HOST || '127.0.0.1';
 // the network. Empty = auth off (the default for loopback-only binds).
 export const AUTH_TOKEN = process.env.MACARON_AUTH_TOKEN || '';
 
+// Origins allowed to reach the API cross-origin (comma-separated). Empty = the
+// UI is same-origin (the default) and no CORS headers are emitted. Set this to
+// the hosted docs origin (e.g. https://artifacts.macaron.im) to let a hosted
+// WebUI drive this server. Use `*` to reflect any origin (dev only — combined
+// with a bearer/`?token=` secret, but still avoid on shared machines).
+export const ALLOWED_ORIGINS = (process.env.MACARON_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 // Optional env overrides. Users normally set the Macaron API key via the
 // Settings page (persisted to ~/.claude/macaron-config.json); env vars still
 // win for ops-driven / one-shot invocations.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -98,7 +98,7 @@ process.once('SIGTERM', () => void shutdown('SIGTERM'));
 // the network. resolveToken auto-generates one when bound to a non-loopback
 // host with no token set; seed it into the module-level armed slot so the hook
 // and a later tunnel-start share one live secret.
-const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
+const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN, ALLOWED_ORIGINS.length > 0);
 setArmedToken(authToken);
 // CORS/LNA must run before auth so a token-less OPTIONS preflight is answered
 // (and short-circuited) instead of being 401'd by the auth hook. Registered
@@ -183,7 +183,7 @@ try {
   await app.listen({ host: HOST, port: PORT });
   app.log.info(`macaron server listening on http://${HOST}:${PORT}`);
   if (authGenerated) {
-    app.log.warn(`bound to non-loopback host ${HOST} with no MACARON_AUTH_TOKEN — generated one for this run.`);
+    app.log.warn(`API reachable beyond a local peer (non-loopback bind or cross-origin enabled) with no MACARON_AUTH_TOKEN — generated one for this run.`);
     // The token is a live credential — keep it out of the structured log (which may be
     // shipped off-box) and print the connection string straight to stdout so the operator
     // can still grab it from their own terminal on first launch.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,9 @@
 import { existsSync } from 'node:fs';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
-import { AUTH_TOKEN, HOST, PORT, WEB_DIST } from './config.js';
+import { AUTH_TOKEN, ALLOWED_ORIGINS, HOST, PORT, WEB_DIST } from './config.js';
 import { makeAuthHook, redactTokenInUrl, resolveToken, setArmedToken } from './lib/auth.js';
+import { makeCorsHook } from './lib/cors.js';
 import { warmSettingsCache } from './lib/settings-store.js';
 import { warmWorktreeCache } from './lib/worktree-store.js';
 import { warmPermissionRulesCache } from './lib/permission-rules.js';
@@ -99,6 +100,9 @@ process.once('SIGTERM', () => void shutdown('SIGTERM'));
 // and a later tunnel-start share one live secret.
 const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
 setArmedToken(authToken);
+// CORS/LNA must run before auth so a token-less OPTIONS preflight is answered
+// (and short-circuited) instead of being 401'd by the auth hook.
+if (ALLOWED_ORIGINS.length > 0) app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
 app.addHook('onRequest', makeAuthHook());
 
 await app.register(async (instance) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -185,9 +185,10 @@ try {
   if (authGenerated) {
     app.log.warn(`API reachable beyond a local peer (non-loopback bind or cross-origin enabled) with no MACARON_AUTH_TOKEN — generated one for this run.`);
     // The token is a live credential — keep it out of the structured log (which may be
-    // shipped off-box) and print the connection string straight to stdout so the operator
-    // can still grab it from their own terminal on first launch.
-    console.log(`connect from another device with: http://${HOST}:${PORT}/?token=${authToken}`);
+    // shipped off-box) and out of any URL (URLs leak via history/referrer/proxy logs).
+    // Print the address and the token on separate lines straight to stdout so the operator
+    // can grab them from their own terminal and paste the token into the UI's login screen.
+    console.log(`connect another device to: http://${HOST}:${PORT}/  ·  access token: ${authToken}`);
   } else if (authToken) {
     app.log.info('server auth enabled (MACARON_AUTH_TOKEN) — remote requests require the token.');
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -101,8 +101,12 @@ process.once('SIGTERM', () => void shutdown('SIGTERM'));
 const { token: authToken, generated: authGenerated } = resolveToken(HOST, AUTH_TOKEN);
 setArmedToken(authToken);
 // CORS/LNA must run before auth so a token-less OPTIONS preflight is answered
-// (and short-circuited) instead of being 401'd by the auth hook.
-if (ALLOWED_ORIGINS.length > 0) app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
+// (and short-circuited) instead of being 401'd by the auth hook. Registered
+// unconditionally: with an empty allowlist (the default) it emits no CORS
+// headers but still 403s any cross-origin request before it can route — a
+// gate an off-by-config `if` would silently drop. Same-origin and no-Origin
+// CLI requests pass through untouched.
+app.addHook('onRequest', makeCorsHook(ALLOWED_ORIGINS));
 app.addHook('onRequest', makeAuthHook());
 
 await app.register(async (instance) => {

--- a/server/src/lib/auth.test.ts
+++ b/server/src/lib/auth.test.ts
@@ -1,11 +1,11 @@
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { isCrossOriginRequest, isLocalRequest, makeAuthHook, setArmedToken } from './auth.js';
+import { isCrossOriginRequest, isLocalRequest, makeAuthHook, redactTokenInUrl, setArmedToken } from './auth.js';
 
 // Minimal FastifyRequest double: only the fields the auth predicates read.
 function req(opts: { ip?: string; host?: string; origin?: string; auth?: string; url?: string; headers?: Record<string, string> } = {}) {
   const headers: Record<string, string> = { ...(opts.headers || {}) };
-  if (opts.host) headers.host = opts.host;
+  headers.host = opts.host ?? '127.0.0.1:7878'; // real clients always send a Host
   if (opts.origin) headers.origin = opts.origin;
   if (opts.auth) headers.authorization = opts.auth;
   return { ip: opts.ip ?? '127.0.0.1', headers, url: opts.url ?? '/api/settings', routeOptions: { url: opts.url ?? '/api/settings' } } as never;
@@ -16,6 +16,17 @@ function reply() {
 }
 
 afterEach(() => setArmedToken(''));
+
+// P1: Fastify percent-decodes the query before authenticating, so a request with
+// `?%74oken=<secret>` authenticates AND must be scrubbed from the pino req.url log.
+// The old literal /token=/ regex missed the encoded key, leaking the full secret.
+test('redactTokenInUrl: scrubs literal and percent-encoded token keys', () => {
+  assert.equal(redactTokenInUrl('/api/x?token=SECRET'), '/api/x?token=[redacted]');
+  assert.equal(redactTokenInUrl('/api/x?a=1&token=SECRET&b=2'), '/api/x?a=1&token=[redacted]&b=2');
+  assert.equal(redactTokenInUrl('/api/x?%74oken=SECRET'), '/api/x?%74oken=[redacted]');
+  assert.equal(redactTokenInUrl('/api/events?TOKEN=SECRET'), '/api/events?TOKEN=[redacted]');
+  assert.equal(redactTokenInUrl('/api/x?other=keep'), '/api/x?other=keep');
+});
 
 test('isCrossOriginRequest: cross-origin Origin true, same-origin/no-origin false', () => {
   assert.equal(isCrossOriginRequest(req({ origin: 'https://hosted.example', host: '127.0.0.1:7878' })), true);
@@ -56,4 +67,18 @@ test('auth hook: same-box CLI (no Origin) stays frictionless even with a token a
   let done = false;
   hook(req({ ip: '127.0.0.1' }), r as never, () => { done = true; });
   assert.equal(done, true);
+});
+
+// P0: a Host-spoofing / DNS-rebinding page served from 127.0.0.1 sends a
+// NON-loopback (attacker-chosen) Host that matches its own Origin, so the old
+// `Origin.host === req.host` same-origin check let it through with no token.
+// A non-loopback Host must never inherit the frictionless-localhost bypass.
+test('auth hook: loopback socket with a spoofed non-loopback Host is 401 (Host-spoofing regression)', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1', origin: 'http://attacker.localhost:7878', host: 'attacker.localhost:7878' }), r as never, () => { done = true; });
+  assert.equal(done, false);
+  assert.equal(r.code_(), 401);
 });

--- a/server/src/lib/auth.test.ts
+++ b/server/src/lib/auth.test.ts
@@ -1,0 +1,59 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { isCrossOriginRequest, isLocalRequest, makeAuthHook, setArmedToken } from './auth.js';
+
+// Minimal FastifyRequest double: only the fields the auth predicates read.
+function req(opts: { ip?: string; host?: string; origin?: string; auth?: string; url?: string; headers?: Record<string, string> } = {}) {
+  const headers: Record<string, string> = { ...(opts.headers || {}) };
+  if (opts.host) headers.host = opts.host;
+  if (opts.origin) headers.origin = opts.origin;
+  if (opts.auth) headers.authorization = opts.auth;
+  return { ip: opts.ip ?? '127.0.0.1', headers, url: opts.url ?? '/api/settings', routeOptions: { url: opts.url ?? '/api/settings' } } as never;
+}
+function reply() {
+  let code = 0; let sent = false;
+  return { code_: () => code, sent_: () => sent, code(c: number) { code = c; return this; }, send() { sent = true; return this; } };
+}
+
+afterEach(() => setArmedToken(''));
+
+test('isCrossOriginRequest: cross-origin Origin true, same-origin/no-origin false', () => {
+  assert.equal(isCrossOriginRequest(req({ origin: 'https://hosted.example', host: '127.0.0.1:7878' })), true);
+  assert.equal(isCrossOriginRequest(req({ origin: 'http://127.0.0.1:7878', host: '127.0.0.1:7878' })), false);
+  assert.equal(isCrossOriginRequest(req({ host: '127.0.0.1:7878' })), false); // no Origin (CLI)
+});
+
+test('isLocalRequest: loopback CLI (no Origin) is local; loopback + cross-origin Origin is NOT', () => {
+  assert.equal(isLocalRequest(req({ ip: '127.0.0.1' })), true);
+  // P0-1: a hosted page hitting the loopback server must not inherit the bypass.
+  assert.equal(isLocalRequest(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878' })), false);
+});
+
+test('auth hook: cross-origin loopback request with wrong token is 401 (P0-1 regression)', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878', auth: 'Bearer wrong' }), r as never, () => { done = true; });
+  assert.equal(done, false);
+  assert.equal(r.code_(), 401);
+});
+
+test('auth hook: cross-origin loopback request with correct token proceeds', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1', origin: 'https://hosted.example', host: '127.0.0.1:7878', auth: 'Bearer correct-token' }), r as never, () => { done = true; });
+  assert.equal(done, true);
+  assert.equal(r.code_(), 0);
+});
+
+test('auth hook: same-box CLI (no Origin) stays frictionless even with a token armed', () => {
+  setArmedToken('correct-token');
+  const hook = makeAuthHook();
+  const r = reply();
+  let done = false;
+  hook(req({ ip: '127.0.0.1' }), r as never, () => { done = true; });
+  assert.equal(done, true);
+});

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -68,11 +68,16 @@ export function tokensMatch(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
-// The configured token wins. When the server is bound to a non-loopback host
-// but no token was set, generate one so an exposed server is never wide open.
-export function resolveToken(host: string, configured: string): { token: string; generated: boolean } {
+// The configured token wins. Otherwise auto-generate one so the API is never
+// left wide open when it's actually reachable by something other than a genuine
+// local peer: a non-loopback bind (exposed to the network) OR cross-origin mode
+// enabled (a hosted WebUI on another origin will drive this loopback server, and
+// isLocalRequest already denies those the frictionless-localhost bypass — so
+// without a token they'd hit a fully unauthenticated API). Loopback-only with no
+// cross-origin stays auth-off (the frictionless local default).
+export function resolveToken(host: string, configured: string, crossOriginEnabled = false): { token: string; generated: boolean } {
   if (configured) return { token: configured, generated: false };
-  if (!isLoopbackHost(host)) return { token: randomBytes(24).toString('base64url'), generated: true };
+  if (!isLoopbackHost(host) || crossOriginEnabled) return { token: randomBytes(24).toString('base64url'), generated: true };
   return { token: '', generated: false };
 }
 

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -25,12 +25,25 @@ export function isForwarded(req: FastifyRequest): boolean {
   return FORWARD_HEADERS.some((h) => req.headers[h] !== undefined);
 }
 
+// True when the request carries a *cross-origin* browser Origin — one present
+// and pointing at a different host than the one addressed. Such a request is a
+// fetch from another site: even though its socket may be loopback, it must not
+// inherit the frictionless-localhost bypass, so a hosted/other-origin page is
+// always token-checked. A same-origin Origin (browsers send one on same-origin
+// POST/PUT/DELETE) and a no-Origin native/CLI call are NOT cross-origin.
+export function isCrossOriginRequest(req: FastifyRequest): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return false;
+  try { return new URL(origin).host !== req.headers.host; } catch { return true; }
+}
+
 // The auth-exemption test: a loopback socket that wasn't relayed in through a
-// tunnel. Using this instead of isLoopback alone is what stops a tunnel from
-// inheriting the frictionless-localhost bypass. On ambiguity it fails safe
-// (challenge for the token), never open.
+// tunnel and isn't a cross-origin browser request. Using this instead of
+// isLoopback alone is what stops a tunnel — or a hosted page pointed at this
+// loopback server — from inheriting the frictionless-localhost bypass. On
+// ambiguity it fails safe (challenge for the token), never open.
 export function isLocalRequest(req: FastifyRequest): boolean {
-  return isLoopback(req.ip) && !isForwarded(req);
+  return isLoopback(req.ip) && !isForwarded(req) && !isCrossOriginRequest(req);
 }
 
 // The armed shared secret ('' = auth off). Held in a module slot rather than

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -37,13 +37,29 @@ export function isCrossOriginRequest(req: FastifyRequest): boolean {
   try { return new URL(origin).host !== req.headers.host; } catch { return true; }
 }
 
+// The addressed host is a loopback literal (localhost / 127.x / ::1). A browser
+// only sends a loopback Host header when the page it fetched was itself served
+// from a loopback origin — i.e. the real server. A page at
+// `http://attacker.localhost:<port>` (which also resolves to 127.0.0.1) sends
+// `Host: attacker.localhost`, and a classic DNS-rebinding page sends its own
+// non-loopback name — neither is a loopback literal. So this is a trusted,
+// non-forgeable signal that the request genuinely addressed the local server as
+// localhost, not the attacker-chosen Host we must never grant a bypass on.
+function isLoopbackHostHeader(req: FastifyRequest): boolean {
+  const host = req.headers.host;
+  if (!host) return false;
+  const hostname = host.replace(/:\d+$/, '').replace(/^\[|\]$/g, '');
+  return isLoopbackHost(hostname);
+}
+
 // The auth-exemption test: a loopback socket that wasn't relayed in through a
-// tunnel and isn't a cross-origin browser request. Using this instead of
-// isLoopback alone is what stops a tunnel — or a hosted page pointed at this
-// loopback server — from inheriting the frictionless-localhost bypass. On
-// ambiguity it fails safe (challenge for the token), never open.
+// tunnel, genuinely addressed the server as a loopback host, and isn't a
+// cross-origin browser request. Requiring a loopback Host (not the request's
+// attacker-controllable Host matching its Origin) is what stops a Host-spoofing
+// / DNS-rebinding page on 127.0.0.1 from inheriting the frictionless-localhost
+// bypass. On ambiguity it fails safe (challenge for the token), never open.
 export function isLocalRequest(req: FastifyRequest): boolean {
-  return isLoopback(req.ip) && !isForwarded(req) && !isCrossOriginRequest(req);
+  return isLoopback(req.ip) && !isForwarded(req) && isLoopbackHostHeader(req) && !isCrossOriginRequest(req);
 }
 
 // The armed shared secret ('' = auth off). Held in a module slot rather than
@@ -115,9 +131,15 @@ export function extractToken(req: FastifyRequest): string {
 // The `token` query param doubles as a share-link credential, so it must never
 // reach the logs. Fastify/pino's default req serializer logs `req.url` verbatim
 // (query and all) on every request — strip any token value before it lands in
-// structured output.
+// structured output. Fastify percent-decodes the query before authenticating,
+// so `?%74oken=<secret>` is a live credential too; decode the key names (not the
+// whole URL, which would mangle an already-encoded value) before matching.
 export function redactTokenInUrl(url: string): string {
-  return url.replace(/([?&]token=)[^&#]*/gi, '$1[redacted]');
+  return url.replace(/([?&])([^=&#]+)=([^&#]*)/g, (m, sep, key, val) => {
+    let decoded = key;
+    try { decoded = decodeURIComponent(key); } catch { /* keep raw key */ }
+    return decoded.toLowerCase() === 'token' ? `${sep}${key}=[redacted]` : m;
+  });
 }
 
 // Fastify onRequest hook. No-op when auth is off; otherwise 401s any protected

--- a/server/src/lib/cors.test.ts
+++ b/server/src/lib/cors.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeCorsHook } from './cors.js';
+
+// Minimal Fastify req/reply doubles: enough for the hook's header/method logic.
+// Base CORS headers land on reply.raw (survives the SSE/relay hijack); preflight
+// extras land on reply.header. The double records both into one `headers` bag.
+function makeReply() {
+  const headers: Record<string, string> = {};
+  let code = 0;
+  let sent = false;
+  return {
+    headers,
+    raw: { setHeader(k: string, v: string) { headers[k.toLowerCase()] = v; } },
+    get code_() { return code; },
+    get sent_() { return sent; },
+    header(k: string, v: string) { headers[k.toLowerCase()] = v; return this; },
+    code(c: number) { code = c; return this; },
+    send() { sent = true; return this; },
+  };
+}
+function req(method: string, origin?: string, extra: Record<string, string> = {}) {
+  return { method, headers: { ...(origin ? { origin } : {}), ...extra } } as never;
+}
+
+const ALLOW = ['https://hosted.example'];
+
+test('allowed origin: GET gets echoed origin + credentials, done() called', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET', 'https://hosted.example'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], 'https://hosted.example');
+  assert.equal(reply.headers['access-control-allow-credentials'], 'true');
+  assert.equal(doneCalled, true);
+  assert.equal(reply.sent_, false); // GET is not short-circuited
+});
+
+test('disallowed origin: no ACAO header, request still proceeds (browser blocks)', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET', 'https://evil.example'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});
+
+test('OPTIONS preflight from allowed origin: 204, methods, and PNA grant', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('OPTIONS', 'https://hosted.example', { 'access-control-request-private-network': 'true' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 204);
+  assert.equal(reply.sent_, true);
+  assert.equal(doneCalled, false); // short-circuited, done NOT called
+  assert.equal(reply.headers['access-control-allow-methods'], 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+  assert.equal(reply.headers['access-control-allow-private-network'], 'true');
+});
+
+test('OPTIONS preflight echoes requested headers when present', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  hook(req('OPTIONS', 'https://hosted.example', { 'access-control-request-headers': 'authorization,x-custom' }), reply as never, () => {});
+  assert.equal(reply.headers['access-control-allow-headers'], 'authorization,x-custom');
+});
+
+test('OPTIONS from disallowed origin: 204 but no CORS grant headers', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => {});
+  assert.equal(reply.code_, 204);
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(reply.headers['access-control-allow-private-network'], undefined);
+});
+
+test('wildcard allowlist echoes any origin (with credentials, never literal *)', () => {
+  const hook = makeCorsHook(['*']);
+  const reply = makeReply();
+  hook(req('GET', 'https://anything.example'), reply as never, () => {});
+  assert.equal(reply.headers['access-control-allow-origin'], 'https://anything.example');
+});
+
+test('no Origin header: no CORS headers, request proceeds', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  hook(req('GET'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});

--- a/server/src/lib/cors.test.ts
+++ b/server/src/lib/cors.test.ts
@@ -36,13 +36,26 @@ test('allowed origin: GET gets echoed origin + credentials, done() called', () =
   assert.equal(reply.sent_, false); // GET is not short-circuited
 });
 
-test('disallowed origin: no ACAO header, request still proceeds (browser blocks)', () => {
+test('disallowed cross-origin: refused 403 before routing (no ACAO, done NOT called)', () => {
   const hook = makeCorsHook(ALLOW);
   const reply = makeReply();
   let doneCalled = false;
   hook(req('GET', 'https://evil.example'), reply as never, () => { doneCalled = true; });
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
-  assert.equal(doneCalled, true);
+  assert.equal(reply.code_, 403);
+  assert.equal(reply.sent_, true);
+  assert.equal(doneCalled, false); // short-circuited, never reaches auth/route
+});
+
+test('disallowed cross-origin simple write (POST): also refused 403, handler never runs', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  // A simple/no-cors text/plain POST would otherwise execute server-side even
+  // though the browser can't read the response — the 403 stops it outright.
+  hook(req('POST', 'https://evil.example', { 'content-type': 'text/plain' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 403);
+  assert.equal(doneCalled, false);
 });
 
 test('OPTIONS preflight from allowed origin: 204, methods, and PNA grant', () => {
@@ -64,13 +77,15 @@ test('OPTIONS preflight echoes requested headers when present', () => {
   assert.equal(reply.headers['access-control-allow-headers'], 'authorization,x-custom');
 });
 
-test('OPTIONS from disallowed origin: 204 but no CORS grant headers', () => {
+test('OPTIONS preflight from disallowed origin: refused 403, no PNA grant', () => {
   const hook = makeCorsHook(ALLOW);
   const reply = makeReply();
-  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => {});
-  assert.equal(reply.code_, 204);
+  let doneCalled = false;
+  hook(req('OPTIONS', 'https://evil.example', { 'access-control-request-private-network': 'true' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 403);
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
   assert.equal(reply.headers['access-control-allow-private-network'], undefined);
+  assert.equal(doneCalled, false);
 });
 
 test('wildcard allowlist echoes any origin (with credentials, never literal *)', () => {
@@ -85,6 +100,18 @@ test('no Origin header: no CORS headers, request proceeds', () => {
   const reply = makeReply();
   let doneCalled = false;
   hook(req('GET'), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.headers['access-control-allow-origin'], undefined);
+  assert.equal(doneCalled, true);
+});
+
+test('same-origin request (Origin host == host): not refused, no CORS headers, proceeds', () => {
+  const hook = makeCorsHook(ALLOW);
+  const reply = makeReply();
+  let doneCalled = false;
+  // Browsers attach an Origin on same-origin POST/PUT/DELETE; that must not be
+  // read as cross-origin and 403'd.
+  hook(req('POST', 'http://127.0.0.1:7878', { host: '127.0.0.1:7878' }), reply as never, () => { doneCalled = true; });
+  assert.equal(reply.code_, 0);
   assert.equal(reply.headers['access-control-allow-origin'], undefined);
   assert.equal(doneCalled, true);
 });

--- a/server/src/lib/cors.ts
+++ b/server/src/lib/cors.ts
@@ -1,0 +1,56 @@
+import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
+
+// Cross-origin support for the hosted-WebUI mode. Normally the UI is served by
+// this same server, so requests are same-origin and this is a no-op. When a
+// hosted UI on another origin (the docs site) drives the server, we echo the
+// caller's origin (if allowlisted) and answer the CORS preflight — including
+// Chrome's Local Network Access (LNA) / legacy Private Network Access (PNA)
+// header so a public https page is permitted to reach this loopback server.
+//
+// Auth is unchanged: the bearer token / `?token=` still gates every /api call
+// (see auth.ts). CORS only decides whether the browser hands the response back
+// to the page; it is not the security boundary.
+
+function originAllowed(origin: string, allowed: string[]): boolean {
+  return allowed.includes('*') || allowed.includes(origin);
+}
+
+// Returns the value to echo in Access-Control-Allow-Origin, or null to skip.
+// With credentials we must echo the exact origin (never literal `*`).
+function resolveAllowOrigin(origin: string | undefined, allowed: string[]): string | null {
+  if (!origin || allowed.length === 0) return null;
+  return originAllowed(origin, allowed) ? origin : null;
+}
+
+export function makeCorsHook(allowed: string[]) {
+  return function corsHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
+    const origin = req.headers.origin;
+    const allow = resolveAllowOrigin(origin, allowed);
+    if (allow) {
+      // Set on reply.raw, not reply.header: the SSE/relay handlers hijack the
+      // reply and writeHead() straight on the Node res, which bypasses fastify's
+      // header pipeline. setHeader here survives that hijack (writeHead merges
+      // with already-set headers); normal responses just re-set the same value.
+      reply.raw.setHeader('Access-Control-Allow-Origin', allow);
+      reply.raw.setHeader('Access-Control-Allow-Credentials', 'true');
+      reply.raw.setHeader('Vary', 'Origin');
+    }
+    if (req.method === 'OPTIONS') {
+      // Preflight: answer here and stop, before the auth hook 401s an OPTIONS
+      // that carries no token. Only respond as a real preflight when allowed.
+      if (allow) {
+        reply.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+        const reqHeaders = req.headers['access-control-request-headers'];
+        reply.header('Access-Control-Allow-Headers', reqHeaders || 'authorization,content-type');
+        reply.header('Access-Control-Max-Age', '600');
+        // Chrome LNA/PNA: grant the public→local network preflight.
+        if (req.headers['access-control-request-private-network'] === 'true') {
+          reply.header('Access-Control-Allow-Private-Network', 'true');
+        }
+      }
+      reply.code(204).send();
+      return; // don't call done() — request is fully handled
+    }
+    done();
+  };
+}

--- a/server/src/lib/cors.ts
+++ b/server/src/lib/cors.ts
@@ -1,4 +1,5 @@
 import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify';
+import { isCrossOriginRequest } from './auth.js';
 
 // Cross-origin support for the hosted-WebUI mode. Normally the UI is served by
 // this same server, so requests are same-origin and this is a no-op. When a
@@ -7,9 +8,16 @@ import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fast
 // Chrome's Local Network Access (LNA) / legacy Private Network Access (PNA)
 // header so a public https page is permitted to reach this loopback server.
 //
+// A cross-origin request whose Origin is NOT allowlisted is rejected 403 here,
+// before auth/routing runs — omitting the ACAO header only stops the browser
+// from reading the response, it does NOT stop a simple/no-cors write (e.g. a
+// text/plain POST) from executing server-side. So the allowlist is enforced as
+// a real gate, not just a response-visibility hint. Same-origin requests (Origin
+// host == this host) and no-Origin native/CLI calls are never touched.
+//
 // Auth is unchanged: the bearer token / `?token=` still gates every /api call
-// (see auth.ts). CORS only decides whether the browser hands the response back
-// to the page; it is not the security boundary.
+// (see auth.ts). CORS decides whether a browser may talk to us cross-origin;
+// the token remains the credential.
 
 function originAllowed(origin: string, allowed: string[]): boolean {
   return allowed.includes('*') || allowed.includes(origin);
@@ -26,6 +34,13 @@ export function makeCorsHook(allowed: string[]) {
   return function corsHook(req: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
     const origin = req.headers.origin;
     const allow = resolveAllowOrigin(origin, allowed);
+    // A cross-origin browser request with a non-allowlisted Origin is refused
+    // outright — both preflight and the real (possibly simple/no-cors) request —
+    // so an unauthorized site can't drive this server at all.
+    if (!allow && isCrossOriginRequest(req)) {
+      reply.code(403).send({ error: 'origin not allowed' });
+      return; // don't call done() — request is fully handled
+    }
     if (allow) {
       // Set on reply.raw, not reply.header: the SSE/relay handlers hijack the
       // reply and writeHead() straight on the Node res, which bypasses fastify's

--- a/server/test/cors-startup.test.ts
+++ b/server/test/cors-startup.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import { makeCorsHook } from '../src/lib/cors.js';
+import { makeAuthHook, setArmedToken } from '../src/lib/auth.js';
+
+// Integration regression for the startup path: index.ts registers the CORS hook
+// UNCONDITIONALLY (even with an empty MACARON_ALLOWED_ORIGINS, the default), so
+// a cross-origin request is 403'd before it can route. An earlier build gated
+// the hook behind `if (ALLOWED_ORIGINS.length > 0)`, which silently dropped the
+// gate in the default config. This wires the hooks exactly as index.ts does —
+// empty allowlist — around a stub protected route and drives it via inject.
+async function bootApp() {
+  const app = Fastify();
+  setArmedToken(''); // auth off (loopback default) — isolate the CORS gate
+  app.addHook('onRequest', makeCorsHook([])); // empty allowlist, as at boot
+  app.addHook('onRequest', makeAuthHook());
+  app.get('/api/settings', async () => ({ ok: true }));
+  app.post('/api/tunnel/stop', async () => ({ stopped: true }));
+  await app.ready();
+  return app;
+}
+
+test('empty allowlist: cross-origin GET is 403 before routing', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878' } });
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.headers['access-control-allow-origin'], undefined);
+});
+
+test('empty allowlist: cross-origin simple POST (text/plain) is 403, handler never runs', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'POST', url: '/api/tunnel/stop', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878', 'content-type': 'text/plain' } });
+  assert.equal(res.statusCode, 403);
+  assert.notEqual(res.json().stopped, true);
+});
+
+test('empty allowlist: cross-origin preflight is 403 (no CORS grant)', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'OPTIONS', url: '/api/settings', headers: { origin: 'https://evil.example', host: '127.0.0.1:7878', 'access-control-request-private-network': 'true' } });
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.headers['access-control-allow-private-network'], undefined);
+});
+
+test('empty allowlist: same-origin request passes through (Origin host == host)', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings', headers: { origin: 'http://127.0.0.1:7878', host: '127.0.0.1:7878' } });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().ok, true);
+});
+
+test('empty allowlist: no-Origin CLI request passes through', async (t) => {
+  const app = await bootApp();
+  t.after(() => app.close());
+  const res = await app.inject({ method: 'GET', url: '/api/settings' });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().ok, true);
+});

--- a/server/test/resolve-token.test.ts
+++ b/server/test/resolve-token.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveToken } from '../src/lib/auth.js';
+
+// P1: enabling hosted mode by setting MACARON_ALLOWED_ORIGINS alone must NOT
+// leave a loopback API unarmed. isLocalRequest denies the frictionless-localhost
+// bypass to any cross-origin browser request, so a hosted page on an allowlisted
+// origin would otherwise reach a fully unauthenticated API. resolveToken arms a
+// token whenever cross-origin is enabled, mirroring the non-loopback-bind case.
+
+test('loopback + no cross-origin + no token → auth off (frictionless local default)', () => {
+  assert.deepEqual(resolveToken('127.0.0.1', '', false), { token: '', generated: false });
+});
+
+test('loopback + cross-origin enabled + no token → a token is generated', () => {
+  const r = resolveToken('127.0.0.1', '', true);
+  assert.equal(r.generated, true);
+  assert.ok(r.token.length > 0);
+});
+
+test('non-loopback bind + no token → generated (unchanged)', () => {
+  assert.equal(resolveToken('0.0.0.0', '', false).generated, true);
+});
+
+test('a configured token always wins, cross-origin or not', () => {
+  assert.deepEqual(resolveToken('127.0.0.1', 'set', true), { token: 'set', generated: false });
+});

--- a/site/app/lib/connect-state.test.ts
+++ b/site/app/lib/connect-state.test.ts
@@ -45,23 +45,28 @@ test('reject: malformed URL with literal + encoded token keys scrubs both', () =
 });
 
 // Success now opens a SAME-ORIGIN hosted route (/app for Claude, /app/codex for
-// Codex) with the server carried as ?server= — NOT a redirect to the server's
-// own origin. The token rides along for consumeServerFromUrl to bind + scrub.
-test('success: opens the hosted Claude route pointed at the server, clears inputs', () => {
+// Codex) and returns a one-time `handoff` with the server + token. The token
+// rides in the handoff (stashed same-tab), NEVER on the navigate URL — so it
+// can't leak into the document GET / access logs / referrers.
+test('success: opens the hosted Claude route + handoff, clears inputs', () => {
   const r = submit('localhost:7878', 'field-tok', SELF, 'claude');
-  assert.equal(r.navigate, '/app?server=http%3A%2F%2Flocalhost%3A7878&token=field-tok');
+  assert.equal(r.navigate, '/app');
+  assert.deepEqual(r.handoff, { server: 'http://localhost:7878', token: 'field-tok' });
+  assert.ok(!r.navigate.includes('field-tok'));   // token never on the URL
   assert.equal(r.state.token, '');                // no token left in the field
   assert.equal(r.state.error, '');
 });
 
 test('success: engine=codex opens the hosted Codex route', () => {
   const r = submit('localhost:7979', 'field-tok', SELF, 'codex');
-  assert.equal(r.navigate, '/app/codex?server=http%3A%2F%2Flocalhost%3A7979&token=field-tok');
+  assert.equal(r.navigate, '/app/codex');
+  assert.deepEqual(r.handoff, { server: 'http://localhost:7979', token: 'field-tok' });
 });
 
-test('success: url-token is honored and scrubbed from the visible input', () => {
+test('success: url-token is honored (in handoff) and scrubbed from the visible input', () => {
   const r = submit('https://tunnel.test/?token=url-tok', '', SELF, 'claude');
-  assert.equal(r.navigate, '/app?server=https%3A%2F%2Ftunnel.test&token=url-tok');
+  assert.equal(r.navigate, '/app');
+  assert.deepEqual(r.handoff, { server: 'https://tunnel.test', token: 'url-tok' });
   assert.ok(!/token=/i.test(r.state.url));        // input no longer shows the token
 });
 

--- a/site/app/lib/connect-state.test.ts
+++ b/site/app/lib/connect-state.test.ts
@@ -10,7 +10,7 @@ const SELF = 'https://docs.example.com';
 // no-navigation guarantee on every rejection path.
 
 test('reject: never navigates and scrubs the token from both fields', () => {
-  const r = submit('http://127.attacker.invalid:7878/?token=EVE_BYPASS', 'EVE_FIELD', SELF);
+  const r = submit('http://127.attacker.invalid:7878/?token=EVE_BYPASS', 'EVE_FIELD', SELF, 'claude');
   assert.equal(r.navigate, undefined);            // NO navigation
   assert.equal(r.state.token, '');                // field token gone
   assert.ok(!/token=/i.test(r.state.url));        // url token stripped
@@ -19,41 +19,49 @@ test('reject: never navigates and scrubs the token from both fields', () => {
 });
 
 test('reject: self-origin (with trailing dot) does not navigate', () => {
-  const r = submit('https://docs.example.com./?token=EVE_SELF_DOT', 'EVE_FIELD', SELF);
+  const r = submit('https://docs.example.com./?token=EVE_SELF_DOT', 'EVE_FIELD', SELF, 'claude');
   assert.equal(r.navigate, undefined);
   assert.equal(r.state.token, '');
   assert.ok(!r.state.url.includes('EVE_SELF_DOT'));
 });
 
 test('reject: malformed URL with duplicate tokens scrubs all of them', () => {
-  const r = submit('http://public.example:bad/?token=EVE_DUP_FIRST&token=EVE_DUP_SECOND', '', SELF);
+  const r = submit('http://public.example:bad/?token=EVE_DUP_FIRST&token=EVE_DUP_SECOND', '', SELF, 'claude');
   assert.equal(r.navigate, undefined);
   assert.ok(!/token=/i.test(r.state.url));
   assert.ok(!r.state.url.includes('EVE_DUP_SECOND'));
 });
 
 test('reject: malformed URL with a percent-encoded token key scrubs it', () => {
-  const r = submit('http://public.example:bad/?%74oken=EVE_ENCODED', '', SELF);
+  const r = submit('http://public.example:bad/?%74oken=EVE_ENCODED', '', SELF, 'claude');
   assert.equal(r.navigate, undefined);                 // no navigation
   assert.ok(!r.state.url.includes('EVE_ENCODED'));     // no retention
 });
 
 test('reject: malformed URL with literal + encoded token keys scrubs both', () => {
-  const r = submit('http://public.example:bad/?token=EVE_LITERAL&%74oken=EVE_ENCODED', '', SELF);
+  const r = submit('http://public.example:bad/?token=EVE_LITERAL&%74oken=EVE_ENCODED', '', SELF, 'claude');
   assert.equal(r.navigate, undefined);
   assert.ok(!r.state.url.includes('EVE_LITERAL') && !r.state.url.includes('EVE_ENCODED'));
 });
 
-test('success: navigates to the built href and clears the inputs', () => {
-  const r = submit('localhost:7878', 'field-tok', SELF);
-  assert.equal(r.navigate, 'http://localhost:7878/?token=field-tok');
+// Success now opens a SAME-ORIGIN hosted route (/app for Claude, /app/codex for
+// Codex) with the server carried as ?server= — NOT a redirect to the server's
+// own origin. The token rides along for consumeServerFromUrl to bind + scrub.
+test('success: opens the hosted Claude route pointed at the server, clears inputs', () => {
+  const r = submit('localhost:7878', 'field-tok', SELF, 'claude');
+  assert.equal(r.navigate, '/app?server=http%3A%2F%2Flocalhost%3A7878&token=field-tok');
   assert.equal(r.state.token, '');                // no token left in the field
   assert.equal(r.state.error, '');
 });
 
+test('success: engine=codex opens the hosted Codex route', () => {
+  const r = submit('localhost:7979', 'field-tok', SELF, 'codex');
+  assert.equal(r.navigate, '/app/codex?server=http%3A%2F%2Flocalhost%3A7979&token=field-tok');
+});
+
 test('success: url-token is honored and scrubbed from the visible input', () => {
-  const r = submit('https://tunnel.test/?token=url-tok', '', SELF);
-  assert.equal(r.navigate, 'https://tunnel.test/?token=url-tok');
+  const r = submit('https://tunnel.test/?token=url-tok', '', SELF, 'claude');
+  assert.equal(r.navigate, '/app?server=https%3A%2F%2Ftunnel.test&token=url-tok');
   assert.ok(!/token=/i.test(r.state.url));        // input no longer shows the token
 });
 

--- a/site/app/lib/connect-state.test.ts
+++ b/site/app/lib/connect-state.test.ts
@@ -32,6 +32,18 @@ test('reject: malformed URL with duplicate tokens scrubs all of them', () => {
   assert.ok(!r.state.url.includes('EVE_DUP_SECOND'));
 });
 
+test('reject: malformed URL with a percent-encoded token key scrubs it', () => {
+  const r = submit('http://public.example:bad/?%74oken=EVE_ENCODED', '', SELF);
+  assert.equal(r.navigate, undefined);                 // no navigation
+  assert.ok(!r.state.url.includes('EVE_ENCODED'));     // no retention
+});
+
+test('reject: malformed URL with literal + encoded token keys scrubs both', () => {
+  const r = submit('http://public.example:bad/?token=EVE_LITERAL&%74oken=EVE_ENCODED', '', SELF);
+  assert.equal(r.navigate, undefined);
+  assert.ok(!r.state.url.includes('EVE_LITERAL') && !r.state.url.includes('EVE_ENCODED'));
+});
+
 test('success: navigates to the built href and clears the inputs', () => {
   const r = submit('localhost:7878', 'field-tok', SELF);
   assert.equal(r.navigate, 'http://localhost:7878/?token=field-tok');

--- a/site/app/lib/connect-state.test.ts
+++ b/site/app/lib/connect-state.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { submit, onRestore } from './connect-state.ts';
+
+const SELF = 'https://docs.example.com';
+
+// These lock the route/component-layer behavior EVE asked for beyond the pure
+// buildTarget negatives: reject (no navigation, token scrubbed), success
+// (navigation + token scrubbed from inputs), BFCache restore, and the
+// no-navigation guarantee on every rejection path.
+
+test('reject: never navigates and scrubs the token from both fields', () => {
+  const r = submit('http://127.attacker.invalid:7878/?token=EVE_BYPASS', 'EVE_FIELD', SELF);
+  assert.equal(r.navigate, undefined);            // NO navigation
+  assert.equal(r.state.token, '');                // field token gone
+  assert.ok(!/token=/i.test(r.state.url));        // url token stripped
+  assert.ok(!r.state.url.includes('EVE_BYPASS'));
+  assert.ok(r.state.error.length > 0);
+});
+
+test('reject: self-origin (with trailing dot) does not navigate', () => {
+  const r = submit('https://docs.example.com./?token=EVE_SELF_DOT', 'EVE_FIELD', SELF);
+  assert.equal(r.navigate, undefined);
+  assert.equal(r.state.token, '');
+  assert.ok(!r.state.url.includes('EVE_SELF_DOT'));
+});
+
+test('reject: malformed URL with duplicate tokens scrubs all of them', () => {
+  const r = submit('http://public.example:bad/?token=EVE_DUP_FIRST&token=EVE_DUP_SECOND', '', SELF);
+  assert.equal(r.navigate, undefined);
+  assert.ok(!/token=/i.test(r.state.url));
+  assert.ok(!r.state.url.includes('EVE_DUP_SECOND'));
+});
+
+test('success: navigates to the built href and clears the inputs', () => {
+  const r = submit('localhost:7878', 'field-tok', SELF);
+  assert.equal(r.navigate, 'http://localhost:7878/?token=field-tok');
+  assert.equal(r.state.token, '');                // no token left in the field
+  assert.equal(r.state.error, '');
+});
+
+test('success: url-token is honored and scrubbed from the visible input', () => {
+  const r = submit('https://tunnel.test/?token=url-tok', '', SELF);
+  assert.equal(r.navigate, 'https://tunnel.test/?token=url-tok');
+  assert.ok(!/token=/i.test(r.state.url));        // input no longer shows the token
+});
+
+test('BFCache restore: strips url token and clears the field token', () => {
+  const s = onRestore({ url: 'https://tunnel.test/?token=EVE_BACK', token: 'EVE_FIELD', error: '' });
+  assert.ok(!/token=/i.test(s.url));
+  assert.equal(s.token, '');
+});

--- a/site/app/lib/connect-state.ts
+++ b/site/app/lib/connect-state.ts
@@ -3,27 +3,30 @@
 // and the no-navigation guarantee on any rejection). The component is a thin
 // shell that renders this state and performs the one side effect — navigation.
 import { buildTarget } from './connect-target';
-import { hostedTarget, type Engine } from './hosted-target';
+import { hostedTarget, type Engine, type Handoff } from './hosted-target';
 import { stripToken } from './strip-token';
 
 export type ConnectState = { url: string; token: string; error: string };
 
 // The result of pressing "Open WebUI": the next input state, plus a `navigate`
-// target that is set ONLY on success. On any rejection `navigate` is undefined
-// (no navigation happens) and the token is scrubbed from both fields.
-export type SubmitResult = { state: ConnectState; navigate?: string };
+// route and its `handoff` that are set ONLY on success. On any rejection both
+// are undefined (no navigation) and the token is scrubbed from both fields.
+// The token rides in `handoff` (stashed same-tab), never on the `navigate` URL,
+// so it can't leak into the document GET / access logs / referrers.
+export type SubmitResult = { state: ConnectState; navigate?: string; handoff?: Handoff };
 
 // `engine` picks which hosted SPA route to open (Claude Code vs Codex). The
-// validated server target is rewritten to a same-origin `/app[/codex]?server=…`
-// URL: we host the WebUI here and point it at the server, rather than redirect
-// the browser to the server's own origin.
+// validated server target becomes a same-origin `/app[/codex]` route plus a
+// one-time handoff: we host the WebUI here and point it at the server, rather
+// than redirect the browser to the server's own origin.
 export function submit(url: string, token: string, selfOrigin: string, engine: Engine): SubmitResult {
   const r = buildTarget(url, token, selfOrigin);
   if ('error' in r) {
     // Rejected: never navigate, and never leave the secret in a visible input.
     return { state: { url: stripToken(url), token: '', error: r.error } };
   }
-  return { state: { url: stripToken(url), token: '', error: '' }, navigate: hostedTarget(r.href, engine) };
+  const { route, handoff } = hostedTarget(r.href, engine);
+  return { state: { url: stripToken(url), token: '', error: '' }, navigate: route, handoff };
 }
 
 // What the inputs become when the page is restored from the BFCache after a Back.

--- a/site/app/lib/connect-state.ts
+++ b/site/app/lib/connect-state.ts
@@ -3,6 +3,7 @@
 // and the no-navigation guarantee on any rejection). The component is a thin
 // shell that renders this state and performs the one side effect — navigation.
 import { buildTarget } from './connect-target';
+import { hostedTarget, type Engine } from './hosted-target';
 import { stripToken } from './strip-token';
 
 export type ConnectState = { url: string; token: string; error: string };
@@ -12,13 +13,17 @@ export type ConnectState = { url: string; token: string; error: string };
 // (no navigation happens) and the token is scrubbed from both fields.
 export type SubmitResult = { state: ConnectState; navigate?: string };
 
-export function submit(url: string, token: string, selfOrigin: string): SubmitResult {
+// `engine` picks which hosted SPA route to open (Claude Code vs Codex). The
+// validated server target is rewritten to a same-origin `/app[/codex]?server=…`
+// URL: we host the WebUI here and point it at the server, rather than redirect
+// the browser to the server's own origin.
+export function submit(url: string, token: string, selfOrigin: string, engine: Engine): SubmitResult {
   const r = buildTarget(url, token, selfOrigin);
   if ('error' in r) {
     // Rejected: never navigate, and never leave the secret in a visible input.
     return { state: { url: stripToken(url), token: '', error: r.error } };
   }
-  return { state: { url: stripToken(url), token: '', error: '' }, navigate: r.href };
+  return { state: { url: stripToken(url), token: '', error: '' }, navigate: hostedTarget(r.href, engine) };
 }
 
 // What the inputs become when the page is restored from the BFCache after a Back.

--- a/site/app/lib/connect-state.ts
+++ b/site/app/lib/connect-state.ts
@@ -1,0 +1,27 @@
+// The Connect page's state transitions, factored out of the React component so
+// they can be unit-tested directly (reject, success-navigation, BFCache restore,
+// and the no-navigation guarantee on any rejection). The component is a thin
+// shell that renders this state and performs the one side effect — navigation.
+import { buildTarget } from './connect-target';
+import { stripToken } from './strip-token';
+
+export type ConnectState = { url: string; token: string; error: string };
+
+// The result of pressing "Open WebUI": the next input state, plus a `navigate`
+// target that is set ONLY on success. On any rejection `navigate` is undefined
+// (no navigation happens) and the token is scrubbed from both fields.
+export type SubmitResult = { state: ConnectState; navigate?: string };
+
+export function submit(url: string, token: string, selfOrigin: string): SubmitResult {
+  const r = buildTarget(url, token, selfOrigin);
+  if ('error' in r) {
+    // Rejected: never navigate, and never leave the secret in a visible input.
+    return { state: { url: stripToken(url), token: '', error: r.error } };
+  }
+  return { state: { url: stripToken(url), token: '', error: '' }, navigate: r.href };
+}
+
+// What the inputs become when the page is restored from the BFCache after a Back.
+export function onRestore(state: ConnectState): ConnectState {
+  return { url: stripToken(state.url), token: '', error: state.error };
+}

--- a/site/app/lib/connect-target.test.ts
+++ b/site/app/lib/connect-target.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTarget } from './connect-target.ts';
+
+// Table-driven coverage of every normalization branch: bare host (scheme
+// inferred by host), https + path/query/hash forced to root, http allowed only
+// for local hosts, other schemes / userinfo rejected, token from field vs URL,
+// and token encoding. Extends PR #144's gate with the http-localhost case.
+const cases: Array<{ name: string; url: string; token: string; expect: { href: string } | { error: true } }> = [
+  // bare host → scheme inferred
+  { name: 'bare public host → https + field token', url: 'x.trycloudflare.com', token: 'tok9', expect: { href: 'https://x.trycloudflare.com/?token=tok9' } },
+  { name: 'bare public host, no token', url: 'x.trycloudflare.com', token: '', expect: { href: 'https://x.trycloudflare.com/' } },
+  { name: 'bare localhost:port → http (the local case)', url: 'localhost:7878', token: 'lt', expect: { href: 'http://localhost:7878/?token=lt' } },
+  { name: 'bare 127.0.0.1 → http', url: '127.0.0.1:7979', token: '', expect: { href: 'http://127.0.0.1:7979/' } },
+  { name: 'bare 192.168 LAN host → http', url: '192.168.1.50:7878', token: 'k', expect: { href: 'http://192.168.1.50:7878/?token=k' } },
+  // explicit https
+  { name: 'https root + url token kept', url: 'https://x.trycloudflare.com/?token=abc123', token: '', expect: { href: 'https://x.trycloudflare.com/?token=abc123' } },
+  { name: 'https + deep path is forced to root', url: 'https://tunnel.test/deep/path?token=url-token', token: '', expect: { href: 'https://tunnel.test/?token=url-token' } },
+  { name: 'https + path + hash dropped', url: 'https://tunnel.test/a/b#frag', token: 'k', expect: { href: 'https://tunnel.test/?token=k' } },
+  { name: 'field token overrides url token', url: 'https://x.test/?token=inurl', token: 'field-wins', expect: { href: 'https://x.test/?token=field-wins' } },
+  { name: 'token is url-encoded', url: 'https://x.test/', token: 'a b/c+d', expect: { href: 'https://x.test/?token=a+b%2Fc%2Bd' } },
+  // explicit http: local ok, public rejected
+  { name: 'explicit http://localhost is allowed', url: 'http://localhost:7878/?token=abc', token: '', expect: { href: 'http://localhost:7878/?token=abc' } },
+  { name: 'explicit http://127.0.0.1 is allowed', url: 'http://127.0.0.1:7878/', token: 't', expect: { href: 'http://127.0.0.1:7878/?token=t' } },
+  { name: 'http to a PUBLIC host is rejected', url: 'http://x.test/?token=abc', token: '', expect: { error: true } },
+  // other schemes / userinfo / junk
+  { name: 'ftp scheme is rejected (not treated as bare host)', url: 'ftp://tunnel.test/share?token=url-token', token: '', expect: { error: true } },
+  { name: 'ws scheme is rejected', url: 'ws://tunnel.test/', token: '', expect: { error: true } },
+  { name: 'userinfo is rejected', url: 'https://user:pass@tunnel.test/path?token=url-token', token: '', expect: { error: true } },
+  { name: 'username-only is rejected', url: 'https://user@tunnel.test/', token: '', expect: { error: true } },
+  { name: 'empty input is rejected', url: '', token: '', expect: { error: true } },
+  { name: 'whitespace-only input is rejected', url: '   ', token: '', expect: { error: true } },
+  { name: 'garbage is rejected', url: 'not a url ::::', token: 'x', expect: { error: true } },
+];
+
+for (const c of cases) {
+  test(c.name, () => {
+    const r = buildTarget(c.url, c.token);
+    if ('error' in c.expect) {
+      assert.ok('error' in r, `expected an error for ${JSON.stringify(c.url)}, got ${JSON.stringify(r)}`);
+    } else {
+      assert.deepEqual(r, c.expect);
+    }
+  });
+}

--- a/site/app/lib/connect-target.test.ts
+++ b/site/app/lib/connect-target.test.ts
@@ -6,7 +6,7 @@ import { buildTarget } from './connect-target.ts';
 // inferred by host), https + path/query/hash forced to root, http allowed only
 // for local hosts, other schemes / userinfo rejected, token from field vs URL,
 // and token encoding. Extends PR #144's gate with the http-localhost case.
-const cases: Array<{ name: string; url: string; token: string; expect: { href: string } | { error: true } }> = [
+const cases: Array<{ name: string; url: string; token: string; self?: string; expect: { href: string } | { error: true } }> = [
   // bare host → scheme inferred
   { name: 'bare public host → https + field token', url: 'x.trycloudflare.com', token: 'tok9', expect: { href: 'https://x.trycloudflare.com/?token=tok9' } },
   { name: 'bare public host, no token', url: 'x.trycloudflare.com', token: '', expect: { href: 'https://x.trycloudflare.com/' } },
@@ -31,11 +31,35 @@ const cases: Array<{ name: string; url: string; token: string; expect: { href: s
   { name: 'empty input is rejected', url: '', token: '', expect: { error: true } },
   { name: 'whitespace-only input is rejected', url: '   ', token: '', expect: { error: true } },
   { name: 'garbage is rejected', url: 'not a url ::::', token: 'x', expect: { error: true } },
+
+  // EVE PR #158 regressions — DNS-prefix bypass of the http/local gate. A hostname
+  // that merely starts with a private-range prefix is NOT local and must fail
+  // closed (http rejected), never send a token in cleartext to a public host.
+  { name: '127.x DNS name is not local (http rejected)', url: 'http://127.attacker.invalid:7878/?token=EVE_BYPASS', token: '', expect: { error: true } },
+  { name: '10.x DNS name is not local', url: 'http://10.attacker.invalid:7878/', token: 't', expect: { error: true } },
+  { name: '192.168 DNS name is not local', url: 'http://192.168.attacker.invalid:7878/', token: 't', expect: { error: true } },
+  { name: '172.16 DNS name is not local', url: 'http://172.16.attacker.invalid:7878/', token: 't', expect: { error: true } },
+  { name: 'fc-prefixed DNS name is not local', url: 'http://fc-attacker.invalid:7878/', token: 't', expect: { error: true } },
+  { name: 'fd-prefixed DNS name is not local', url: 'http://fd.attacker.invalid:7878/', token: 't', expect: { error: true } },
+  { name: 'bare 127.x DNS name infers https, not http', url: '127.attacker.invalid:7878', token: 't', expect: { href: 'https://127.attacker.invalid:7878/?token=t' } },
+  { name: 'octet > 255 is not a v4 literal (public)', url: 'http://127.0.0.999:7878/', token: 't', expect: { error: true } },
+  { name: 'five octets is not a v4 literal (public)', url: 'http://127.0.0.0.1:7878/', token: 't', expect: { error: true } },
+
+  // Ranges the header comment claims but the old code missed.
+  { name: '169.254 link-local → http allowed', url: 'http://169.254.1.2:7878/', token: 't', expect: { href: 'http://169.254.1.2:7878/?token=t' } },
+  { name: 'fe80 link-local IPv6 → http allowed', url: 'http://[fe80::1]:7878/', token: 't', expect: { href: 'http://[fe80::1]:7878/?token=t' } },
+  { name: '::1 IPv6 loopback → http allowed', url: 'http://[::1]:7878/', token: 't', expect: { href: 'http://[::1]:7878/?token=t' } },
+  { name: 'trailing-dot localhost. → http allowed', url: 'http://localhost.:7878/', token: 't', expect: { href: 'http://localhost.:7878/?token=t' } },
+
+  // Self-origin rejection — never send the token back to the docs host itself.
+  { name: 'self origin is rejected', url: 'https://docs.example.com/?token=EVE_SELF', token: '', self: 'https://docs.example.com', expect: { error: true } },
+  { name: 'self origin bare host is rejected', url: 'docs.example.com', token: 't', self: 'https://docs.example.com', expect: { error: true } },
+  { name: 'different origin under same self is allowed', url: 'https://other.example.com/', token: 't', self: 'https://docs.example.com', expect: { href: 'https://other.example.com/?token=t' } },
 ];
 
 for (const c of cases) {
   test(c.name, () => {
-    const r = buildTarget(c.url, c.token);
+    const r = buildTarget(c.url, c.token, c.self);
     if ('error' in c.expect) {
       assert.ok('error' in r, `expected an error for ${JSON.stringify(c.url)}, got ${JSON.stringify(r)}`);
     } else {

--- a/site/app/lib/connect-target.test.ts
+++ b/site/app/lib/connect-target.test.ts
@@ -55,6 +55,22 @@ const cases: Array<{ name: string; url: string; token: string; self?: string; ex
   { name: 'self origin is rejected', url: 'https://docs.example.com/?token=EVE_SELF', token: '', self: 'https://docs.example.com', expect: { error: true } },
   { name: 'self origin bare host is rejected', url: 'docs.example.com', token: 't', self: 'https://docs.example.com', expect: { error: true } },
   { name: 'different origin under same self is allowed', url: 'https://other.example.com/', token: 't', self: 'https://docs.example.com', expect: { href: 'https://other.example.com/?token=t' } },
+
+  // EVE round-2: IPv6 range must be decided by the numeric first hextet, not a
+  // text prefix. `fc::1` is 00fc::1 and is NOT in fc00::/7 — must fail closed.
+  { name: 'fc::1 is not ULA (http rejected)', url: 'http://[fc::1]:7878/?token=EVE_IPV6', token: '', expect: { error: true } },
+  { name: 'fca::1 is not ULA', url: 'http://[fca::1]:7878/', token: 't', expect: { error: true } },
+  { name: 'fd0::1 is not ULA', url: 'http://[fd0::1]:7878/', token: 't', expect: { error: true } },
+  { name: 'fe8::1 is not link-local', url: 'http://[fe8::1]:7878/', token: 't', expect: { error: true } },
+  { name: 'feb::1 is not link-local', url: 'http://[feb::1]:7878/', token: 't', expect: { error: true } },
+  { name: 'fc00::1 IS ULA (http allowed)', url: 'http://[fc00::1]:7878/', token: 't', expect: { href: 'http://[fc00::1]:7878/?token=t' } },
+  { name: 'fdff::1 IS ULA', url: 'http://[fdff::1]:7878/', token: 't', expect: { href: 'http://[fdff::1]:7878/?token=t' } },
+  { name: 'fe80::1 IS link-local', url: 'http://[fe80::1]:7878/', token: 't', expect: { href: 'http://[fe80::1]:7878/?token=t' } },
+  { name: 'febf::1 IS link-local', url: 'http://[febf::1]:7878/', token: 't', expect: { href: 'http://[febf::1]:7878/?token=t' } },
+
+  // EVE round-2: self-origin must survive a DNS trailing dot on either side.
+  { name: 'self origin with trailing dot is rejected', url: 'https://docs.example.com./?token=EVE_DOT', token: '', self: 'https://docs.example.com', expect: { error: true } },
+  { name: 'self origin bare host with trailing dot is rejected', url: 'docs.example.com.', token: 't', self: 'https://docs.example.com', expect: { error: true } },
 ];
 
 for (const c of cases) {

--- a/site/app/lib/connect-target.ts
+++ b/site/app/lib/connect-target.ts
@@ -1,0 +1,72 @@
+// Normalize a pasted Macaron server URL (+ optional token) into a safe jump
+// target `<origin>/?token=<t>`. The macaron server serves its OWN WebUI, so
+// "connecting" is a redirect: we send the browser to the server's origin where
+// the WebUI loads same-origin (no CORS, no in-page cross-origin fetch). This
+// function is the whole security surface, so it fails closed.
+//
+// Scheme rules:
+//   - scheme-less input (`box.example.com`, `localhost:7878`) → assume the
+//     right scheme by host: loopback / private hosts get http (the local case
+//     the user actually runs), everything else gets https.
+//   - explicit `https://` always allowed.
+//   - explicit `http://` allowed ONLY for a loopback / private-LAN host — an
+//     access token over http to a public host is unsafe and is rejected.
+//   - any other explicit scheme (ftp/ws/…) and any userinfo is rejected.
+// See MAC-8578 / EVE's review on PR #144 (this revives + widens that gate so
+// `http://localhost:7878` works).
+
+export type BuildResult = { href: string } | { error: string };
+
+// Matches a leading URI scheme per RFC 3986 (`scheme ":"`), but NOT a bare
+// `host:port` — a scheme's colon is never followed by a digit, whereas
+// `localhost:7878` is host:port. So `https://x` / `ftp://x` are schemes, while
+// `localhost:7878` is treated as scheme-less and gets its scheme inferred.
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
+
+// A host that never leaves the machine / LAN, where an http token is acceptable:
+// loopback names, 127.0.0.0/8, ::1, and the RFC1918 / link-local private ranges.
+function isLocalHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (h === '::1' || h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
+  if (/^127\./.test(h)) return true;
+  if (/^10\./.test(h)) return true;
+  if (/^192\.168\./.test(h)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+  return false;
+}
+
+export function buildTarget(rawUrl: string, rawToken: string): BuildResult {
+  const input = rawUrl.trim();
+  if (!input) return { error: 'Paste your Macaron server URL first.' };
+
+  let parsed: URL;
+  try {
+    if (HAS_SCHEME.test(input)) {
+      parsed = new URL(input);
+    } else {
+      // Infer the scheme from the host: local hosts default to http (that's how
+      // the local server is reached), everything else to https.
+      const probe = new URL(`https://${input}`);
+      parsed = new URL((isLocalHost(probe.hostname) ? 'http://' : 'https://') + input);
+    }
+  } catch {
+    return { error: 'That does not look like a valid URL.' };
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return { error: 'Use an http:// or https:// URL.' };
+  }
+  if (parsed.protocol === 'http:' && !isLocalHost(parsed.hostname)) {
+    return { error: 'Use https:// for a public server — an access token over http is unsafe.' };
+  }
+  if (parsed.username || parsed.password) return { error: 'Remove the user:pass@ part from the URL.' };
+
+  // A token typed into the field wins; otherwise keep one already in the URL.
+  const token = rawToken.trim() || parsed.searchParams.get('token') || '';
+  // Force root: origin drops any pathname/query/hash, so the token can only
+  // land on `<origin>/`, never a deeper path or a different host.
+  const base = new URL('/', parsed.origin);
+  if (token) base.searchParams.set('token', token);
+  return { href: base.toString() };
+}

--- a/site/app/lib/connect-target.ts
+++ b/site/app/lib/connect-target.ts
@@ -20,6 +20,16 @@
 
 export type BuildResult = { href: string } | { error: string };
 
+// Compare a parsed URL's origin against `selfOrigin`, treating a hostname that
+// differs only by a single trailing dot (`host` vs `host.`) as the same origin.
+function sameOrigin(parsed: URL, selfOrigin: string): boolean {
+  let self: URL;
+  try { self = new URL(selfOrigin); } catch { return false; }
+  if (parsed.protocol !== self.protocol || parsed.port !== self.port) return false;
+  const strip = (host: string) => host.replace(/\.$/, '').toLowerCase();
+  return strip(parsed.hostname) === strip(self.hostname);
+}
+
 // Matches a leading URI scheme per RFC 3986 (`scheme ":"`), but NOT a bare
 // `host:port` — a scheme's colon is never followed by a digit, whereas
 // `localhost:7878` is host:port. So `https://x` / `ftp://x` are schemes, while
@@ -54,12 +64,16 @@ function isLocalHost(hostname: string): boolean {
   // Loopback names (accept a trailing dot, the FQDN root form).
   if (h === 'localhost' || h === 'localhost.' || h.endsWith('.localhost') || h.endsWith('.localhost.')) return true;
 
-  // IPv6 literal (URL keeps the brackets in .hostname; strip them).
+  // IPv6 literal (URL keeps the brackets in .hostname; strip them). Decide the
+  // range by the numeric value of the FIRST 16-bit hextet, never a text prefix:
+  // `fc::1` is `00fc::1` (first hextet 0x00fc) and is NOT ULA, so it fails closed.
   if (h.startsWith('[') && h.endsWith(']')) {
     const v6 = h.slice(1, -1);
-    if (v6 === '::1') return true;                                    // loopback
-    if (/^fe[89ab][0-9a-f]?:/.test(v6) || /^fe[89ab]$/.test(v6)) return true; // fe80::/10 link-local
-    if (/^f[cd][0-9a-f]{0,2}:/.test(v6) || /^f[cd][0-9a-f]{0,2}$/.test(v6)) return true; // fc00::/7 ULA
+    if (v6 === '::1') return true;                       // loopback
+    const first = v6.startsWith('::') ? 0 : parseInt(v6.split(':')[0], 16);
+    if (Number.isNaN(first)) return false;
+    if (first >= 0xfe80 && first <= 0xfebf) return true; // fe80::/10 link-local
+    if (first >= 0xfc00 && first <= 0xfdff) return true; // fc00::/7 unique-local
     return false;
   }
 
@@ -101,7 +115,9 @@ export function buildTarget(rawUrl: string, rawToken: string, selfOrigin?: strin
   if (parsed.username || parsed.password) return { error: 'Remove the user:pass@ part from the URL.' };
   // Never send the token to this site's own origin — that would leak it into
   // the docs host's request log / browser history instead of a Macaron server.
-  if (selfOrigin && parsed.origin === selfOrigin) {
+  // Normalize a single trailing dot on the hostname so `<host>.` (DNS-equal but
+  // a distinct serialized origin) can't slip past the equality check.
+  if (selfOrigin && sameOrigin(parsed, selfOrigin)) {
     return { error: 'That is this site’s own address — paste your Macaron server URL instead.' };
   }
 

--- a/site/app/lib/connect-target.ts
+++ b/site/app/lib/connect-target.ts
@@ -10,10 +10,13 @@
 //     the user actually runs), everything else gets https.
 //   - explicit `https://` always allowed.
 //   - explicit `http://` allowed ONLY for a loopback / private-LAN host — an
-//     access token over http to a public host is unsafe and is rejected.
+//     access token over http to a public host is unsafe and is rejected. "Local"
+//     is decided by a STRICT IP-literal parse, never string prefixes, so a DNS
+//     name like `127.attacker.invalid` is public and fails closed.
 //   - any other explicit scheme (ftp/ws/…) and any userinfo is rejected.
-// See MAC-8578 / EVE's review on PR #144 (this revives + widens that gate so
-// `http://localhost:7878` works).
+//   - the site's own origin is rejected — never send the token back to the docs
+//     host (pass `selfOrigin` = `window.location.origin`).
+// See MAC-8578 / EVE's reviews on PR #144 and #158.
 
 export type BuildResult = { href: string } | { error: string };
 
@@ -23,20 +26,55 @@ export type BuildResult = { href: string } | { error: string };
 // `localhost:7878` is treated as scheme-less and gets its scheme inferred.
 const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
 
+// Parse a string as a strict IPv4 literal (exactly four 0-255 octets, no
+// leading zeros beyond a lone 0). Returns the octets, or null if it isn't a
+// literal — so a DNS name like `127.attacker.invalid` returns null and cannot
+// masquerade as a private address via prefix matching.
+function parseIPv4(h: string): [number, number, number, number] | null {
+  const parts = h.split('.');
+  if (parts.length !== 4) return null;
+  const out: number[] = [];
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    if (p.length > 1 && p[0] === '0') return null; // no leading zeros (rejects octal-ish input)
+    const n = Number(p);
+    if (n > 255) return null;
+    out.push(n);
+  }
+  return out as [number, number, number, number];
+}
+
 // A host that never leaves the machine / LAN, where an http token is acceptable:
-// loopback names, 127.0.0.0/8, ::1, and the RFC1918 / link-local private ranges.
+// loopback names, 127.0.0.0/8, 10/8, 192.168/16, 172.16-31/12, 169.254/16
+// (link-local), and ::1 / fe80::/10 / fc00::/7. Anything that is neither an
+// explicit loopback name nor a valid IP literal in these ranges fails closed —
+// an ordinary DNS name is NEVER treated as local.
 function isLocalHost(hostname: string): boolean {
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
-  if (h === 'localhost' || h.endsWith('.localhost')) return true;
-  if (h === '::1' || h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
-  if (/^127\./.test(h)) return true;
-  if (/^10\./.test(h)) return true;
-  if (/^192\.168\./.test(h)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+  const h = hostname.toLowerCase();
+  // Loopback names (accept a trailing dot, the FQDN root form).
+  if (h === 'localhost' || h === 'localhost.' || h.endsWith('.localhost') || h.endsWith('.localhost.')) return true;
+
+  // IPv6 literal (URL keeps the brackets in .hostname; strip them).
+  if (h.startsWith('[') && h.endsWith(']')) {
+    const v6 = h.slice(1, -1);
+    if (v6 === '::1') return true;                                    // loopback
+    if (/^fe[89ab][0-9a-f]?:/.test(v6) || /^fe[89ab]$/.test(v6)) return true; // fe80::/10 link-local
+    if (/^f[cd][0-9a-f]{0,2}:/.test(v6) || /^f[cd][0-9a-f]{0,2}$/.test(v6)) return true; // fc00::/7 ULA
+    return false;
+  }
+
+  const ip = parseIPv4(h);
+  if (!ip) return false; // not a loopback name and not an IPv4 literal → fail closed
+  const [a, b] = ip;
+  if (a === 127) return true;                 // 127.0.0.0/8 loopback
+  if (a === 10) return true;                  // 10.0.0.0/8
+  if (a === 192 && b === 168) return true;    // 192.168.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 169 && b === 254) return true;    // 169.254.0.0/16 link-local
   return false;
 }
 
-export function buildTarget(rawUrl: string, rawToken: string): BuildResult {
+export function buildTarget(rawUrl: string, rawToken: string, selfOrigin?: string): BuildResult {
   const input = rawUrl.trim();
   if (!input) return { error: 'Paste your Macaron server URL first.' };
 
@@ -61,6 +99,11 @@ export function buildTarget(rawUrl: string, rawToken: string): BuildResult {
     return { error: 'Use https:// for a public server — an access token over http is unsafe.' };
   }
   if (parsed.username || parsed.password) return { error: 'Remove the user:pass@ part from the URL.' };
+  // Never send the token to this site's own origin — that would leak it into
+  // the docs host's request log / browser history instead of a Macaron server.
+  if (selfOrigin && parsed.origin === selfOrigin) {
+    return { error: 'That is this site’s own address — paste your Macaron server URL instead.' };
+  }
 
   // A token typed into the field wins; otherwise keep one already in the URL.
   const token = rawToken.trim() || parsed.searchParams.get('token') || '';

--- a/site/app/lib/hosted-target.test.ts
+++ b/site/app/lib/hosted-target.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { hostedTarget } from './hosted-target.ts';
+
+// hostedTarget turns buildTarget's `<origin>/?token=` into the same-origin
+// hosted-route URL. It must: pick /app vs /app/codex by engine, carry the
+// server as an encoded ?server=<origin> (no trailing slash, no path), keep the
+// token when present and drop it when absent, and never emit an absolute URL
+// (staying on the docs origin is the whole point of hosting vs redirecting).
+
+test('claude engine → /app with encoded server + token', () => {
+  assert.equal(hostedTarget('http://localhost:7878/?token=t', 'claude'), '/app?server=http%3A%2F%2Flocalhost%3A7878&token=t');
+});
+
+test('codex engine → /app/codex', () => {
+  assert.equal(hostedTarget('http://localhost:7979/?token=t', 'codex'), '/app/codex?server=http%3A%2F%2Flocalhost%3A7979&token=t');
+});
+
+test('no token → server only, no token param', () => {
+  assert.equal(hostedTarget('https://x.trycloudflare.com/', 'claude'), '/app?server=https%3A%2F%2Fx.trycloudflare.com');
+});
+
+test('server is the ORIGIN only — any path/query on the input is dropped', () => {
+  // buildTarget already forces root, but hostedTarget must not re-introduce a path.
+  assert.equal(hostedTarget('https://tunnel.test/?token=abc', 'claude'), '/app?server=https%3A%2F%2Ftunnel.test&token=abc');
+});
+
+test('always relative — never an absolute URL to the server origin', () => {
+  const href = hostedTarget('https://tunnel.test/?token=abc', 'codex');
+  assert.ok(href.startsWith('/app/codex?'), href);
+  assert.ok(!/^https?:/i.test(href));
+});

--- a/site/app/lib/hosted-target.test.ts
+++ b/site/app/lib/hosted-target.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { hostedTarget } from './hosted-target.ts';
+import { hostedTarget, HANDOFF_KEY } from './hosted-target.ts';
 
 // hostedTarget turns buildTarget's `<origin>/?token=` into a same-origin hosted
 // route + a one-time handoff. The server/token ride in the HANDOFF (stashed
@@ -39,4 +39,12 @@ test('route is a bare relative path — no token/server ever on the URL', () => 
   const { route } = hostedTarget('https://tunnel.test/?token=secret', 'codex');
   assert.equal(route, '/app/codex');
   assert.ok(!route.includes('secret') && !route.includes('server') && !route.includes('?'), route);
+});
+
+// Cross-workspace contract: the web bundle reads this exact sessionStorage key
+// (web/src/lib/auth.ts pins the same literal in web/test/apiBase.test.ts). If
+// either side renames it, its own tests fail instead of hosted mode silently
+// never consuming the handoff.
+test('HANDOFF_KEY matches the literal the web bundle consumes', () => {
+  assert.equal(HANDOFF_KEY, 'macaron_connect_handoff');
 });

--- a/site/app/lib/hosted-target.test.ts
+++ b/site/app/lib/hosted-target.test.ts
@@ -2,31 +2,41 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { hostedTarget } from './hosted-target.ts';
 
-// hostedTarget turns buildTarget's `<origin>/?token=` into the same-origin
-// hosted-route URL. It must: pick /app vs /app/codex by engine, carry the
-// server as an encoded ?server=<origin> (no trailing slash, no path), keep the
-// token when present and drop it when absent, and never emit an absolute URL
-// (staying on the docs origin is the whole point of hosting vs redirecting).
+// hostedTarget turns buildTarget's `<origin>/?token=` into a same-origin hosted
+// route + a one-time handoff. The server/token ride in the HANDOFF (stashed
+// same-tab by the connect page), NEVER on the route URL — that's the P0 fix so
+// the credential can't leak into the document GET / access logs / referrers. It
+// must pick /app vs /app/codex by engine, split origin + token, and keep the
+// route a bare relative path with no query.
 
-test('claude engine → /app with encoded server + token', () => {
-  assert.equal(hostedTarget('http://localhost:7878/?token=t', 'claude'), '/app?server=http%3A%2F%2Flocalhost%3A7878&token=t');
+test('claude engine → /app route + handoff carrying origin and token', () => {
+  assert.deepEqual(hostedTarget('http://localhost:7878/?token=t', 'claude'), {
+    route: '/app',
+    handoff: { server: 'http://localhost:7878', token: 't' },
+  });
 });
 
-test('codex engine → /app/codex', () => {
-  assert.equal(hostedTarget('http://localhost:7979/?token=t', 'codex'), '/app/codex?server=http%3A%2F%2Flocalhost%3A7979&token=t');
+test('codex engine → /app/codex route', () => {
+  assert.deepEqual(hostedTarget('http://localhost:7979/?token=t', 'codex'), {
+    route: '/app/codex',
+    handoff: { server: 'http://localhost:7979', token: 't' },
+  });
 });
 
-test('no token → server only, no token param', () => {
-  assert.equal(hostedTarget('https://x.trycloudflare.com/', 'claude'), '/app?server=https%3A%2F%2Fx.trycloudflare.com');
+test('no token → empty token in handoff', () => {
+  assert.deepEqual(hostedTarget('https://x.trycloudflare.com/', 'claude'), {
+    route: '/app',
+    handoff: { server: 'https://x.trycloudflare.com', token: '' },
+  });
 });
 
 test('server is the ORIGIN only — any path/query on the input is dropped', () => {
-  // buildTarget already forces root, but hostedTarget must not re-introduce a path.
-  assert.equal(hostedTarget('https://tunnel.test/?token=abc', 'claude'), '/app?server=https%3A%2F%2Ftunnel.test&token=abc');
+  const { handoff } = hostedTarget('https://tunnel.test/?token=abc', 'claude');
+  assert.equal(handoff.server, 'https://tunnel.test');
 });
 
-test('always relative — never an absolute URL to the server origin', () => {
-  const href = hostedTarget('https://tunnel.test/?token=abc', 'codex');
-  assert.ok(href.startsWith('/app/codex?'), href);
-  assert.ok(!/^https?:/i.test(href));
+test('route is a bare relative path — no token/server ever on the URL', () => {
+  const { route } = hostedTarget('https://tunnel.test/?token=secret', 'codex');
+  assert.equal(route, '/app/codex');
+  assert.ok(!route.includes('secret') && !route.includes('server') && !route.includes('?'), route);
 });

--- a/site/app/lib/hosted-target.ts
+++ b/site/app/lib/hosted-target.ts
@@ -1,25 +1,29 @@
 // Turn a validated server target (from buildTarget: `<origin>/?token=<t>`) into
-// the SAME-ORIGIN hosted-route URL that opens the WebUI we host under /app and
-// points it at that server. This is the difference between the old flow (a full
-// redirect to the server's own origin) and hosting: we stay on the docs origin,
-// load our staged SPA, and pass the server as `?server=` for apiBase to consume.
+// the same-origin hosted route that opens the WebUI we host under /app, plus a
+// one-time handoff carrying the server origin and token.
 //
 // Claude Code → /app (index.html), Codex → /app/codex (codex.html). The server
-// origin and token ride as query params; the WebUI's consumeServerFromUrl binds
-// the token to that origin and scrubs both from the URL on first load.
+// and token are deliberately NOT put on the URL: the connect page stashes the
+// handoff in sessionStorage and navigates to the clean route, so the credential
+// never lands in the document GET, the docs/CDN access logs, or referrers. The
+// hosted SPA reads the handoff on first load (see web apiBase.consumeHandoff),
+// binds the token to that server origin, and clears it. A crafted `/app?server=…`
+// URL is inert — only the same-tab handoff is trusted — so buildTarget's
+// scheme / self-origin / public-HTTP validation cannot be bypassed.
 export type Engine = 'claude' | 'codex';
 
 const ROUTE: Record<Engine, string> = { claude: '/app', codex: '/app/codex' };
 
+// sessionStorage key the docs connect page WRITES and the hosted SPA READS.
+// Must stay identical to HANDOFF_KEY in web/src/lib/apiBase.ts.
+export const HANDOFF_KEY = 'macaron_connect_handoff';
+
+export type Handoff = { server: string; token: string };
+export type HostedTarget = { route: string; handoff: Handoff };
+
 // `serverHref` is buildTarget's output, already normalized to `<origin>/` with
-// an optional `?token=`. We split it back into origin + token so the hosted
-// route gets `?server=<origin>` (no trailing `/`, path already dropped upstream)
-// and `?token=<t>` only when present.
-export function hostedTarget(serverHref: string, engine: Engine): string {
+// an optional `?token=`. Split it into origin + token for the handoff.
+export function hostedTarget(serverHref: string, engine: Engine): HostedTarget {
   const u = new URL(serverHref);
-  const token = u.searchParams.get('token') || '';
-  const target = new URL(ROUTE[engine], 'https://placeholder.invalid');
-  target.searchParams.set('server', u.origin);
-  if (token) target.searchParams.set('token', token);
-  return target.pathname + target.search; // relative, same-origin
+  return { route: ROUTE[engine], handoff: { server: u.origin, token: u.searchParams.get('token') || '' } };
 }

--- a/site/app/lib/hosted-target.ts
+++ b/site/app/lib/hosted-target.ts
@@ -1,0 +1,25 @@
+// Turn a validated server target (from buildTarget: `<origin>/?token=<t>`) into
+// the SAME-ORIGIN hosted-route URL that opens the WebUI we host under /app and
+// points it at that server. This is the difference between the old flow (a full
+// redirect to the server's own origin) and hosting: we stay on the docs origin,
+// load our staged SPA, and pass the server as `?server=` for apiBase to consume.
+//
+// Claude Code → /app (index.html), Codex → /app/codex (codex.html). The server
+// origin and token ride as query params; the WebUI's consumeServerFromUrl binds
+// the token to that origin and scrubs both from the URL on first load.
+export type Engine = 'claude' | 'codex';
+
+const ROUTE: Record<Engine, string> = { claude: '/app', codex: '/app/codex' };
+
+// `serverHref` is buildTarget's output, already normalized to `<origin>/` with
+// an optional `?token=`. We split it back into origin + token so the hosted
+// route gets `?server=<origin>` (no trailing `/`, path already dropped upstream)
+// and `?token=<t>` only when present.
+export function hostedTarget(serverHref: string, engine: Engine): string {
+  const u = new URL(serverHref);
+  const token = u.searchParams.get('token') || '';
+  const target = new URL(ROUTE[engine], 'https://placeholder.invalid');
+  target.searchParams.set('server', u.origin);
+  if (token) target.searchParams.set('token', token);
+  return target.pathname + target.search; // relative, same-origin
+}

--- a/site/app/lib/strip-token.test.ts
+++ b/site/app/lib/strip-token.test.ts
@@ -35,6 +35,24 @@ test('bare host with token strips the token, keeps the host', () => {
   assert.equal(stripToken('x.test/?token=abc'), 'x.test/');
 });
 
+test('malformed URL: strips a percent-encoded token key (%74oken)', () => {
+  const out = stripToken('http://public.example:bad/?%74oken=EVE_ENCODED');
+  assert.ok(!out.includes('EVE_ENCODED'), `encoded token survived: ${out}`);
+  assert.ok(!/oken=/i.test(out));
+});
+
+test('malformed URL: strips literal + encoded token keys together', () => {
+  const out = stripToken('http://public.example:bad/?token=EVE_LITERAL&%74oken=EVE_ENCODED');
+  assert.ok(!out.includes('EVE_LITERAL') && !out.includes('EVE_ENCODED'), out);
+});
+
+test('malformed URL: an undecodable key fails safe (dropped)', () => {
+  // `%zz` can't be decoded; treat it as a token key and drop it rather than leak.
+  const out = stripToken('http://public.example:bad/?%zzoken=EVE_BAD&a=1');
+  assert.ok(!out.includes('EVE_BAD'));
+  assert.ok(out.includes('a=1'));
+});
+
 test('input without a token is returned unchanged', () => {
   assert.equal(stripToken('localhost:7878'), 'localhost:7878');
 });

--- a/site/app/lib/strip-token.test.ts
+++ b/site/app/lib/strip-token.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripToken } from './strip-token.ts';
+
+// stripToken must remove EVERY `token` query param, on both the URL-parse path
+// and the malformed-URL fallback (EVE round-2 found the fallback left the second
+// of a duplicated `token` behind on `http://public.example:bad/?token=a&token=b`).
+test('removes a single token from a well-formed URL', () => {
+  assert.equal(stripToken('https://x.test/?token=abc'), 'https://x.test/');
+});
+
+test('removes duplicate tokens from a well-formed URL', () => {
+  assert.equal(stripToken('https://x.test/?token=a&token=b'), 'https://x.test/');
+});
+
+test('removes duplicate tokens from a malformed URL (bad port), keeping other params', () => {
+  const out = stripToken('http://public.example:bad/?token=EVE_DUP_FIRST&token=EVE_DUP_SECOND');
+  assert.ok(!/token=/i.test(out), `token still present: ${out}`);
+  assert.ok(!out.includes('EVE_DUP_SECOND'));
+});
+
+test('malformed URL: keeps non-token params and drops only tokens', () => {
+  const out = stripToken('http://public.example:bad/?a=1&token=x&b=2&token=y');
+  assert.ok(!/token=/i.test(out));
+  assert.ok(out.includes('a=1') && out.includes('b=2'));
+});
+
+test('malformed URL: preserves the fragment while stripping tokens', () => {
+  const out = stripToken('http://public.example:bad/?token=x#frag');
+  assert.ok(!/token=/i.test(out));
+  assert.ok(out.endsWith('#frag'));
+});
+
+test('bare host with token strips the token, keeps the host', () => {
+  assert.equal(stripToken('x.test/?token=abc'), 'x.test/');
+});
+
+test('input without a token is returned unchanged', () => {
+  assert.equal(stripToken('localhost:7878'), 'localhost:7878');
+});
+
+test('empty / whitespace input is returned as-is', () => {
+  assert.equal(stripToken(''), '');
+  assert.equal(stripToken('   '), '   ');
+});

--- a/site/app/lib/strip-token.ts
+++ b/site/app/lib/strip-token.ts
@@ -13,12 +13,23 @@ export function stripToken(raw: string): string {
     return hasScheme ? u.toString() : u.toString().replace(/^https:\/\//, '');
   } catch {
     // Split off the query, drop every token=... pair, reattach what's left.
+    // Compare the DECODED key so a percent-encoded `token` (e.g. `%74oken`,
+    // which URLSearchParams would decode back to `token`) can't survive here.
     const hash = trimmed.indexOf('#');
     const head = hash === -1 ? trimmed : trimmed.slice(0, hash);
     const frag = hash === -1 ? '' : trimmed.slice(hash);
     const q = head.indexOf('?');
     if (q === -1) return trimmed;
-    const pairs = head.slice(q + 1).split('&').filter((p) => p && !/^token=/i.test(p));
+    const pairs = head.slice(q + 1).split('&').filter((p) => p && !isTokenKey(p.split('=', 1)[0]));
     return head.slice(0, q) + (pairs.length ? '?' + pairs.join('&') : '') + frag;
   }
+}
+
+// Is this raw query key the `token` param, once percent-decoding is applied?
+// Fails safe: an undecodable key (malformed `%`) is treated AS a token key so a
+// secret can never slip through a decode error.
+function isTokenKey(rawKey: string): boolean {
+  let decoded: string;
+  try { decoded = decodeURIComponent(rawKey.replace(/\+/g, ' ')); } catch { return true; }
+  return decoded.toLowerCase() === 'token';
 }

--- a/site/app/lib/strip-token.ts
+++ b/site/app/lib/strip-token.ts
@@ -1,0 +1,24 @@
+// Remove EVERY `token` query param from what the user pasted, so a rejected or
+// completed attempt never leaves the secret visible in the URL input. Falls
+// back to string surgery when the value isn't a parseable URL (e.g. a bare host
+// or a malformed `:bad` port) — that path must still strip all occurrences.
+export function stripToken(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return raw;
+  const hasScheme = /^[a-z][a-z0-9+.-]*:(?!\d)/i.test(trimmed);
+  try {
+    const u = new URL(hasScheme ? trimmed : `https://${trimmed}`);
+    if (!u.searchParams.has('token')) return raw;
+    u.searchParams.delete('token'); // removes all occurrences
+    return hasScheme ? u.toString() : u.toString().replace(/^https:\/\//, '');
+  } catch {
+    // Split off the query, drop every token=... pair, reattach what's left.
+    const hash = trimmed.indexOf('#');
+    const head = hash === -1 ? trimmed : trimmed.slice(0, hash);
+    const frag = hash === -1 ? '' : trimmed.slice(hash);
+    const q = head.indexOf('?');
+    if (q === -1) return trimmed;
+    const pairs = head.slice(q + 1).split('&').filter((p) => p && !/^token=/i.test(p));
+    return head.slice(0, q) + (pairs.length ? '?' + pairs.join('&') : '') + frag;
+  }
+}

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -2,6 +2,7 @@ import { index, route, type RouteConfig } from '@react-router/dev/routes';
 
 export default [
   index('routes/home.tsx'),
+  route('connect', 'routes/connect.tsx'),
   route('docs/*', 'routes/docs.tsx'),
   route('api/search', 'routes/search.ts'),
 

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { baseOptions } from '@/lib/layout.shared';
 import { submit, onRestore } from '@/lib/connect-state';
+import type { Engine } from '@/lib/hosted-target';
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -16,6 +17,7 @@ export default function Connect() {
   const [url, setUrl] = useState('');
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
+  const [engine, setEngine] = useState<Engine>('claude');
 
   // If the browser restores this page from the BFCache after a Back (e.g. the
   // user opened the WebUI then navigated back), wipe any token that the cached
@@ -29,11 +31,11 @@ export default function Connect() {
   }, [url, token, error]);
 
   const go = () => {
-    const { state, navigate } = submit(url, token, window.location.origin);
+    const { state, navigate } = submit(url, token, window.location.origin, engine);
     setUrl(state.url);
     setToken(state.token);
     setError(state.error);
-    if (navigate) window.location.assign(navigate); // full navigation to the server's own WebUI — no token kept here
+    if (navigate) window.location.assign(navigate); // same-origin hosted route (?server=) — the WebUI binds the token to that server, then scrubs it
   };
 
   return (
@@ -44,6 +46,20 @@ export default function Connect() {
           <p className="text-fd-muted-foreground mb-6 text-center text-sm">
             Start a Macaron server on your machine, then paste its URL here to open its WebUI on this device.
           </p>
+
+          <label className="block text-sm font-medium mb-1">Interface</label>
+          <div className="grid grid-cols-2 gap-2 mb-4">
+            {(['claude', 'codex'] as const).map((e) => (
+              <button
+                key={e}
+                type="button"
+                onClick={() => setEngine(e)}
+                className={`rounded-md border px-3 py-2 text-sm font-medium transition-colors ${engine === e ? 'border-fd-primary bg-fd-primary/10 text-fd-primary' : 'border-fd-border text-fd-muted-foreground hovered:bg-fd-accent'}`}
+              >
+                {e === 'claude' ? 'Claude Code' : 'Codex'}
+              </button>
+            ))}
+          </div>
 
           <label className="block text-sm font-medium mb-1">Server URL</label>
           <input
@@ -80,7 +96,7 @@ export default function Connect() {
           </button>
 
           <p className="text-xs text-fd-muted-foreground mt-4 text-center">
-            This page only redirects to the server you name — your token is never stored here and never leaves your browser except in the link you open.
+            The WebUI runs here and talks directly to the server you name — your token is bound to that server, never stored on this site, and scrubbed from the URL on load.
           </p>
         </div>
       </div>

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -1,0 +1,75 @@
+import type { Route } from './+types/connect';
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { baseOptions } from '@/lib/layout.shared';
+import { buildTarget } from '@/lib/connect-target';
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: 'Connect · Macaron' },
+    { name: 'description', content: 'Open a Macaron WebUI running on your machine or behind a public tunnel.' },
+  ];
+}
+
+export default function Connect() {
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+
+  const go = () => {
+    const r = buildTarget(url, token);
+    if ('error' in r) { setError(r.error); return; }
+    setError('');
+    window.location.assign(r.href); // full navigation to the server's own WebUI — no token kept here
+  };
+
+  return (
+    <HomeLayout {...baseOptions()}>
+      <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
+        <div className="w-full max-w-md text-left">
+          <h1 className="text-xl font-bold mb-1 text-center">Connect to a Macaron server</h1>
+          <p className="text-fd-muted-foreground mb-6 text-center text-sm">
+            Start a Macaron server on your machine, then paste its URL here to open its WebUI on this device.
+          </p>
+
+          <label className="block text-sm font-medium mb-1">Server URL</label>
+          <input
+            className="w-full rounded-md border border-fd-border bg-fd-background px-3 py-2 text-sm mb-1"
+            placeholder="localhost:7878  ·  https://xxxx.trycloudflare.com/?token=…"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') go(); }}
+            autoFocus
+          />
+          <p className="text-xs text-fd-muted-foreground mb-4">
+            Local server defaults: Claude on <code>localhost:7878</code>, Codex on <code>localhost:7979</code>.
+          </p>
+
+          <label className="block text-sm font-medium mb-1">Access token <span className="text-fd-muted-foreground font-normal">(optional if the link already has one)</span></label>
+          <input
+            className="w-full rounded-md border border-fd-border bg-fd-background px-3 py-2 text-sm mb-4"
+            placeholder="token"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') go(); }}
+          />
+
+          {error && <p className="text-sm text-fd-destructive mb-4">{error}</p>}
+
+          <button
+            type="button"
+            className="w-full inline-flex items-center justify-center gap-2 text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
+            onClick={go}
+          >
+            Open WebUI <ArrowRight className="size-4" />
+          </button>
+
+          <p className="text-xs text-fd-muted-foreground mt-4 text-center">
+            This page only redirects to the server you name — your token is never stored here and never leaves your browser except in the link you open.
+          </p>
+        </div>
+      </div>
+    </HomeLayout>
+  );
+}

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { baseOptions } from '@/lib/layout.shared';
 import { submit, onRestore } from '@/lib/connect-state';
-import type { Engine } from '@/lib/hosted-target';
+import { HANDOFF_KEY, type Engine } from '@/lib/hosted-target';
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -31,11 +31,18 @@ export default function Connect() {
   }, [url, token, error]);
 
   const go = () => {
-    const { state, navigate } = submit(url, token, window.location.origin, engine);
+    const { state, navigate, handoff } = submit(url, token, window.location.origin, engine);
     setUrl(state.url);
     setToken(state.token);
     setError(state.error);
-    if (navigate) window.location.assign(navigate); // same-origin hosted route (?server=) — the WebUI binds the token to that server, then scrubs it
+    if (navigate && handoff) {
+      // Stash the {server, token} in sessionStorage (same tab, same origin) and
+      // open the clean hosted route — the credential never rides the URL, so it
+      // can't leak into the document GET / access logs / referrers. The hosted
+      // SPA reads and clears it on load.
+      try { sessionStorage.setItem(HANDOFF_KEY, JSON.stringify(handoff)); } catch { /* private mode */ }
+      window.location.assign(navigate);
+    }
   };
 
   return (
@@ -96,7 +103,11 @@ export default function Connect() {
           </button>
 
           <p className="text-xs text-fd-muted-foreground mt-4 text-center">
-            The WebUI runs here and talks directly to the server you name — your token is bound to that server, never stored on this site, and scrubbed from the URL on load.
+            The WebUI runs here and talks directly to the server you name — your token is bound to that server, never put in the URL, and never stored on this site.
+          </p>
+          <p className="text-xs text-fd-muted-foreground mt-2 text-center">
+            Your server must allow this origin: start it with{' '}
+            <code>MACARON_ALLOWED_ORIGINS={typeof window !== 'undefined' ? window.location.origin : 'https://artifacts.macaron.im'}</code>. It then requires an access token for cross-origin requests — set <code>MACARON_AUTH_TOKEN</code> or copy the one it prints on start.
           </p>
         </div>
       </div>

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -3,24 +3,7 @@ import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { baseOptions } from '@/lib/layout.shared';
-import { buildTarget } from '@/lib/connect-target';
-
-// Remove any `token` query param from what the user pasted, so a rejected or
-// completed attempt never leaves the secret visible in the URL input. Falls
-// back to a regex when the value isn't a parseable URL (e.g. bare host).
-function stripToken(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return raw;
-  try {
-    const u = new URL(/^[a-z][a-z0-9+.-]*:(?!\d)/i.test(trimmed) ? trimmed : `https://${trimmed}`);
-    if (!u.searchParams.has('token')) return raw;
-    u.searchParams.delete('token');
-    // Rebuild without the scheme we may have added, keeping it close to input.
-    return /^[a-z][a-z0-9+.-]*:(?!\d)/i.test(trimmed) ? u.toString() : u.toString().replace(/^https:\/\//, '');
-  } catch {
-    return trimmed.replace(/([?&])token=[^&#]*(&?)/i, (_m, sep, amp) => (amp ? sep : '')).replace(/[?&]$/, '');
-  }
-}
+import { submit, onRestore } from '@/lib/connect-state';
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -39,26 +22,18 @@ export default function Connect() {
   // DOM would otherwise show.
   useEffect(() => {
     const onShow = (e: PageTransitionEvent) => {
-      if (e.persisted) { setToken(''); setUrl((u) => stripToken(u)); }
+      if (e.persisted) { const s = onRestore({ url, token, error }); setUrl(s.url); setToken(s.token); }
     };
     window.addEventListener('pageshow', onShow);
     return () => window.removeEventListener('pageshow', onShow);
-  }, []);
+  }, [url, token, error]);
 
   const go = () => {
-    const r = buildTarget(url, token, window.location.origin);
-    if ('error' in r) {
-      setError(r.error);
-      // Don't leave a token sitting in visible inputs / the DOM on a rejected
-      // attempt: drop the field token and strip any `?token=` from the URL box.
-      setToken('');
-      setUrl((u) => stripToken(u));
-      return;
-    }
-    setError('');
-    setToken('');
-    setUrl((u) => stripToken(u)); // clear before we navigate, so Back/BFCache can't restore a token
-    window.location.assign(r.href); // full navigation to the server's own WebUI — no token kept here
+    const { state, navigate } = submit(url, token, window.location.origin);
+    setUrl(state.url);
+    setToken(state.token);
+    setError(state.error);
+    if (navigate) window.location.assign(navigate); // full navigation to the server's own WebUI — no token kept here
   };
 
   return (

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -1,9 +1,26 @@
 import type { Route } from './+types/connect';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { baseOptions } from '@/lib/layout.shared';
 import { buildTarget } from '@/lib/connect-target';
+
+// Remove any `token` query param from what the user pasted, so a rejected or
+// completed attempt never leaves the secret visible in the URL input. Falls
+// back to a regex when the value isn't a parseable URL (e.g. bare host).
+function stripToken(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return raw;
+  try {
+    const u = new URL(/^[a-z][a-z0-9+.-]*:(?!\d)/i.test(trimmed) ? trimmed : `https://${trimmed}`);
+    if (!u.searchParams.has('token')) return raw;
+    u.searchParams.delete('token');
+    // Rebuild without the scheme we may have added, keeping it close to input.
+    return /^[a-z][a-z0-9+.-]*:(?!\d)/i.test(trimmed) ? u.toString() : u.toString().replace(/^https:\/\//, '');
+  } catch {
+    return trimmed.replace(/([?&])token=[^&#]*(&?)/i, (_m, sep, amp) => (amp ? sep : '')).replace(/[?&]$/, '');
+  }
+}
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -17,10 +34,30 @@ export default function Connect() {
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
 
+  // If the browser restores this page from the BFCache after a Back (e.g. the
+  // user opened the WebUI then navigated back), wipe any token that the cached
+  // DOM would otherwise show.
+  useEffect(() => {
+    const onShow = (e: PageTransitionEvent) => {
+      if (e.persisted) { setToken(''); setUrl((u) => stripToken(u)); }
+    };
+    window.addEventListener('pageshow', onShow);
+    return () => window.removeEventListener('pageshow', onShow);
+  }, []);
+
   const go = () => {
-    const r = buildTarget(url, token);
-    if ('error' in r) { setError(r.error); return; }
+    const r = buildTarget(url, token, window.location.origin);
+    if ('error' in r) {
+      setError(r.error);
+      // Don't leave a token sitting in visible inputs / the DOM on a rejected
+      // attempt: drop the field token and strip any `?token=` from the URL box.
+      setToken('');
+      setUrl((u) => stripToken(u));
+      return;
+    }
     setError('');
+    setToken('');
+    setUrl((u) => stripToken(u)); // clear before we navigate, so Back/BFCache can't restore a token
     window.location.assign(r.href); // full navigation to the server's own WebUI — no token kept here
   };
 
@@ -50,6 +87,8 @@ export default function Connect() {
           <input
             className="w-full rounded-md border border-fd-border bg-fd-background px-3 py-2 text-sm mb-4"
             placeholder="token"
+            type="password"
+            autoComplete="off"
             value={token}
             onChange={(e) => setToken(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') go(); }}

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -83,6 +83,12 @@ export default function Home() {
             >
               Quick Start
             </Link>
+            <Link
+              className="text-sm border rounded-full font-medium px-5 py-2.5 transition-colors hovered:bg-fd-accent hovered:text-fd-accent-foreground"
+              to="/connect"
+            >
+              Connect a Server
+            </Link>
           </div>
         </section>
 

--- a/site/host-webui.mjs
+++ b/site/host-webui.mjs
@@ -1,0 +1,33 @@
+// Build the Macaron WebUI (the /web SPA) and stage it under the docs site's
+// build output at /app, so artifacts.macaron.im can HOST the exact same
+// front-end that `mcc`/`mcx` serve locally — not redirect to a server origin.
+//
+// It reuses /web's existing vite build verbatim (no source fork): the only
+// override is `--base=/app/`, which rewrites every asset URL to /app/assets/*.
+// Both SPA entries ship: index.html (Claude Code) and codex.html (Codex). Their
+// hash router keeps deep links inside the '#' fragment, so no server-side SPA
+// fallback is needed under /app — the two static HTML files are enough.
+//
+// Run after `react-router build`: the docs client lands in build/client, then
+// we drop web/dist alongside it at build/client/app.
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(siteDir, '..');
+const webDir = path.join(repoRoot, 'web');
+const webDist = path.join(webDir, 'dist');
+const target = path.join(siteDir, 'build', 'client', 'app');
+
+console.log('[host-webui] building /web with base=/app/ …');
+execFileSync('pnpm', ['exec', 'vite', 'build', '--base=/app/'], { cwd: webDir, stdio: 'inherit' });
+
+if (!existsSync(path.join(webDist, 'index.html')) || !existsSync(path.join(webDist, 'codex.html'))) {
+  throw new Error('[host-webui] web/dist is missing index.html or codex.html after build');
+}
+
+if (existsSync(target)) rmSync(target, { recursive: true });
+cpSync(webDist, target, { recursive: true });
+console.log(`[host-webui] staged WebUI at ${path.relative(repoRoot, target)} (Claude Code: /app, Codex: /app/codex)`);

--- a/site/host-webui.mjs
+++ b/site/host-webui.mjs
@@ -21,6 +21,16 @@ const webDir = path.join(repoRoot, 'web');
 const webDist = path.join(webDir, 'dist');
 const target = path.join(siteDir, 'build', 'client', 'app');
 
+// Vercel's install step runs only in `site/` (site/vercel.json installCommand),
+// so the app workspace (`web` + its `@macaron/shared` build dep) is uninstalled
+// and unbuilt when we get here. Bootstrap the repo-root workspace ourselves so a
+// clean CI/Vercel build can produce web/dist — the `site` install stays isolated
+// by site/pnpm-workspace.yaml, so this is the only place the app deps come from.
+console.log('[host-webui] installing app workspace deps (web + shared) …');
+execFileSync('pnpm', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
+console.log('[host-webui] building @macaron/shared (web imports it) …');
+execFileSync('pnpm', ['--filter', '@macaron/shared', 'build'], { cwd: repoRoot, stdio: 'inherit' });
+
 console.log('[host-webui] building /web with base=/app/ …');
 execFileSync('pnpm', ['exec', 'vite', 'build', '--base=/app/'], { cwd: webDir, stdio: 'inherit' });
 

--- a/site/host-webui.mjs
+++ b/site/host-webui.mjs
@@ -18,7 +18,11 @@ import { fileURLToPath } from 'node:url';
 const siteDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(siteDir, '..');
 const webDir = path.join(repoRoot, 'web');
-const webDist = path.join(webDir, 'dist');
+// Build the hosted bundle into its OWN outDir, never web/dist. web/dist is the
+// root-based ('/') bundle that local `mcc`/`mcx` serve at `/`; overwriting it
+// with a `/app/`-based build would make the local WebUI request /app/assets/*
+// (404 → blank). Keep the two artifacts fully separate.
+const webDistApp = path.join(webDir, 'dist-app');
 const target = path.join(siteDir, 'build', 'client', 'app');
 
 // Vercel's install step runs only in `site/` (site/vercel.json installCommand),
@@ -31,13 +35,13 @@ execFileSync('pnpm', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: '
 console.log('[host-webui] building @macaron/shared (web imports it) …');
 execFileSync('pnpm', ['--filter', '@macaron/shared', 'build'], { cwd: repoRoot, stdio: 'inherit' });
 
-console.log('[host-webui] building /web with base=/app/ …');
-execFileSync('pnpm', ['exec', 'vite', 'build', '--base=/app/'], { cwd: webDir, stdio: 'inherit' });
+console.log('[host-webui] building /web with base=/app/ into dist-app …');
+execFileSync('pnpm', ['exec', 'vite', 'build', '--base=/app/', '--outDir=dist-app', '--emptyOutDir'], { cwd: webDir, stdio: 'inherit' });
 
-if (!existsSync(path.join(webDist, 'index.html')) || !existsSync(path.join(webDist, 'codex.html'))) {
-  throw new Error('[host-webui] web/dist is missing index.html or codex.html after build');
+if (!existsSync(path.join(webDistApp, 'index.html')) || !existsSync(path.join(webDistApp, 'codex.html'))) {
+  throw new Error('[host-webui] web/dist-app is missing index.html or codex.html after build');
 }
 
 if (existsSync(target)) rmSync(target, { recursive: true });
-cpSync(webDist, target, { recursive: true });
+cpSync(webDistApp, target, { recursive: true });
 console.log(`[host-webui] staged WebUI at ${path.relative(repoRoot, target)} (Claude Code: /app, Codex: /app/codex)`);

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {
-    "build": "react-router build",
+    "build": "react-router build && node host-webui.mjs",
     "dev": "react-router dev",
     "start": "serve ./build/client --config ../../serve.json",
     "typecheck": "react-router typegen && fumadocs-mdx && tsc --noEmit",

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
     "paths": {

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,1 @@
+dist-app/

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -2,15 +2,15 @@
   "name": "Macaron Artifacts",
   "short_name": "Macaron",
   "description": "Macaron Artifacts — GenUI-powered artifacts, workspace, and session management. Presented by Mind Lab.",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": ".",
+  "scope": ".",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#FAF9F5",
   "theme_color": "#C96442",
   "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
-    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
   ]
 }

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -6,6 +6,17 @@
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
 
+// The SW is registered under the app's base path — `/` for a local mcc/mcx
+// server, `/app/` when the docs site hosts the bundle at a subpath. Derive that
+// base from the SW's own scope so icon paths and the cold-start open URL resolve
+// under the app, not the docs root (where `/icons/*` and `/` would 404 / miss).
+const BASE = new URL(self.registration.scope).pathname.replace(/\/$/, ''); // '' or '/app'
+const asset = (p) => BASE + p;
+// The server builds deep links root-relative (`/#/w/:project/s/:sid`) — it can't
+// know the client's hosted base. Rebase such a link under the app so a hosted
+// push opens `/app/#/…`, not the docs root.
+const rebase = (u) => (typeof u === 'string' && u.startsWith('/#') ? asset(u) : u);
+
 self.addEventListener('push', (event) => {
   let payload = {};
   try {
@@ -27,12 +38,12 @@ self.addEventListener('push', (event) => {
       if (active && !payload.requireInteraction) return undefined;
       return self.registration.showNotification(title, {
         body: payload.body || '',
-        icon: '/icons/icon-192.png',
-        badge: '/icons/badge.png',
+        icon: asset('/icons/icon-192.png'),
+        badge: asset('/icons/badge.png'),
         tag: payload.tag,
         renotify: Boolean(payload.tag),
         requireInteraction: Boolean(payload.requireInteraction),
-        data: { url: payload.url || '/' },
+        data: { url: rebase(payload.url) || asset('/') },
       });
     }),
   );
@@ -40,7 +51,7 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = (event.notification.data && event.notification.data.url) || '/';
+  const url = (event.notification.data && event.notification.data.url) || asset('/');
   // The deep link is a hash route (`/#/w/:project/s/:sid`); a client already on
   // that session is the one to focus. Match its hash so a push for session C
   // doesn't yank an unrelated tab showing session B.

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ChevronDown, ChevronRight, Check, Circle, Plus, X, Settings } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { assetUrl } from '../lib/assetBase';
 import { codexApi, type CodexThread, type CodexWorkspace } from './api';
 import {
   getCanvasSids,
@@ -135,7 +136,7 @@ export function CodexSidebar() {
   return (
     <aside className="cx-sidebar">
       <Link className="cx-sb-brand" to="/">
-        <img className="cx-sb-logo" src="/mindlab-symbol.svg" alt="" />
+        <img className="cx-sb-logo" src={assetUrl('/mindlab-symbol.svg')} alt="" />
         <div>
           <div className="cx-sb-brand-name">Macaron Artifacts</div>
           <div className="cx-sb-brand-sub">Presented by Mind Lab</div>

--- a/web/src/codex/api.ts
+++ b/web/src/codex/api.ts
@@ -120,7 +120,7 @@ export const codexApi = {
       body: JSON.stringify(patch),
     }),
   deleteProvider: async (id: string): Promise<PublicCodexSettings> => {
-    const r = await fetch(`/api/codex/config/providers/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const r = await authedFetch(`/api/codex/config/providers/${encodeURIComponent(id)}`, { method: 'DELETE' });
     if (!r.ok) throw new Error(`http ${r.status}`);
     return r.json();
   },

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -12,15 +12,15 @@ import { CodexWorkspace } from './CodexWorkspace';
 import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
-import { clearToken, consumeTokenFromUrl } from '../lib/auth';
-import { consumeServerFromUrl } from '../lib/apiBase';
+import { consumeTokenFromUrl, consumeHandoff } from '../lib/auth';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
-// Pick up a ?server=... then ?token=... bootstrap from a shared link before
-// anything fetches. clearToken lets a server switch drop a stale credential.
-consumeServerFromUrl(clearToken);
+// Pick up the hosted-mode handoff (docs connect page stashed {server, token}
+// same-tab in sessionStorage), then a same-origin ?token= share link. The
+// handoff binds the token to its server origin; nothing secret rides the URL.
+consumeHandoff();
 consumeTokenFromUrl();
 
 const router = createHashRouter([

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -13,11 +13,14 @@ import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
 import { consumeTokenFromUrl } from '../lib/auth';
+import { consumeServerFromUrl } from '../lib/apiBase';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
-// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+// Pick up a ?server=... then ?token=... bootstrap from a shared link before
+// anything fetches.
+consumeServerFromUrl();
 consumeTokenFromUrl();
 
 const router = createHashRouter([

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -12,16 +12,15 @@ import { CodexWorkspace } from './CodexWorkspace';
 import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
-import { consumeTokenFromUrl, consumeHandoff } from '../lib/auth';
+import { consumeHandoff } from '../lib/auth';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
 // Pick up the hosted-mode handoff (docs connect page stashed {server, token}
-// same-tab in sessionStorage), then a same-origin ?token= share link. The
-// handoff binds the token to its server origin; nothing secret rides the URL.
+// same-tab in sessionStorage). The handoff binds the token to its server origin;
+// nothing secret rides the URL.
 consumeHandoff();
-consumeTokenFromUrl();
 
 const router = createHashRouter([
   {

--- a/web/src/codex/main.tsx
+++ b/web/src/codex/main.tsx
@@ -12,15 +12,15 @@ import { CodexWorkspace } from './CodexWorkspace';
 import { AuthGate } from '../components/AuthGate';
 import { ToastProvider } from '../components/Toast';
 import { ConfirmProvider } from '../components/Confirm';
-import { consumeTokenFromUrl } from '../lib/auth';
+import { clearToken, consumeTokenFromUrl } from '../lib/auth';
 import { consumeServerFromUrl } from '../lib/apiBase';
 import { registerServiceWorker } from '../lib/pwa';
 import './styles.css';
 import '../chat-code.css';
 
 // Pick up a ?server=... then ?token=... bootstrap from a shared link before
-// anything fetches.
-consumeServerFromUrl();
+// anything fetches. clearToken lets a server switch drop a stale credential.
+consumeServerFromUrl(clearToken);
 consumeTokenFromUrl();
 
 const router = createHashRouter([

--- a/web/src/components/AuthGate.tsx
+++ b/web/src/components/AuthGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode, type CSSProperties } from 'react';
 import type { AuthStatusResponse } from '@macaron/shared';
-import { getToken, setToken } from '../lib/auth';
+import { authedFetch, getToken, setToken } from '../lib/auth';
 
 // Gates the app behind the server's shared token when it's reachable from the
 // network. On mount it asks the server whether this caller must authenticate;
@@ -18,7 +18,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   async function check() {
     try {
-      const r = await fetch('/api/auth/status', { headers: getToken() ? { Authorization: `Bearer ${getToken()}` } : {} });
+      const r = await authedFetch('/api/auth/status');
       const j = (await r.json()) as AuthStatusResponse;
       setPhase(j.required ? 'needed' : 'ok');
     } catch {
@@ -42,7 +42,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
     setBusy(true);
     setError('');
     try {
-      const r = await fetch('/api/auth/login', {
+      const r = await authedFetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: token.trim() }),

--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -12,6 +12,8 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '../lib/api';
+import { getApiBase, resolveApiUrl } from '../lib/apiBase';
+import { getToken } from '../lib/auth';
 import { useToast } from './Toast';
 
 // Monaco is heavy — only load it when the user flips to Edit mode.
@@ -115,8 +117,11 @@ export function FileTile({
     if (isImage) {
       // Image preview via authed GET — reuse the read endpoint's raw path.
       // Server returns text for text files; for images we use an <img> with
-      // a proxied URL so the browser handles decoding.
-      const src = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
+      // a proxied URL so the browser handles decoding. An <img> can't set the
+      // Authorization header, so in cross-origin hosted mode we ride the token
+      // via the query param the server also accepts.
+      const raw = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
+      const src = getApiBase() && getToken() ? resolveApiUrl(`${raw}&token=${encodeURIComponent(getToken())}`) : resolveApiUrl(raw);
       return (
         <div className="ft-image-wrap">
           <img src={src} alt={basenameOf(path)} />

--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -12,7 +12,6 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '../lib/api';
-import { resolveApiUrl } from '../lib/apiBase';
 import { authedFetch } from '../lib/auth';
 import { useToast } from './Toast';
 
@@ -67,7 +66,7 @@ export function FileTile({
     let url = '';
     let cancelled = false;
     const raw = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
-    authedFetch(resolveApiUrl(raw))
+    authedFetch(raw)
       .then((r) => (r.ok ? r.blob() : Promise.reject(new Error(`http ${r.status}`))))
       .then((b) => { if (cancelled) return; url = URL.createObjectURL(b); setImageUrl(url); })
       .catch(() => { if (!cancelled) setImageUrl(''); });

--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -12,8 +12,8 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '../lib/api';
-import { getApiBase, resolveApiUrl } from '../lib/apiBase';
-import { getToken } from '../lib/auth';
+import { resolveApiUrl } from '../lib/apiBase';
+import { authedFetch } from '../lib/auth';
 import { useToast } from './Toast';
 
 // Monaco is heavy — only load it when the user flips to Edit mode.
@@ -51,12 +51,28 @@ export function FileTile({
   const [loading, setLoading] = useState(true);
   const [mode, setMode] = useState<'preview' | 'split' | 'edit'>('preview');
   const [saving, setSaving] = useState(false);
+  const [imageUrl, setImageUrl] = useState<string>('');
   const dirty = content !== original;
 
   const ext = extOf(path);
   const isImage = IMAGE_EXTS.has(ext);
   const isMarkdown = MARKDOWN_EXTS.has(ext);
   const isBinary = BINARY_EXTS.has(ext);
+
+  // Images load through authedFetch (Authorization header) into a blob object
+  // URL — an <img src> can't set headers, and the old `?token=` query leaked the
+  // credential into logs/referrers. Revoke the previous URL on change/unmount.
+  useEffect(() => {
+    if (!isImage) return;
+    let url = '';
+    let cancelled = false;
+    const raw = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
+    authedFetch(resolveApiUrl(raw))
+      .then((r) => (r.ok ? r.blob() : Promise.reject(new Error(`http ${r.status}`))))
+      .then((b) => { if (cancelled) return; url = URL.createObjectURL(b); setImageUrl(url); })
+      .catch(() => { if (!cancelled) setImageUrl(''); });
+    return () => { cancelled = true; if (url) URL.revokeObjectURL(url); };
+  }, [isImage, project, path, refreshKey]);
 
   const load = useCallback(() => {
     if (isImage || isBinary) {
@@ -115,16 +131,12 @@ export function FileTile({
 
   const previewNode = useMemo(() => {
     if (isImage) {
-      // Image preview via authed GET — reuse the read endpoint's raw path.
-      // Server returns text for text files; for images we use an <img> with
-      // a proxied URL so the browser handles decoding. An <img> can't set the
-      // Authorization header, so in cross-origin hosted mode we ride the token
-      // via the query param the server also accepts.
-      const raw = `/api/files/${encodeURIComponent(project)}/raw?path=${encodeURIComponent(path)}`;
-      const src = getApiBase() && getToken() ? resolveApiUrl(`${raw}&token=${encodeURIComponent(getToken())}`) : resolveApiUrl(raw);
+      // Image preview via authed GET → blob object URL (see the effect above);
+      // an <img> can't send the Authorization header, so we can't ride the token
+      // on the URL. While the blob loads, imageUrl is empty.
       return (
         <div className="ft-image-wrap">
-          <img src={src} alt={basenameOf(path)} />
+          {imageUrl ? <img src={imageUrl} alt={basenameOf(path)} /> : <div className="ft-placeholder">Loading…</div>}
         </div>
       );
     }
@@ -143,7 +155,7 @@ export function FileTile({
     }
     // Plain preview — monospace, no syntax highlight (CodeMirror is only in Edit).
     return <pre className="ft-preview code">{content}</pre>;
-  }, [isImage, isBinary, isMarkdown, error, loading, tooBig, content, project, path]);
+  }, [isImage, isBinary, isMarkdown, error, loading, tooBig, content, project, path, imageUrl]);
 
   const editorNode = error ? (
     <div className="ft-placeholder err">Can't read: {error}</div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { getApiBase } from '../lib/apiBase';
 import { assetUrl } from '../lib/assetBase';
 import {
   Check,
@@ -249,10 +250,14 @@ export function Sidebar() {
           onClick: async () => {
             try {
               const { token } = await api.createShare(w.project, s.sessionId);
-              // Build from the browser's origin + app base so it works over
-              // LAN/tunnel and under the hosted /app/ subpath, not just the
-              // server's 127.0.0.1 root bind.
-              const url = `${window.location.origin}${assetUrl('/')}#/share/${token}`;
+              // A recipient needs an origin that serves the UI AND answers
+              // /api/public: hosted mode (api base set) must use the server's
+              // own origin — a docs-origin /app link has no server bound and
+              // can never resolve. Local/tunnel keeps the browser's origin +
+              // app base so it works over LAN/tunnel, not just the server's
+              // 127.0.0.1 root bind.
+              const server = getApiBase();
+              const url = server ? `${server}/#/share/${token}` : `${window.location.origin}${assetUrl('/')}#/share/${token}`;
               await navigator.clipboard.writeText(url);
               toast('share link copied');
             } catch (err) {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { assetUrl } from '../lib/assetBase';
 import {
   Check,
   ChevronDown,
@@ -342,7 +343,7 @@ export function Sidebar() {
   return (
     <aside className="sidebar-v2">
       <Link className="sb-brand" to="/">
-        <img className="sb-logo" src="/mindlab-symbol.svg" alt="" />
+        <img className="sb-logo" src={assetUrl('/mindlab-symbol.svg')} alt="" />
         <div>
           <div className="sb-brand-name">Macaron Artifacts</div>
           <div className="sb-brand-sub">Presented by Mind Lab</div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -249,9 +249,10 @@ export function Sidebar() {
           onClick: async () => {
             try {
               const { token } = await api.createShare(w.project, s.sessionId);
-              // Build the URL from the browser's own origin so it works over
-              // LAN/tunnel, not just the server's 127.0.0.1 bind.
-              const url = `${window.location.origin}/#/share/${token}`;
+              // Build from the browser's origin + app base so it works over
+              // LAN/tunnel and under the hosted /app/ subpath, not just the
+              // server's 127.0.0.1 root bind.
+              const url = `${window.location.origin}${assetUrl('/')}#/share/${token}`;
               await navigator.clipboard.writeText(url);
               toast('share link copied');
             } catch (err) {

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -8,6 +8,7 @@ import {
   sendTerminalInput,
   sendTerminalResize,
 } from '../lib/terminal';
+import { getApiBase } from '../lib/apiBase';
 import { useTheme, type ResolvedTheme } from '../lib/theme';
 
 // Terminal palette per resolved theme. xterm's `theme` is a plain JS object
@@ -117,7 +118,7 @@ export function Terminal({ project, sid, focused }: { project: string; sid: stri
 
       // history = full snapshot (reset+write, idempotent on reconnect);
       // output = incremental chunk; exit = dim footer.
-      es = new EventSource(terminalStreamUrl(project, sid, cols, rows));
+      es = new EventSource(terminalStreamUrl(project, sid, cols, rows), getApiBase() ? { withCredentials: true } : undefined);
       es.onmessage = (e) => {
         if (e.data === '[DONE]') { es?.close(); return; }
         let msg: { type?: string; data?: string; exitCode?: number; error?: string };

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -128,7 +128,7 @@ export function Terminal({ project, sid, focused }: { project: string; sid: stri
         else if (msg.type === 'error') term?.write(`\r\n\x1b[31m${msg.error || 'error'}\x1b[0m\r\n`);
       });
       // Reconnects are useful while the PTY is alive; exit/[DONE] are terminal
-      // states, so close the EventSource above to avoid respawning a shell.
+      // states, so close the stream above to avoid respawning a shell.
 
       const doFit = () => {
         cancelAnimationFrame(raf);

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -8,7 +8,7 @@ import {
   sendTerminalInput,
   sendTerminalResize,
 } from '../lib/terminal';
-import { getApiBase } from '../lib/apiBase';
+import { openEventStream, type EventStreamHandle } from '../lib/eventStream';
 import { useTheme, type ResolvedTheme } from '../lib/theme';
 
 // Terminal palette per resolved theme. xterm's `theme` is a plain JS object
@@ -90,7 +90,7 @@ export function Terminal({ project, sid, focused }: { project: string; sid: stri
     let disposed = false;
     let raf = 0;
     let ro: ResizeObserver | null = null;
-    let es: EventSource | null = null;
+    let es: EventStreamHandle | null = null;
     let term: XTerm | null = null;
 
     void (async () => {
@@ -118,16 +118,15 @@ export function Terminal({ project, sid, focused }: { project: string; sid: stri
 
       // history = full snapshot (reset+write, idempotent on reconnect);
       // output = incremental chunk; exit = dim footer.
-      es = new EventSource(terminalStreamUrl(project, sid, cols, rows), getApiBase() ? { withCredentials: true } : undefined);
-      es.onmessage = (e) => {
-        if (e.data === '[DONE]') { es?.close(); return; }
+      es = openEventStream(terminalStreamUrl(project, sid, cols, rows), (data) => {
+        if (data === '[DONE]') { es?.close(); return; }
         let msg: { type?: string; data?: string; exitCode?: number; error?: string };
-        try { msg = JSON.parse(e.data); } catch { return; }
+        try { msg = JSON.parse(data); } catch { return; }
         if (msg.type === 'history') { term?.reset(); if (msg.data) term?.write(msg.data); }
         else if (msg.type === 'output') term?.write(msg.data || '');
         else if (msg.type === 'exit') { term?.write(`\r\n\x1b[2m[process exited${msg.exitCode ? ` (${msg.exitCode})` : ''}]\x1b[0m\r\n`); es?.close(); }
         else if (msg.type === 'error') term?.write(`\r\n\x1b[31m${msg.error || 'error'}\x1b[0m\r\n`);
-      };
+      });
       // Reconnects are useful while the PTY is alive; exit/[DONE] are terminal
       // states, so close the EventSource above to avoid respawning a shell.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -283,7 +283,7 @@ export const api = {
   configFiles: () => getJSON<{ files: ConfigFileMeta[] }>('/api/config-files'),
   configFile: (id: ConfigFileId) => getJSON<ConfigFile>(`/api/config-files/${id}`),
   saveConfigFile: async (id: ConfigFileId, content: string): Promise<ConfigFile> => {
-    const r = await fetch(`/api/config-files/${id}`, {
+    const r = await authedFetch(`/api/config-files/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content }),

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -62,4 +62,3 @@ export function resolveApiUrl(input: string): string {
   if (!input.startsWith('/api') && !input.startsWith('/relay')) return input;
   return base + input;
 }
-

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -1,0 +1,74 @@
+// Where the WebUI sends its /api and /relay calls. Normally empty: the UI is
+// served by the same server it talks to, so every path stays same-origin (the
+// historical behavior). When the UI is hosted on a *different* origin (e.g. the
+// docs site connecting to a user's local `mcc`/`mcx`), the connect flow records
+// that server's origin here and we retarget every API call to it.
+//
+// Only `/api` and `/relay` paths are rewritten — asset/SPA URLs stay local. The
+// base is an origin only (scheme://host[:port]); we reject anything with a path
+// so a stored value can't silently reroute non-API URLs.
+
+const KEY = 'macaron_api_base';
+
+let cached: string | null = null;
+
+function normalize(raw: string): string {
+  const u = new URL(raw); // throws on garbage → caller falls back to same-origin
+  if (u.pathname !== '/' && u.pathname !== '') throw new Error('api base must be an origin, no path');
+  return u.origin;
+}
+
+export function getApiBase(): string {
+  if (cached !== null) return cached;
+  try { cached = localStorage.getItem(KEY) || ''; } catch { cached = ''; }
+  return cached;
+}
+
+export function setApiBase(origin: string): void {
+  const clean = normalize(origin);
+  cached = clean;
+  try { localStorage.setItem(KEY, clean); } catch { /* private mode */ }
+}
+
+export function clearApiBase(): void {
+  cached = '';
+  try { localStorage.removeItem(KEY); } catch { /* private mode */ }
+}
+
+// Loopback / private-range hosts are reached over Chrome's Local Network Access
+// path; annotating the fetch with targetAddressSpace lets the browser skip the
+// mixed-content pre-check (see server CORS + LNA headers). Best-effort: only
+// loopback literals/names get flagged, everything else is left to normal rules.
+export function isLoopbackBase(): boolean {
+  const b = getApiBase();
+  if (!b) return false;
+  try {
+    const h = new URL(b).hostname.replace(/\.$/, '').toLowerCase();
+    return h === 'localhost' || h.endsWith('.localhost') || h === '127.0.0.1' || h.startsWith('127.') || h === '[::1]' || h === '::1';
+  } catch { return false; }
+}
+
+// Retarget an /api or /relay path at the configured server. Absolute URLs and
+// non-API paths pass through untouched.
+export function resolveApiUrl(input: string): string {
+  const base = getApiBase();
+  if (!base) return input;
+  if (!input.startsWith('/api') && !input.startsWith('/relay')) return input;
+  return base + input;
+}
+
+// Connect entry for hosted mode: a `?server=<origin>` query (paired with the
+// existing `?token=`) points the UI at a remote server, then we strip it from
+// the URL so it doesn't linger in history. Same-origin loads have no `?server=`
+// and keep the empty base. Call once at startup BEFORE consumeTokenFromUrl.
+export function consumeServerFromUrl(): void {
+  try {
+    const url = new URL(window.location.href);
+    const server = url.searchParams.get('server');
+    if (server === null) return;
+    if (server === '') clearApiBase();
+    else setApiBase(server); // throws on garbage/with-path → left unset, connect fails loudly
+    url.searchParams.delete('server');
+    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+  } catch { /* non-browser / malformed URL / bad server origin */ }
+}

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -7,6 +7,12 @@
 // Only `/api` and `/relay` paths are rewritten — asset/SPA URLs stay local. The
 // base is an origin only (scheme://host[:port]); we reject anything with a path
 // so a stored value can't silently reroute non-API URLs.
+//
+// The base lives in sessionStorage, NOT localStorage: it is per-tab. Two tabs
+// hosted on the same docs origin can point at different servers without one
+// clobbering the other's target (the localStorage-backed old design let Tab B's
+// server overwrite Tab A's, so Tab A then sent its token to the wrong host). The
+// token is keyed by this base in auth.ts, so {origin, token} bind atomically.
 
 const KEY = 'macaron_api_base';
 
@@ -20,19 +26,19 @@ function normalize(raw: string): string {
 
 export function getApiBase(): string {
   if (cached !== null) return cached;
-  try { cached = localStorage.getItem(KEY) || ''; } catch { cached = ''; }
+  try { cached = sessionStorage.getItem(KEY) || ''; } catch { cached = ''; }
   return cached;
 }
 
 export function setApiBase(origin: string): void {
   const clean = normalize(origin);
   cached = clean;
-  try { localStorage.setItem(KEY, clean); } catch { /* private mode */ }
+  try { sessionStorage.setItem(KEY, clean); } catch { /* private mode */ }
 }
 
 export function clearApiBase(): void {
   cached = '';
-  try { localStorage.removeItem(KEY); } catch { /* private mode */ }
+  try { sessionStorage.removeItem(KEY); } catch { /* private mode */ }
 }
 
 // Loopback / private-range hosts are reached over Chrome's Local Network Access
@@ -57,34 +63,3 @@ export function resolveApiUrl(input: string): string {
   return base + input;
 }
 
-// Connect entry for hosted mode: a `?server=<origin>` query (paired with the
-// existing `?token=`) points the UI at a remote server, then we strip it from
-// the URL so it doesn't linger in history. Same-origin loads have no `?server=`
-// and keep the empty base. Call once at startup BEFORE consumeTokenFromUrl.
-//
-// Credentials are bound to the origin: whenever `?server=` is present we drop
-// any previously stored token unless the SAME URL carries a fresh `?token=`.
-// Otherwise a token minted for server A would be sent as the bearer — and into
-// `/api/events?token=` — of an attacker-supplied server B. `clearToken` is
-// passed in (not imported) to avoid an apiBase↔auth import cycle. The URL is
-// scrubbed even when the server value is malformed, so a bad `?server=` can't
-// linger in history either.
-export function consumeServerFromUrl(clearToken?: () => void): void {
-  try {
-    const url = new URL(window.location.href);
-    const server = url.searchParams.get('server');
-    if (server === null) return;
-    // A `?server=` switch invalidates any stored credential unless this same
-    // load also brings a matching token. Clear first; consumeTokenFromUrl runs
-    // next and re-sets the token when `?token=` is present.
-    if (!url.searchParams.get('token')) clearToken?.();
-    try {
-      if (server === '') clearApiBase();
-      else setApiBase(server); // throws on garbage/with-path
-    } finally {
-      // Always scrub, even if setApiBase threw on a malformed origin.
-      url.searchParams.delete('server');
-      window.history.replaceState(null, '', url.pathname + url.search + url.hash);
-    }
-  } catch { /* non-browser / malformed URL */ }
-}

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -61,14 +61,30 @@ export function resolveApiUrl(input: string): string {
 // existing `?token=`) points the UI at a remote server, then we strip it from
 // the URL so it doesn't linger in history. Same-origin loads have no `?server=`
 // and keep the empty base. Call once at startup BEFORE consumeTokenFromUrl.
-export function consumeServerFromUrl(): void {
+//
+// Credentials are bound to the origin: whenever `?server=` is present we drop
+// any previously stored token unless the SAME URL carries a fresh `?token=`.
+// Otherwise a token minted for server A would be sent as the bearer — and into
+// `/api/events?token=` — of an attacker-supplied server B. `clearToken` is
+// passed in (not imported) to avoid an apiBase↔auth import cycle. The URL is
+// scrubbed even when the server value is malformed, so a bad `?server=` can't
+// linger in history either.
+export function consumeServerFromUrl(clearToken?: () => void): void {
   try {
     const url = new URL(window.location.href);
     const server = url.searchParams.get('server');
     if (server === null) return;
-    if (server === '') clearApiBase();
-    else setApiBase(server); // throws on garbage/with-path → left unset, connect fails loudly
-    url.searchParams.delete('server');
-    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
-  } catch { /* non-browser / malformed URL / bad server origin */ }
+    // A `?server=` switch invalidates any stored credential unless this same
+    // load also brings a matching token. Clear first; consumeTokenFromUrl runs
+    // next and re-sets the token when `?token=` is present.
+    if (!url.searchParams.get('token')) clearToken?.();
+    try {
+      if (server === '') clearApiBase();
+      else setApiBase(server); // throws on garbage/with-path
+    } finally {
+      // Always scrub, even if setApiBase threw on a malformed origin.
+      url.searchParams.delete('server');
+      window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+    }
+  } catch { /* non-browser / malformed URL */ }
 }

--- a/web/src/lib/assetBase.ts
+++ b/web/src/lib/assetBase.ts
@@ -1,0 +1,10 @@
+// Resolve a public/ asset path against the Vite base so it works both when the
+// server serves the SPA at its own root (BASE_URL '/') and when the docs site
+// HOSTS the bundle under /app/ (BASE_URL '/app/'). Vite rewrites bundled asset
+// URLs automatically, but runtime string refs (import-map shims, the service
+// worker, logos, the manifest) don't go through the bundler — they'd 404 under
+// /app without this. Pass a root-relative path like '/genui-shim/react.mjs'.
+export function assetUrl(path: string): string {
+  const base = import.meta.env.BASE_URL; // '/' locally, '/app/' hosted
+  return base.replace(/\/$/, '') + path;
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -31,11 +31,6 @@ export function clearToken(): void {
   try { sessionStorage.removeItem(tokenKey()); } catch { /* private mode */ }
 }
 
-export function authHeaders(): Record<string, string> {
-  const t = getToken();
-  return t ? { Authorization: `Bearer ${t}` } : {};
-}
-
 // fetch wrapper that injects the token and re-gates the UI on 401 (expired /
 // wrong token). Every call site that hits our own server uses this.
 export async function authedFetch(input: string, init: RequestInit = {}): Promise<Response> {

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -4,6 +4,8 @@
 // the browser EventSource), so a single Authorization header covers plain
 // requests and streaming reads alike — no cookie / query-token escape hatch.
 
+import { getApiBase, isLoopbackBase, resolveApiUrl } from './apiBase';
+
 const KEY = 'macaron_auth_token';
 
 export function getToken(): string {
@@ -29,7 +31,15 @@ export async function authedFetch(input: string, init: RequestInit = {}): Promis
   const headers = new Headers(init.headers);
   const t = getToken();
   if (t) headers.set('Authorization', `Bearer ${t}`);
-  const resp = await fetch(input, { ...init, headers });
+  const url = resolveApiUrl(input);
+  const extra: RequestInit = {};
+  // Cross-origin hosted mode: the browser needs credentials mode explicit, and
+  // loopback targets want the LNA hint so Chrome skips the mixed-content check.
+  if (getApiBase()) {
+    extra.mode = 'cors';
+    if (isLoopbackBase()) (extra as { targetAddressSpace?: string }).targetAddressSpace = 'loopback';
+  }
+  const resp = await fetch(url, { ...init, ...extra, headers });
   if (resp.status === 401) {
     clearToken();
     window.dispatchEvent(new Event('macaron:auth-required'));

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -4,20 +4,29 @@
 // the browser EventSource), so a single Authorization header covers plain
 // requests and streaming reads alike — no cookie / query-token escape hatch.
 
-import { getApiBase, isLoopbackBase, resolveApiUrl } from './apiBase';
+import { getApiBase, isLoopbackBase, resolveApiUrl, setApiBase, clearApiBase } from './apiBase';
 
+// The token is keyed by the server origin it was minted for, so a token bound to
+// server A can never be sent to server B — even with two hosted tabs sharing one
+// localStorage. Same-origin (empty base) keeps the historical bare key so an
+// existing local login survives the upgrade. See the P0-3 two-realm regression.
 const KEY = 'macaron_auth_token';
+function tokenKey(): string { const b = getApiBase(); return b ? `${KEY}::${b}` : KEY; }
+
+// sessionStorage key the docs connect page WRITES and we READ once on load.
+// Must stay identical to HANDOFF_KEY in site/app/lib/hosted-target.ts.
+const HANDOFF_KEY = 'macaron_connect_handoff';
 
 export function getToken(): string {
-  try { return localStorage.getItem(KEY) || ''; } catch { return ''; }
+  try { return localStorage.getItem(tokenKey()) || ''; } catch { return ''; }
 }
 
 export function setToken(token: string): void {
-  try { localStorage.setItem(KEY, token); } catch { /* private mode */ }
+  try { localStorage.setItem(tokenKey(), token); } catch { /* private mode */ }
 }
 
 export function clearToken(): void {
-  try { localStorage.removeItem(KEY); } catch { /* private mode */ }
+  try { localStorage.removeItem(tokenKey()); } catch { /* private mode */ }
 }
 
 export function authHeaders(): Record<string, string> {
@@ -58,4 +67,27 @@ export function consumeTokenFromUrl(): void {
     url.searchParams.delete('token');
     window.history.replaceState(null, '', url.pathname + url.search + url.hash);
   } catch { /* non-browser / malformed URL */ }
+}
+
+// Hosted-mode bootstrap. The docs connect page validated the server target and
+// stashed {server, token} in sessionStorage (same tab, same origin) — never on
+// the URL, so the credential can't leak into the document GET / logs / referrers.
+// Read it ONCE, bind the api base FIRST so the token is keyed to that origin,
+// then store the token atomically with it, and delete the handoff.
+//
+// Only this same-tab handoff is trusted: a hand-crafted `/app?server=<attacker>`
+// carries no handoff and is ignored, so the connect page's scheme / self-origin
+// / public-HTTP validation cannot be bypassed by a direct link. Call once at
+// startup, before anything fetches. No handoff → same-origin local mode, base
+// stays empty and any existing local login survives.
+export function consumeHandoff(): void {
+  let raw: string | null = null;
+  try { raw = sessionStorage.getItem(HANDOFF_KEY); sessionStorage.removeItem(HANDOFF_KEY); } catch { return; }
+  if (!raw) return;
+  try {
+    const { server, token } = JSON.parse(raw) as { server?: string; token?: string };
+    if (!server) return;
+    setApiBase(server);                       // bind origin FIRST → token keys to it
+    if (token) setToken(token); else clearToken();
+  } catch { clearApiBase(); }                 // malformed handoff → no half-bound base
 }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -7,9 +7,11 @@
 import { getApiBase, isLoopbackBase, resolveApiUrl, setApiBase, clearApiBase } from './apiBase';
 
 // The token is keyed by the server origin it was minted for, so a token bound to
-// server A can never be sent to server B — even with two hosted tabs sharing one
-// localStorage. Same-origin (empty base) keeps the historical bare key so an
-// existing local login survives the upgrade. See the P0-3 two-realm regression.
+// server A can never be sent to server B. It lives in sessionStorage — per browser
+// tab, not shared like localStorage — so two hosted tabs each bound to the SAME
+// server keep their OWN tokens instead of the later tab clobbering the earlier
+// one. Same-origin (empty base) keeps the historical bare key. See the two-realm
+// and same-server dual-tab regressions.
 const KEY = 'macaron_auth_token';
 function tokenKey(): string { const b = getApiBase(); return b ? `${KEY}::${b}` : KEY; }
 
@@ -18,15 +20,15 @@ function tokenKey(): string { const b = getApiBase(); return b ? `${KEY}::${b}` 
 const HANDOFF_KEY = 'macaron_connect_handoff';
 
 export function getToken(): string {
-  try { return localStorage.getItem(tokenKey()) || ''; } catch { return ''; }
+  try { return sessionStorage.getItem(tokenKey()) || ''; } catch { return ''; }
 }
 
 export function setToken(token: string): void {
-  try { localStorage.setItem(tokenKey(), token); } catch { /* private mode */ }
+  try { sessionStorage.setItem(tokenKey(), token); } catch { /* private mode */ }
 }
 
 export function clearToken(): void {
-  try { localStorage.removeItem(tokenKey()); } catch { /* private mode */ }
+  try { sessionStorage.removeItem(tokenKey()); } catch { /* private mode */ }
 }
 
 export function authHeaders(): Record<string, string> {
@@ -54,19 +56,6 @@ export async function authedFetch(input: string, init: RequestInit = {}): Promis
     window.dispatchEvent(new Event('macaron:auth-required'));
   }
   return resp;
-}
-
-// Bootstrap from a shared link: ?token=... → store it, then strip it from the
-// URL so it doesn't linger in history / referrers. Call once at startup.
-export function consumeTokenFromUrl(): void {
-  try {
-    const url = new URL(window.location.href);
-    const t = url.searchParams.get('token');
-    if (!t) return;
-    setToken(t);
-    url.searchParams.delete('token');
-    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
-  } catch { /* non-browser / malformed URL */ }
 }
 
 // Hosted-mode bootstrap. The docs connect page validated the server target and

--- a/web/src/lib/eventStream.ts
+++ b/web/src/lib/eventStream.ts
@@ -1,0 +1,46 @@
+// A reconnecting SSE client built on fetch()+getReader() instead of the browser
+// EventSource. EventSource can't set request headers, which forced the token
+// onto the URL as `?token=` — where it leaks into proxy / access logs and
+// referrers. fetch carries the token in an Authorization header (via authedFetch)
+// and keeps the query clean, at the cost of re-implementing EventSource's
+// auto-reconnect, which we do with a simple backoff loop.
+import { authedFetch } from './auth';
+
+export type EventStreamHandle = { close: () => void };
+
+// Open `url` and deliver each SSE `data:` payload to onMessage until close().
+// Reconnects with a fixed short delay on any drop (mirrors EventSource), unless
+// closed. onMessage receives the raw data string (same as EventSource's e.data).
+export function openEventStream(url: string, onMessage: (data: string) => void): EventStreamHandle {
+  let closed = false;
+  let controller: AbortController | null = null;
+
+  const run = async () => {
+    while (!closed) {
+      controller = new AbortController();
+      try {
+        const resp = await authedFetch(url, { headers: { Accept: 'text/event-stream' }, signal: controller.signal });
+        if (!resp.ok || !resp.body) throw new Error(`http ${resp.status}`);
+        const reader = resp.body.getReader();
+        const dec = new TextDecoder();
+        let buf = '';
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += dec.decode(value, { stream: true });
+          const events = buf.split(/\r?\n\r?\n/);
+          buf = events.pop() || '';
+          for (const ev of events) {
+            const data = ev.split(/\r?\n/).filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trimStart()).join('\n');
+            if (data) onMessage(data);
+          }
+        }
+      } catch { /* fall through to reconnect */ }
+      if (closed) return;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  };
+  void run();
+
+  return { close: () => { closed = true; controller?.abort(); } };
+}

--- a/web/src/lib/pwa.ts
+++ b/web/src/lib/pwa.ts
@@ -6,8 +6,10 @@
 // installed PWA) degrades to "unsupported" rather than throwing.
 
 import { authedFetch } from './auth';
+import { assetUrl } from './assetBase';
 
-const SW_URL = '/sw.js';
+// Base-relative so the SW resolves under /app/ when hosted, not just at root.
+const SW_URL = assetUrl('/sw.js');
 
 export function pushSupported(): boolean {
   return (

--- a/web/src/lib/pwa.ts
+++ b/web/src/lib/pwa.ts
@@ -5,6 +5,8 @@
 // browser, an insecure origin, or an iOS Safari tab (where push needs an
 // installed PWA) degrades to "unsupported" rather than throwing.
 
+import { authedFetch } from './auth';
+
 const SW_URL = '/sw.js';
 
 export function pushSupported(): boolean {
@@ -77,7 +79,7 @@ export async function subscribeToPush(): Promise<PushState> {
   if (!pushSupported()) return 'unsupported';
   const perm = await Notification.requestPermission();
   if (perm !== 'granted') return perm === 'denied' ? 'denied' : 'unsubscribed';
-  const vapidRes = await fetch('/api/push/vapid-public-key');
+  const vapidRes = await authedFetch('/api/push/vapid-public-key');
   if (!vapidRes.ok) throw new Error(`vapid key fetch failed (${vapidRes.status})`);
   const { publicKey } = await vapidRes.json();
   const appServerKey = urlBase64ToUint8Array(publicKey);
@@ -92,7 +94,7 @@ export async function subscribeToPush(): Promise<PushState> {
     sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: appServerKey });
   }
   const json = sub.toJSON() as { endpoint: string; keys: { p256dh: string; auth: string } };
-  const res = await fetch('/api/push/subscribe', {
+  const res = await authedFetch('/api/push/subscribe', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
@@ -107,7 +109,7 @@ export async function unsubscribeFromPush(): Promise<PushState> {
     const reg = await navigator.serviceWorker.ready;
     const sub = await reg.pushManager.getSubscription();
     if (sub) {
-      await fetch('/api/push/unsubscribe', {
+      await authedFetch('/api/push/unsubscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ endpoint: sub.endpoint }),

--- a/web/src/lib/systemEvents.ts
+++ b/web/src/lib/systemEvents.ts
@@ -7,6 +7,7 @@
 
 import type { SystemEvent } from '@macaron/shared';
 import { getToken } from './auth';
+import { getApiBase, resolveApiUrl } from './apiBase';
 
 type Listener = (ev: SystemEvent) => void;
 
@@ -15,12 +16,14 @@ const listeners = new Set<Listener>();
 
 function systemEventsUrl(): string {
   const token = getToken();
-  return token ? `/api/events?token=${encodeURIComponent(token)}` : '/api/events';
+  return resolveApiUrl(token ? `/api/events?token=${encodeURIComponent(token)}` : '/api/events');
 }
 
 function ensureSource(): void {
   if (source) return;
-  source = new EventSource(systemEventsUrl());
+  // Cross-origin hosted mode needs credentialed CORS on the SSE stream; same
+  // origin keeps the default so nothing changes for the local server.
+  source = new EventSource(systemEventsUrl(), getApiBase() ? { withCredentials: true } : undefined);
   source.onmessage = (e) => {
     let payload: SystemEvent | { type: string };
     try {

--- a/web/src/lib/systemEvents.ts
+++ b/web/src/lib/systemEvents.ts
@@ -6,37 +6,27 @@
 // server restarts, so there's no manual retry loop here.
 
 import type { SystemEvent } from '@macaron/shared';
-import { getToken } from './auth';
-import { getApiBase, resolveApiUrl } from './apiBase';
+import { openEventStream, type EventStreamHandle } from './eventStream';
 
 type Listener = (ev: SystemEvent) => void;
 
-let source: EventSource | null = null;
+let source: EventStreamHandle | null = null;
 const listeners = new Set<Listener>();
-
-function systemEventsUrl(): string {
-  const token = getToken();
-  return resolveApiUrl(token ? `/api/events?token=${encodeURIComponent(token)}` : '/api/events');
-}
 
 function ensureSource(): void {
   if (source) return;
-  // Cross-origin hosted mode needs credentialed CORS on the SSE stream; same
-  // origin keeps the default so nothing changes for the local server.
-  source = new EventSource(systemEventsUrl(), getApiBase() ? { withCredentials: true } : undefined);
-  source.onmessage = (e) => {
+  // fetch-based SSE so the token rides an Authorization header, never the URL.
+  source = openEventStream('/api/events', (data) => {
     let payload: SystemEvent | { type: string };
     try {
-      payload = JSON.parse(e.data);
+      payload = JSON.parse(data);
     } catch {
       return;
     }
     if ((payload as SystemEvent).type === 'sessions-changed') {
       for (const l of listeners) l(payload as SystemEvent);
     }
-  };
-  // On error EventSource retries automatically; nothing to do but keep it.
-  source.onerror = () => {};
+  });
 }
 
 export function subscribeSystemEvents(cb: Listener): () => void {

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -8,7 +8,6 @@
 // fetch()+getReader() (see openEventStream) so its token rides a header too —
 // never a `?token=` query param that would leak into logs/referrers.
 import { authedFetch } from './auth';
-import { resolveApiUrl } from './apiBase';
 
 const TERMINAL_PREFIX = 'term:';
 
@@ -33,7 +32,9 @@ function base(project: string, sid: string): string {
 }
 
 export function terminalStreamUrl(project: string, sid: string, cols: number, rows: number): string {
-  return resolveApiUrl(`${base(project, sid)}/stream?cols=${cols}&rows=${rows}`);
+  // Path only — openEventStream's authedFetch retargets /api paths at the
+  // configured server, so resolution happens in exactly one place.
+  return `${base(project, sid)}/stream?cols=${cols}&rows=${rows}`;
 }
 
 // Keystrokes must arrive in order. Chain each input POST behind the previous

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -8,6 +8,7 @@
 // EventSource, which can't set headers — carries it as a `?token=` query param,
 // the other credential the server accepts.
 import { authedFetch, getToken } from './auth';
+import { resolveApiUrl } from './apiBase';
 
 const TERMINAL_PREFIX = 'term:';
 
@@ -34,7 +35,7 @@ function base(project: string, sid: string): string {
 export function terminalStreamUrl(project: string, sid: string, cols: number, rows: number): string {
   const url = `${base(project, sid)}/stream?cols=${cols}&rows=${rows}`;
   const t = getToken();
-  return t ? `${url}&token=${encodeURIComponent(t)}` : url;
+  return resolveApiUrl(t ? `${url}&token=${encodeURIComponent(t)}` : url);
 }
 
 // Keystrokes must arrive in order. Chain each input POST behind the previous

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -4,10 +4,10 @@
 // output stream is a sibling SSE endpoint (see Terminal.tsx).
 //
 // /api/terminal/* is auth-gated (server/src/lib/auth.ts): POSTs ride the token
-// via authedFetch's Authorization header, and the stream — a browser
-// EventSource, which can't set headers — carries it as a `?token=` query param,
-// the other credential the server accepts.
-import { authedFetch, getToken } from './auth';
+// via authedFetch's Authorization header, and the output stream is read with
+// fetch()+getReader() (see openEventStream) so its token rides a header too —
+// never a `?token=` query param that would leak into logs/referrers.
+import { authedFetch } from './auth';
 import { resolveApiUrl } from './apiBase';
 
 const TERMINAL_PREFIX = 'term:';
@@ -33,9 +33,7 @@ function base(project: string, sid: string): string {
 }
 
 export function terminalStreamUrl(project: string, sid: string, cols: number, rows: number): string {
-  const url = `${base(project, sid)}/stream?cols=${cols}&rows=${rows}`;
-  const t = getToken();
-  return resolveApiUrl(t ? `${url}&token=${encodeURIComponent(t)}` : url);
+  return resolveApiUrl(`${base(project, sid)}/stream?cols=${cols}&rows=${rows}`);
 }
 
 // Keystrokes must arrive in order. Chain each input POST behind the previous

--- a/web/src/macaron-vendor/StaticGenUIRenderer.tsx
+++ b/web/src/macaron-vendor/StaticGenUIRenderer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, type RefOb
 import { GenUIRenderer, type GenUIRendererFlushMode, type GenUIRenderPhase } from "partial-react";
 import { createImportMapResolver, esmShFallback, extractBareModuleSpecifiers, hasImportMapEntry, literalImportMap, prepareRendererImportMap } from "partial-react/import-map";
 import { createTsxCompiler } from "partial-react/compiler";
+import { assetUrl } from "../lib/assetBase";
 
 // --- stubs replacing @/components/GenUIStyleScope and useAppStoreBridge ---
 // Our preview doesn't use UnoCSS scope isolation (we use UnoCSS runtime globally)
@@ -85,10 +86,10 @@ const hasLocalNodeModulePackage = (packageName: string) => {
 // files re-export from window.__macaron_* globals (set in main.tsx), so user
 // code, our vendored components, and partial-react all share one React.
 const BASE_IMPORTS: Record<string, string> = (() => {
-  // origin + Vite base, so shims resolve under /app/ when hosted (BASE_URL
-  // '/app/') and at root locally. The import map needs absolute URLs.
+  // origin + Vite base (via assetUrl), so shims resolve under /app/ when
+  // hosted and at root locally. The import map needs absolute URLs.
   const origin = typeof location !== 'undefined' ? location.origin : '';
-  const prefix = origin + import.meta.env.BASE_URL.replace(/\/$/, '');
+  const prefix = origin + assetUrl('');
   return {
     react: prefix + '/genui-shim/react.mjs',
     'react/jsx-runtime': prefix + '/genui-shim/react-jsx-runtime.mjs',

--- a/web/src/macaron-vendor/StaticGenUIRenderer.tsx
+++ b/web/src/macaron-vendor/StaticGenUIRenderer.tsx
@@ -85,19 +85,22 @@ const hasLocalNodeModulePackage = (packageName: string) => {
 // files re-export from window.__macaron_* globals (set in main.tsx), so user
 // code, our vendored components, and partial-react all share one React.
 const BASE_IMPORTS: Record<string, string> = (() => {
+  // origin + Vite base, so shims resolve under /app/ when hosted (BASE_URL
+  // '/app/') and at root locally. The import map needs absolute URLs.
   const origin = typeof location !== 'undefined' ? location.origin : '';
+  const prefix = origin + import.meta.env.BASE_URL.replace(/\/$/, '');
   return {
-    react: origin + '/genui-shim/react.mjs',
-    'react/jsx-runtime': origin + '/genui-shim/react-jsx-runtime.mjs',
-    'react/jsx-dev-runtime': origin + '/genui-shim/react-jsx-dev-runtime.mjs',
-    'react-dom': origin + '/genui-shim/react-dom.mjs',
-    '$macaron/ui': origin + '/genui-shim/ui.mjs',
-    '$macaron/ui/charts': origin + '/genui-shim/charts.mjs',
-    'lucide-react': origin + '/genui-shim/lucide.mjs',
-    'framer-motion': origin + '/genui-shim/motion.mjs',
-    motion: origin + '/genui-shim/motion.mjs',
-    'motion/react': origin + '/genui-shim/motion.mjs',
-    '$macaron/chat': origin + '/genui-shim/chat.mjs',
+    react: prefix + '/genui-shim/react.mjs',
+    'react/jsx-runtime': prefix + '/genui-shim/react-jsx-runtime.mjs',
+    'react/jsx-dev-runtime': prefix + '/genui-shim/react-jsx-dev-runtime.mjs',
+    'react-dom': prefix + '/genui-shim/react-dom.mjs',
+    '$macaron/ui': prefix + '/genui-shim/ui.mjs',
+    '$macaron/ui/charts': prefix + '/genui-shim/charts.mjs',
+    'lucide-react': prefix + '/genui-shim/lucide.mjs',
+    'framer-motion': prefix + '/genui-shim/motion.mjs',
+    motion: prefix + '/genui-shim/motion.mjs',
+    'motion/react': prefix + '/genui-shim/motion.mjs',
+    '$macaron/chat': prefix + '/genui-shim/chat.mjs',
   };
 })();
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -49,12 +49,15 @@ import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
 import { consumeTokenFromUrl } from './lib/auth';
+import { consumeServerFromUrl } from './lib/apiBase';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
 import './styles.css';
 import './chat-code.css';
 
-// Pick up a ?token=... bootstrap from a shared link before anything fetches.
+// Pick up a ?server=... (hosted-mode server origin) then ?token=... bootstrap
+// from a shared link before anything fetches.
+consumeServerFromUrl();
 consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,17 +48,17 @@ import { Mcp } from './views/Mcp';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
-import { clearToken, consumeTokenFromUrl } from './lib/auth';
-import { consumeServerFromUrl } from './lib/apiBase';
+import { consumeTokenFromUrl, consumeHandoff } from './lib/auth';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
 import './styles.css';
 import './chat-code.css';
 
-// Pick up a ?server=... (hosted-mode server origin) then ?token=... bootstrap
-// from a shared link before anything fetches. Passing clearToken lets a server
-// switch drop a credential that wasn't reissued for the new origin.
-consumeServerFromUrl(clearToken);
+// Pick up the hosted-mode handoff (the docs connect page stashed {server, token}
+// in sessionStorage same-tab), then a same-origin ?token= share link. The
+// handoff binds the token to its server origin; nothing secret is read from the
+// URL, so a crafted ?server= link can't point us at an attacker.
+consumeHandoff();
 consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -65,16 +65,17 @@ consumeTokenFromUrl();
 // only the hash. Promote a pathname route before the router initializes so
 // opening /board (or a copied workspace/session URL) lands on that view rather
 // than silently rendering the dashboard.
-if (
-  !window.location.hash &&
-  window.location.pathname !== '/' &&
-  window.location.pathname !== '/index.html'
-) {
-  window.history.replaceState(
-    null,
-    '',
-    `/#${window.location.pathname}${window.location.search}`,
-  );
+//
+// BASE_URL is `/` when the server serves the SPA at its own root, but `/app/`
+// when the docs site HOSTS this bundle under a subpath. Strip the base so the
+// hash route is server-relative (`/app/w/x` → `#/w/x`), and treat the bare base
+// (`/app/`) the same as root so it boots the dashboard, not a 404 `#/app/`.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, ''); // '' locally, '/app' when hosted
+const rel = BASE && window.location.pathname.startsWith(BASE)
+  ? window.location.pathname.slice(BASE.length) || '/'
+  : window.location.pathname;
+if (!window.location.hash && rel !== '/' && rel !== '/index.html') {
+  window.history.replaceState(null, '', `/#${rel}${window.location.search}`);
 }
 
 // Boot UnoCSS runtime: scans the DOM for utility classes and injects CSS as

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,18 +48,17 @@ import { Mcp } from './views/Mcp';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
-import { consumeTokenFromUrl, consumeHandoff } from './lib/auth';
+import { consumeHandoff } from './lib/auth';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
 import './styles.css';
 import './chat-code.css';
 
 // Pick up the hosted-mode handoff (the docs connect page stashed {server, token}
-// in sessionStorage same-tab), then a same-origin ?token= share link. The
-// handoff binds the token to its server origin; nothing secret is read from the
-// URL, so a crafted ?server= link can't point us at an attacker.
+// in sessionStorage same-tab). The handoff binds the token to its server origin;
+// nothing secret is read from the URL, so a crafted ?server= link can't point us
+// at an attacker and no token ever rides the query string.
 consumeHandoff();
-consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads
 // only the hash. Promote a pathname route before the router initializes so

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,7 +48,7 @@ import { Mcp } from './views/Mcp';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/Confirm';
 import { AuthGate } from './components/AuthGate';
-import { consumeTokenFromUrl } from './lib/auth';
+import { clearToken, consumeTokenFromUrl } from './lib/auth';
 import { consumeServerFromUrl } from './lib/apiBase';
 import { preloadRendererRuntime } from './macaron-vendor/StaticGenUIRenderer';
 import { registerServiceWorker } from './lib/pwa';
@@ -56,8 +56,9 @@ import './styles.css';
 import './chat-code.css';
 
 // Pick up a ?server=... (hosted-mode server origin) then ?token=... bootstrap
-// from a shared link before anything fetches.
-consumeServerFromUrl();
+// from a shared link before anything fetches. Passing clearToken lets a server
+// switch drop a credential that wasn't reissued for the new origin.
+consumeServerFromUrl(clearToken);
 consumeTokenFromUrl();
 
 // The server serves the SPA for direct deep links, while createHashRouter reads

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -533,11 +533,10 @@ function RemoteAccess() {
   const status = state?.status ?? 'stopped';
   const live = status === 'running' && state?.url;
   const starting = status === 'starting';
-  // The tunnel arms an access token; fold it into the shared URL as ?token= so
-  // the first load unlocks itself (consumeTokenFromUrl strips it after storing).
-  const shareUrl = live && state?.url
-    ? (state.token ? `${state.url}/?token=${encodeURIComponent(state.token)}` : state.url)
-    : '';
+  // The share URL carries NO token — a URL leaks via history/referrer/proxy logs.
+  // Opening it lands on the AuthGate login screen; the operator pastes the token
+  // (shown below) there. Never fold the credential into the link.
+  const shareUrl = (live && state?.url) || '';
 
   return (
     <div className="settings-section">
@@ -599,7 +598,7 @@ function RemoteAccess() {
               </div>
               <div className="settings-hint">
                 {state.token
-                  ? <><strong>This link embeds an access token</strong> — anyone you share it with can drive your Claude Code sessions. Share it only with people you trust, and stop the tunnel when you're done.</>
+                  ? <>This server requires an access token: <code>{state.token}</code>. Share it <strong>separately</strong> from the URL (never in the link) with people you trust, and stop the tunnel when you're done.</>
                   : <><strong>This server already requires its access token.</strong> Share the URL together with that token, and stop the tunnel when you're done.</>}
               </div>
             </div>

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -1,28 +1,23 @@
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-// jsdom-free localStorage shim so apiBase's storage-backed cache works under
-// node:test. Must be installed before importing the module (it caches on read).
+// jsdom-free storage shims. apiBase caches on read, so install before import.
 class MemStorage {
   private m = new Map<string, string>();
   getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
   setItem(k: string, v: string) { this.m.set(k, v); }
   removeItem(k: string) { this.m.delete(k); }
+  clear() { this.m.clear(); }
 }
-(globalThis as unknown as { localStorage: MemStorage }).localStorage = new MemStorage();
+const local = new MemStorage();
+const session = new MemStorage();
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = local;
+(globalThis as unknown as { sessionStorage: MemStorage }).sessionStorage = session;
 
-// window shim so consumeServerFromUrl can read location + scrub via replaceState.
-let currentHref = 'https://hosted.example/';
-const win = {
-  get location() { return new URL(currentHref); },
-  history: { replaceState(_s: unknown, _t: string, url: string) { currentHref = new URL(url, currentHref).href; } },
-};
-(globalThis as unknown as { window: typeof win }).window = win;
-function setHref(h: string) { currentHref = h; }
+const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase } = await import('../src/lib/apiBase');
+const { getToken, setToken, clearToken, consumeHandoff } = await import('../src/lib/auth');
 
-const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase, consumeServerFromUrl } = await import('../src/lib/apiBase');
-
-beforeEach(() => { clearApiBase(); setHref('https://hosted.example/'); });
+beforeEach(() => { local.clear(); session.clear(); clearApiBase(); });
 
 test('same-origin (empty base): /api paths pass through untouched', () => {
   assert.equal(getApiBase(), '');
@@ -73,38 +68,45 @@ test('clearApiBase reverts to same-origin passthrough', () => {
   assert.equal(resolveApiUrl('/api/x'), '/api/x');
 });
 
-// --- P0-3: credential must bind to origin; a ?server= switch can't leak a token ---
+// --- P0-2 + P1-bypass: hosted handoff comes from same-tab sessionStorage, NOT
+// the URL. A crafted ?server= link carries no handoff and is inert. ---
 
-test('consumeServerFromUrl: ?server= without ?token= clears the stored token (no leak to new origin)', () => {
-  let cleared = false;
-  setHref('https://hosted.example/?server=https%3A%2F%2Fattacker.example');
-  consumeServerFromUrl(() => { cleared = true; });
-  assert.equal(cleared, true);            // stale credential dropped
-  assert.equal(getApiBase(), 'https://attacker.example');
-  assert.equal(window.location.search, ''); // ?server= scrubbed
-});
+const HANDOFF_KEY = 'macaron_connect_handoff';
+function stashHandoff(server: string, token: string) { session.setItem(HANDOFF_KEY, JSON.stringify({ server, token })); }
 
-test('consumeServerFromUrl: ?server= WITH a fresh ?token= keeps the token (reissued for new origin)', () => {
-  let cleared = false;
-  setHref('https://hosted.example/?server=https%3A%2F%2Ftunnel.test&token=fresh');
-  consumeServerFromUrl(() => { cleared = true; });
-  assert.equal(cleared, false);           // same load brings a matching token
+test('consumeHandoff: binds api base + token from the same-tab handoff, then clears it', () => {
+  stashHandoff('https://tunnel.test', 'tok-A');
+  consumeHandoff();
   assert.equal(getApiBase(), 'https://tunnel.test');
+  assert.equal(getToken(), 'tok-A');
+  assert.equal(session.getItem(HANDOFF_KEY), null); // one-time
 });
 
-test('consumeServerFromUrl: malformed ?server= still scrubs the URL (and clears token)', () => {
-  let cleared = false;
-  setHref('https://hosted.example/?server=https%3A%2F%2Fbad.example%2Fdeep%2Fpath');
-  consumeServerFromUrl(() => { cleared = true; });
-  assert.equal(cleared, true);
-  assert.equal(getApiBase(), '');         // rejected, base left unset
-  assert.equal(window.location.search, ''); // but URL still scrubbed
-});
-
-test('consumeServerFromUrl: no ?server= at all is a no-op (token untouched)', () => {
-  let cleared = false;
-  setHref('https://hosted.example/?token=keepme');
-  consumeServerFromUrl(() => { cleared = true; });
-  assert.equal(cleared, false);
+test('consumeHandoff: no handoff is a no-op (same-origin local mode, base stays empty)', () => {
+  consumeHandoff();
   assert.equal(getApiBase(), '');
 });
+
+test('consumeHandoff: malformed handoff leaves no half-bound base', () => {
+  session.setItem(HANDOFF_KEY, '{not json');
+  consumeHandoff();
+  assert.equal(getApiBase(), '');
+});
+
+// --- P0-3: {origin, token} bind atomically. Two hosted tabs on different
+// servers can't leak one's token to the other, even sharing one localStorage. ---
+
+test('two-realm: token minted for server A is never returned when the base is server B', () => {
+  // Tab A binds server A + token A.
+  stashHandoff('https://server-a.test', 'TOKEN_A');
+  consumeHandoff();
+  assert.equal(getToken(), 'TOKEN_A');
+  // Tab B (same localStorage) binds server B + token B via its own sessionStorage.
+  setApiBase('https://server-b.test');
+  setToken('TOKEN_B');
+  assert.equal(getToken(), 'TOKEN_B');
+  // Back on server A's base, we still read A's token — B never clobbered it.
+  setApiBase('https://server-a.test');
+  assert.equal(getToken(), 'TOKEN_A');
+});
+

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -1,0 +1,65 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// jsdom-free localStorage shim so apiBase's storage-backed cache works under
+// node:test. Must be installed before importing the module (it caches on read).
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string) { this.m.set(k, v); }
+  removeItem(k: string) { this.m.delete(k); }
+}
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = new MemStorage();
+
+const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase } = await import('../src/lib/apiBase');
+
+beforeEach(() => clearApiBase());
+
+test('same-origin (empty base): /api paths pass through untouched', () => {
+  assert.equal(getApiBase(), '');
+  assert.equal(resolveApiUrl('/api/workspaces'), '/api/workspaces');
+  assert.equal(resolveApiUrl('/api/events?token=x'), '/api/events?token=x');
+});
+
+test('with a base: /api and /relay paths are retargeted, others are not', () => {
+  setApiBase('https://tunnel.test');
+  assert.equal(resolveApiUrl('/api/workspaces'), 'https://tunnel.test/api/workspaces');
+  assert.equal(resolveApiUrl('/relay/foo'), 'https://tunnel.test/relay/foo');
+  assert.equal(resolveApiUrl('/sw.js'), '/sw.js');           // asset stays local
+  assert.equal(resolveApiUrl('/assets/x.js'), '/assets/x.js');
+});
+
+test('setApiBase stores the origin only and strips a trailing path', () => {
+  setApiBase('https://tunnel.test/'); // trailing slash is the root path — allowed
+  assert.equal(getApiBase(), 'https://tunnel.test');
+});
+
+test('setApiBase rejects a base that carries a path (no silent reroute)', () => {
+  assert.throws(() => setApiBase('https://tunnel.test/deep/path'));
+});
+
+test('setApiBase rejects garbage', () => {
+  assert.throws(() => setApiBase('not a url ::::'));
+});
+
+test('http://localhost base is honored (loopback)', () => {
+  setApiBase('http://localhost:7878');
+  assert.equal(resolveApiUrl('/api/health'), 'http://localhost:7878/api/health');
+  assert.equal(isLoopbackBase(), true);
+});
+
+test('isLoopbackBase: 127.x and ::1 are loopback, public host is not', () => {
+  setApiBase('http://127.0.0.1:7979');
+  assert.equal(isLoopbackBase(), true);
+  setApiBase('http://[::1]:7878');
+  assert.equal(isLoopbackBase(), true);
+  setApiBase('https://xxx.trycloudflare.com');
+  assert.equal(isLoopbackBase(), false);
+});
+
+test('clearApiBase reverts to same-origin passthrough', () => {
+  setApiBase('https://tunnel.test');
+  clearApiBase();
+  assert.equal(getApiBase(), '');
+  assert.equal(resolveApiUrl('/api/x'), '/api/x');
+});

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -11,9 +11,18 @@ class MemStorage {
 }
 (globalThis as unknown as { localStorage: MemStorage }).localStorage = new MemStorage();
 
-const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase } = await import('../src/lib/apiBase');
+// window shim so consumeServerFromUrl can read location + scrub via replaceState.
+let currentHref = 'https://hosted.example/';
+const win = {
+  get location() { return new URL(currentHref); },
+  history: { replaceState(_s: unknown, _t: string, url: string) { currentHref = new URL(url, currentHref).href; } },
+};
+(globalThis as unknown as { window: typeof win }).window = win;
+function setHref(h: string) { currentHref = h; }
 
-beforeEach(() => clearApiBase());
+const { getApiBase, setApiBase, clearApiBase, resolveApiUrl, isLoopbackBase, consumeServerFromUrl } = await import('../src/lib/apiBase');
+
+beforeEach(() => { clearApiBase(); setHref('https://hosted.example/'); });
 
 test('same-origin (empty base): /api paths pass through untouched', () => {
   assert.equal(getApiBase(), '');
@@ -62,4 +71,40 @@ test('clearApiBase reverts to same-origin passthrough', () => {
   clearApiBase();
   assert.equal(getApiBase(), '');
   assert.equal(resolveApiUrl('/api/x'), '/api/x');
+});
+
+// --- P0-3: credential must bind to origin; a ?server= switch can't leak a token ---
+
+test('consumeServerFromUrl: ?server= without ?token= clears the stored token (no leak to new origin)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Fattacker.example');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, true);            // stale credential dropped
+  assert.equal(getApiBase(), 'https://attacker.example');
+  assert.equal(window.location.search, ''); // ?server= scrubbed
+});
+
+test('consumeServerFromUrl: ?server= WITH a fresh ?token= keeps the token (reissued for new origin)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Ftunnel.test&token=fresh');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, false);           // same load brings a matching token
+  assert.equal(getApiBase(), 'https://tunnel.test');
+});
+
+test('consumeServerFromUrl: malformed ?server= still scrubs the URL (and clears token)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?server=https%3A%2F%2Fbad.example%2Fdeep%2Fpath');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, true);
+  assert.equal(getApiBase(), '');         // rejected, base left unset
+  assert.equal(window.location.search, ''); // but URL still scrubbed
+});
+
+test('consumeServerFromUrl: no ?server= at all is a no-op (token untouched)', () => {
+  let cleared = false;
+  setHref('https://hosted.example/?token=keepme');
+  consumeServerFromUrl(() => { cleared = true; });
+  assert.equal(cleared, false);
+  assert.equal(getApiBase(), '');
 });

--- a/web/test/apiBase.test.ts
+++ b/web/test/apiBase.test.ts
@@ -110,3 +110,17 @@ test('two-realm: token minted for server A is never returned when the base is se
   assert.equal(getToken(), 'TOKEN_A');
 });
 
+// --- same-server dual-tab: two tabs bound to the SAME server must keep their
+// OWN token. localStorage is shared across a tab group, sessionStorage is not,
+// so the token must live in sessionStorage — asserted by it never touching the
+// shared localStorage shim. ---
+
+test('token is stored per-tab (sessionStorage), never in shared localStorage', () => {
+  setApiBase('https://server-a.test');
+  setToken('TOKEN_A');
+  // The credential is in sessionStorage (per-tab) and absent from localStorage
+  // (shared) — so a second tab on the same server can't overwrite this one.
+  assert.equal(session.getItem('macaron_auth_token::https://server-a.test'), 'TOKEN_A');
+  assert.equal(local.getItem('macaron_auth_token::https://server-a.test'), null);
+});
+


### PR DESCRIPTION
## What

Make `artifacts.macaron.im` **host** the Macaron WebUI instead of redirecting to a server's own origin. The docs site now serves the exact same `web/` build that `mcc`/`mcx` serve locally, under two routes, and `/connect` opens that same-origin route pointed at the user's server.

- **Claude Code** → `/app` (`index.html`)
- **Codex** → `/app/codex` (`codex.html`)

Closes the gap between #158 (redirect-only Connect page) and #160 (cross-origin API base): this branch contains #160's commits and cherry-picks #158's Connect page, then wires them together.

## How

- **Reuse the existing build, no source fork.** `site/host-webui.mjs` runs the `/web` vite build with `--base=/app/` (rewrites every asset URL to `/app/assets/*`) and copies `web/dist` into `site/build/client/app`. Wired into `site` build as `react-router build && node host-webui.mjs`. Both SPA entries ship; their hash router keeps deep links in the `#` fragment, so no server-side SPA fallback is needed under `/app`.
- **`/connect` enters the hosted route, not the server.** New `hosted-target.ts` turns a validated `<origin>/?token=` into a same-origin `/app[/codex]?server=<origin>&token=<t>`. The whole `buildTarget` security surface (http/https gate, self-origin reject, IP-literal parsing, token scrubbing) is untouched and still tested — hosting is layered on top. Added an engine selector to the Connect UI.
- **Hosted-base fix in `web/`.** `main.tsx`'s pathname-promotion assumed the SPA sits at origin root; under `/app` it produced a 404 `#/app`. Now it strips `import.meta.env.BASE_URL` first (`''` locally, `/app` hosted), so `/app` boots the dashboard and local behavior is unchanged.

## Verification

- **site**: 85 tests pass (new `hosted-target` cases + updated `connect-state`), typecheck clean, full `pnpm build` stages `/app` + `/app/codex` with correct `/app/assets` refs.
- **Real Chrome end-to-end** (built docs site served cross-origin over HTTPS, real `mcc` server, LNA post-grant): drove the `/connect` form for both engines.
  - Claude: lands on `/app`, **935** `/api` calls all cross-origin to the server, 0 leaked to the docs origin, 0 failed.
  - Codex: lands on `/app/codex`, **487** `/api` calls (incl. `/api/codex/*`) all cross-origin, 0 leaked, 0 failed.
  - Both stay on the docs origin — no redirect to the server.

Head: `5a6993ca8870a0651e2f3130b56e1db29309ba28`
