### PR TITLE
refine artifact workspace hierarchy

### DIFF
--- a/web/src/components/FileTile.tsx
+++ b/web/src/components/FileTile.tsx
@@ -7,7 +7,7 @@
 // api.writeFile; unsaved changes are indicated by a dot and confirmed
 // before switching files.
 
-import { Circle } from 'lucide-react';
+import { Circle, Save } from 'lucide-react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -132,7 +132,9 @@ export function FileTile({
     if (isMarkdown) {
       return (
         <div className="ft-preview md">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          <div className="ft-reading">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </div>
         </div>
       );
     }
@@ -154,67 +156,70 @@ export function FileTile({
 
   return (
     <div className="ft-root">
-      {/* Redundant tile-header replaced by a compact floating action strip
-          in the body's top-right corner — the outer SortableTile chrome
-          already shows the filename, so we don't repeat the path here. */}
       <div className="ft-body">
-        {!isImage && !isBinary && (
-          <div className="ft-actions">
-            <div className="ft-mode-toggle" role="tablist">
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mode === 'preview'}
-                className={'ft-mode-btn' + (mode === 'preview' ? ' active' : '')}
-                onClick={() => setMode('preview')}
-              >
-                Preview
-              </button>
-              {isMarkdown && (
+        <div className="ft-toolbar">
+          <span className="ft-path" title={path}>{path}</span>
+          {!isImage && !isBinary && (
+            <div className="ft-actions">
+              <div className="ft-mode-toggle" role="tablist" aria-label="File view mode">
                 <button
                   type="button"
                   role="tab"
-                  aria-selected={mode === 'split'}
-                  className={'ft-mode-btn' + (mode === 'split' ? ' active' : '')}
-                  onClick={() => setMode('split')}
+                  aria-selected={mode === 'preview'}
+                  className={'ft-mode-btn' + (mode === 'preview' ? ' active' : '')}
+                  onClick={() => setMode('preview')}
                 >
-                  Split
+                  Preview
+                </button>
+                {isMarkdown && (
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={mode === 'split'}
+                    className={'ft-mode-btn' + (mode === 'split' ? ' active' : '')}
+                    onClick={() => setMode('split')}
+                  >
+                    Split
+                  </button>
+                )}
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === 'edit'}
+                  className={'ft-mode-btn' + (mode === 'edit' ? ' active' : '')}
+                  onClick={() => setMode('edit')}
+                >
+                  Edit
+                  {dirty && <span className="ft-dirty" role="img" aria-label="Unsaved changes" title="Unsaved changes"><Circle size={8} fill="currentColor" strokeWidth={0} aria-hidden="true" /></span>}
+                </button>
+              </div>
+              {mode !== 'preview' && (
+                <button
+                  type="button"
+                  className="ft-save"
+                  disabled={!dirty || saving}
+                  onClick={save}
+                  title={dirty ? 'Save (⌘S)' : 'Saved'}
+                  aria-label={saving ? 'Saving' : dirty ? 'Save file' : 'Saved'}
+                >
+                  <Save size={13} aria-hidden="true" />
                 </button>
               )}
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mode === 'edit'}
-                className={'ft-mode-btn' + (mode === 'edit' ? ' active' : '')}
-                onClick={() => setMode('edit')}
-              >
-                Edit
-                {dirty && <span className="ft-dirty" role="img" aria-label="Unsaved changes" title="Unsaved changes"><Circle size={8} fill="currentColor" strokeWidth={0} aria-hidden="true" /></span>}
-              </button>
             </div>
-            {mode !== 'preview' && (
-              <button
-                type="button"
-                className="ft-save"
-                disabled={!dirty || saving}
-                onClick={save}
-                title={dirty ? 'Save (⌘S)' : 'Saved'}
-              >
-                {saving ? 'Saving…' : 'Save'}
-              </button>
-            )}
-          </div>
-        )}
-        {mode === 'preview' && previewNode}
-        {mode === 'edit' && (
-          <div className="ft-editor-pane">{editorNode}</div>
-        )}
-        {mode === 'split' && (
-          <div className="ft-split">
+          )}
+        </div>
+        <div className="ft-content">
+          {mode === 'preview' && previewNode}
+          {mode === 'edit' && (
             <div className="ft-editor-pane">{editorNode}</div>
-            {previewNode}
-          </div>
-        )}
+          )}
+          {mode === 'split' && (
+            <div className="ft-split">
+              <div className="ft-editor-pane">{editorNode}</div>
+              {previewNode}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -6,7 +6,7 @@
 // Mirrors GitPanel's slide-in shell (fixed backdrop + right-side panel
 // via the .above-modal escape hatch so it stacks over the composer).
 
-import { ChevronDown, ChevronRight, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, File, Folder, FolderOpen, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api, type FileEntry, type FileContentSearchResponse } from '../lib/api';
 
@@ -58,6 +58,9 @@ function TreeRow({
         title={entry.path}
       >
         <span className="fp-caret">{isDir ? (open ? <ChevronDown size={10} aria-hidden="true" /> : <ChevronRight size={10} aria-hidden="true" />) : ' '}</span>
+        <span className="fp-file-icon" aria-hidden="true">
+          {isDir ? <Folder size={13} /> : <File size={13} />}
+        </span>
         <span className="fp-name">{entry.name}</span>
       </button>
       {isDir && open && (
@@ -151,17 +154,21 @@ export function FilesPanel({
   return (
     <aside className="fp-panel" aria-label="Files panel">
         <div className="fp-head">
-          <div className="fp-title">Files</div>
+          <div className="fp-title"><FolderOpen size={15} aria-hidden="true" /> Files</div>
           <button className="fp-close" onClick={onClose} title="Close" aria-label="Close"><X size={14} aria-hidden="true" /></button>
         </div>
         <div className="fp-search">
+          <Search className="fp-search-icon" size={14} aria-hidden="true" />
           <input
             type="text"
             className="fp-input"
-            placeholder="Search files —  name, or > text for content"
+            name="file-search"
+            aria-label="Search files"
+            autoComplete="off"
+            placeholder="Search files"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            autoFocus
+            autoFocus={typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(min-width: 769px)').matches}
           />
           {searching && <span className="fp-hint">…</span>}
         </div>
@@ -237,11 +244,6 @@ export function FilesPanel({
           )}
         </div>
 
-        <div className="fp-foot">
-          <span className="fp-hint">
-            Tip: type <code>&gt;</code> to search file contents (git grep).
-          </span>
-        </div>
     </aside>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -74,18 +74,18 @@
    tokens change; fonts and layout are inherited from :root above. */
 :root[data-theme="dark"] {
   color-scheme: dark;
-  --bg: #1F1E1B;
-  --surface: #262521;
-  --surface-2: #2C2B26;
-  --surface-3: #35332C;
-  --code-bg: #2C2B26;
-  --border: #38362F;
-  --border-strong: #48453B;
+  --bg: #1A1A19;
+  --surface: #232321;
+  --surface-2: #2A2A27;
+  --surface-3: #33332F;
+  --code-bg: #20201F;
+  --border: #393936;
+  --border-strong: #4A4944;
 
-  --text: #EDEAE0;
-  --text-2: #C9C4B5;
-  --muted: #948E7D;
-  --muted-2: #6E6A5C;
+  --text: #F0EEE8;
+  --text-2: #CBC8BF;
+  --muted: #969288;
+  --muted-2: #6F6C64;
 
   --accent: #E08159;
   --accent-hover: #EC8F67;
@@ -2072,11 +2072,14 @@ textarea:focus, select:focus, input:focus {
   min-height: 0;
   padding: 16px 20px;
   gap: 12px;
+  background: var(--bg);
 }
 .ws-canvas-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
+  min-height: 34px;
   flex-shrink: 0;
 }
 .ws-canvas-title { display: flex; align-items: baseline; gap: 12px; min-width: 0; }
@@ -2088,6 +2091,16 @@ textarea:focus, select:focus, input:focus {
 }
 .ws-canvas-meta { font-size: 12px; color: var(--muted); }
 .ws-canvas-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.ws-canvas-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 32px;
+  white-space: nowrap;
+}
+.ws-canvas-action svg { flex: 0 0 auto; color: var(--muted); }
+.ws-canvas-action:hover svg { color: var(--text-2); }
 .ws-canvas-empty {
   flex: 1;
   display: flex;
@@ -2135,7 +2148,7 @@ textarea:focus, select:focus, input:focus {
   display: grid;
   gap: 12px;
   overflow-y: auto;
-  padding-right: 4px;
+  padding: 2px 4px 16px 2px;
   /* grid-template-columns + grid-auto-rows are set inline from constants
      in Workspace.tsx so JS resize math stays in sync with layout. */
 }
@@ -2146,10 +2159,11 @@ textarea:focus, select:focus, input:focus {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  border: 2px solid var(--border);
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
   overflow: hidden;
   background: var(--surface);
+  box-shadow: 0 1px 2px rgba(44, 40, 32, 0.04);
   /* Silky transitions on layout state — dnd-kit provides the reorder
      transform/transition inline; these cover the resize + focus paths. */
   transition:
@@ -2158,8 +2172,15 @@ textarea:focus, select:focus, input:focus {
   will-change: transform;
 }
 .ws-tile.focused {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-soft), 0 6px 22px rgba(61, 57, 41, 0.06);
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px var(--accent-soft-2), 0 10px 28px rgba(44, 40, 32, 0.08);
+}
+.ws-tile:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+:root[data-theme="dark"] .ws-tile {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
+}
+:root[data-theme="dark"] .ws-tile.focused {
+  box-shadow: 0 0 0 1px var(--accent-soft-2), 0 12px 32px rgba(0, 0, 0, 0.28);
 }
 .ws-tile.dragging {
   box-shadow: 0 12px 30px rgba(61, 57, 41, 0.18);
@@ -2180,8 +2201,8 @@ textarea:focus, select:focus, input:focus {
   overflow: hidden;
   z-index: var(--z-tile-inline);
   pointer-events: none;
-  border-top-left-radius: 12px;
-  border-top-right-radius: 12px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
 }
 .ws-tile-running-bar::before {
   content: '';
@@ -2204,12 +2225,22 @@ textarea:focus, select:focus, input:focus {
   0%   { left: -40%; }
   100% { left: 100%; }
 }
+@media (prefers-reduced-motion: reduce) {
+  .ws-tile-running-bar::before {
+    left: 0;
+    width: 100%;
+    animation: none;
+    background: var(--accent);
+    opacity: 0.72;
+  }
+}
 
 .ws-tile-grip {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
+  min-height: 38px;
+  padding: 5px 8px 5px 10px;
   background: var(--surface-2);
   border-bottom: 1px solid var(--border);
   font-size: 11.5px;
@@ -2253,8 +2284,12 @@ textarea:focus, select:focus, input:focus {
 .ws-tile-grip-dots {
   color: var(--muted-2);
   user-select: none;
-  letter-spacing: -2px;
-  opacity: 0;
+  width: 14px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.48;
   transition: opacity 0.15s ease;
 }
 .ws-tile:hover .ws-tile-grip-dots { opacity: 1; }
@@ -2267,14 +2302,23 @@ textarea:focus, select:focus, input:focus {
   color: var(--text-2);
   font-family: var(--font-mono);
 }
+.ws-tile-kind {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-2);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+}
 /* Grip-bar action buttons — copy / refresh / × all live in the same
    fixed-size box so they align on both axes regardless of whether their
    content is a 13px SVG or a text glyph. Hover reveals them so the tile
    stays clean while idle. */
 .ws-tile-action,
 .ws-tile-x {
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -2285,7 +2329,7 @@ textarea:focus, select:focus, input:focus {
   align-items: center;
   justify-content: center;
   line-height: 1;
-  opacity: 0;
+  opacity: 0.62;
   transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
   flex-shrink: 0;
 }
@@ -2296,7 +2340,11 @@ textarea:focus, select:focus, input:focus {
   font-family: var(--font-mono);
 }
 .ws-tile:hover .ws-tile-action,
-.ws-tile:hover .ws-tile-x { opacity: 1; }
+.ws-tile:hover .ws-tile-x,
+.ws-tile:focus-within .ws-tile-action,
+.ws-tile:focus-within .ws-tile-x { opacity: 1; }
+.ws-tile-action:focus-visible,
+.ws-tile-x:focus-visible { opacity: 1; outline: 2px solid var(--accent); outline-offset: 1px; }
 .ws-tile-action:hover { color: var(--accent); background: var(--surface); }
 .ws-tile-action.ws-tile-delete:hover { color: var(--bad); background: rgba(192, 82, 74, 0.08); }
 .ws-tile-x:hover { color: var(--bad); background: rgba(192, 82, 74, 0.08); }
@@ -4427,9 +4475,52 @@ textarea:focus, select:focus, input:focus {
 
   .ws-canvas-v2 {
     height: 100dvh;
-    padding: 56px 12px calc(12px + env(safe-area-inset-bottom));
+    padding: calc(10px + env(safe-area-inset-top)) 12px calc(12px + env(safe-area-inset-bottom));
+    gap: 10px;
   }
-  .ws-canvas-head { padding-left: 44px; }
+  .ws-canvas-head {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding-left: 44px;
+  }
+  .ws-canvas-title {
+    min-height: 40px;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0;
+  }
+  .ws-canvas-name {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 18px;
+  }
+  .ws-canvas-meta {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ws-canvas-actions {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+    margin-left: -44px;
+  }
+  .ws-canvas-action {
+    width: 100%;
+    min-width: 0;
+    height: 40px;
+    padding: 0 6px;
+    gap: 5px;
+    font-size: 11.5px;
+  }
+  .ws-canvas-body { margin: 0; }
+  .ws-canvas-main { padding: 0; }
+  .ws-canvas-body.with-files .ws-canvas-main { border-left: 0; }
 
   /* Use the dynamic viewport for the scroll containers too, so the composer
      isn't pushed behind the phone's dynamic toolbar (100vh = the *large*
@@ -4439,7 +4530,7 @@ textarea:focus, select:focus, input:focus {
 
   /* Stack the canvas as one scrolling column; ignore per-tile spans so tiles
      never overflow the viewport width. Height inline-set from rowSpan stays. */
-  .ws-canvas-grid-v2 { grid-template-columns: 1fr !important; }
+  .ws-canvas-grid-v2 { grid-template-columns: 1fr !important; padding: 2px 1px 16px; }
   .ws-tile { grid-column: span 1 !important; }
   /* Drag-reorder + resize handles are pointer-hover affordances with no touch
      equivalent; hide the resize grip so it can't fight page scroll. */
@@ -4449,6 +4540,17 @@ textarea:focus, select:focus, input:focus {
 
   /* Comfortable tap targets on the small controls the mobile user actually hits. */
   .sb-ws-head, .sb-sess, .sb-settings-link { min-height: 44px; }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .ws-tile-action,
+  .ws-tile-x {
+    width: 40px;
+    height: 40px;
+    opacity: 1;
+  }
+  .ws-tile-grip { min-height: 48px; padding-top: 4px; padding-bottom: 4px; }
+  .ws-tile-grip-dots { opacity: 0.72; }
 }
 
 /* ---------- git panel ---------- */
@@ -4982,6 +5084,7 @@ textarea:focus, select:focus, input:focus {
   display: flex;
   overflow: hidden;
   margin: 0 -20px;
+  position: relative;
 }
 .ws-canvas-main {
   flex: 1;
@@ -4994,9 +5097,9 @@ textarea:focus, select:focus, input:focus {
 }
 .ws-canvas-body.with-files .ws-canvas-main { border-left: 1px solid var(--border); }
 .fp-panel {
-  width: 300px;
+  width: 320px;
   flex-shrink: 0;
-  background: var(--surface-2);
+  background: var(--surface);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
@@ -5007,40 +5110,67 @@ textarea:focus, select:focus, input:focus {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 14px 16px 10px;
+  min-height: 44px;
+  padding: 7px 10px 7px 14px;
   border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
 }
-.fp-title { font-family: var(--font-serif); font-size: 16px; font-weight: 500; flex: 1; }
+.fp-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-2);
+  flex: 1;
+}
+.fp-title svg { color: var(--muted); }
 .fp-close {
   background: none;
   border: 0;
   color: var(--muted);
-  font-size: 20px;
   cursor: pointer;
-  padding: 2px 8px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border-radius: 6px;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
-.fp-close:hover { color: var(--text); background: var(--surface-2); }
+.fp-close:hover { color: var(--text); background: var(--surface-3); }
+.fp-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .fp-search {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border);
-  background: var(--surface-2);
+  background: var(--surface);
+}
+.fp-search-icon {
+  position: absolute;
+  left: 22px;
+  color: var(--muted);
+  pointer-events: none;
 }
 .fp-input {
   flex: 1;
-  padding: 7px 10px;
+  width: 100%;
+  height: 36px;
+  padding: 7px 10px 7px 32px;
   border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface);
+  border-radius: 6px;
+  background: var(--surface-2);
   color: var(--text);
   font-size: 13px;
   outline: none;
 }
-.fp-input:focus { border-color: var(--border-strong); }
+.fp-input:focus-visible {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
 .fp-body {
   flex: 1;
   overflow-y: auto;
@@ -5051,6 +5181,7 @@ textarea:focus, select:focus, input:focus {
   align-items: center;
   gap: 4px;
   width: 100%;
+  min-height: 30px;
   padding: 5px 12px;
   background: none;
   border: 0;
@@ -5066,6 +5197,7 @@ textarea:focus, select:focus, input:focus {
 .fp-row:hover { background: var(--surface-2); color: var(--text); }
 .fp-row.focused { background: var(--accent-soft); color: var(--accent); }
 .fp-row.dir { font-weight: 500; }
+.fp-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .fp-caret {
   display: inline-block;
   width: 10px;
@@ -5073,6 +5205,16 @@ textarea:focus, select:focus, input:focus {
   font-size: 10px;
   flex-shrink: 0;
 }
+.fp-file-icon {
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+.fp-row.dir .fp-file-icon { color: var(--text-2); }
 .fp-name {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5130,47 +5272,51 @@ textarea:focus, select:focus, input:focus {
   text-overflow: ellipsis;
   flex: 1;
 }
-.fp-foot {
-  padding: 8px 14px;
-  border-top: 1px solid var(--border);
-  color: var(--muted);
-  font-size: 11.5px;
-  background: var(--surface-2);
-}
-.fp-foot code {
-  background: var(--surface);
-  padding: 0 5px;
-  border-radius: 3px;
-  font-size: 11px;
-}
-
 /* ---------- file tile ---------- */
-.ft-root { display: flex; flex-direction: column; height: 100%; min-height: 0; background: var(--surface); }
-/* Floating action strip in the body's top-right corner. Absolute so it
-   overlays the preview/editor and doesn't repeat the tile-chrome title
-   the SortableTile grip bar already renders. */
-.ft-actions {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+.ft-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--surface);
+  container-type: inline-size;
+}
+.ft-toolbar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  z-index: 2;
+  gap: 12px;
+  min-height: 42px;
+  padding: 6px 8px 6px 14px;
+  border-bottom: 1px solid var(--border);
   background: var(--surface);
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  flex: 0 0 auto;
+}
+.ft-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.ft-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  flex: 0 0 auto;
 }
 .ft-mode-toggle {
   display: inline-flex;
-  background: var(--surface);
+  background: var(--surface-2);
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
 }
 .ft-mode-btn {
+  min-height: 28px;
   padding: 3px 10px;
   background: transparent;
   border: 0;
@@ -5184,26 +5330,38 @@ textarea:focus, select:focus, input:focus {
 }
 .ft-mode-btn.active { background: var(--accent-soft); color: var(--accent); }
 .ft-mode-btn:hover:not(.active) { color: var(--text-2); }
+.ft-mode-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .ft-dirty { color: var(--accent); font-size: 8px; }
 .ft-save {
-  padding: 3px 10px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--surface);
+  background: var(--surface-2);
   color: var(--text);
-  font-size: 11.5px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .ft-save:hover:not(:disabled) { border-color: var(--border-strong); background: var(--surface-2); }
 .ft-save:disabled { opacity: 0.4; cursor: not-allowed; }
+.ft-save:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .ft-body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  /* Anchor for .ft-actions (absolute inside this body). */
-  position: relative;
+}
+.ft-content {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 .ft-editor-pane {
   flex: 1;
@@ -5237,10 +5395,11 @@ textarea:focus, select:focus, input:focus {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  padding: 12px 16px;
+  padding: 24px 28px 40px;
   margin: 0;
 }
 .ft-preview.code {
+  padding: 18px 20px 32px;
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.55;
@@ -5249,16 +5408,17 @@ textarea:focus, select:focus, input:focus {
   background: var(--surface);
 }
 .ft-preview.md {
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: 15px;
+  line-height: 1.7;
   color: var(--text);
 }
-.ft-preview.md h1 { font-size: 20px; font-weight: 600; margin: 12px 0 8px; }
-.ft-preview.md h2 { font-size: 17px; font-weight: 600; margin: 12px 0 6px; }
-.ft-preview.md h3 { font-size: 15px; font-weight: 600; margin: 10px 0 5px; }
-.ft-preview.md p { margin: 0 0 10px; }
-.ft-preview.md ul, .ft-preview.md ol { padding-left: 22px; margin: 6px 0 10px; }
-.ft-preview.md li { margin: 2px 0; }
+.ft-reading { width: 100%; max-width: 840px; margin: 0 auto; }
+.ft-preview.md h1 { font-size: 26px; line-height: 1.25; font-weight: 600; margin: 4px 0 16px; }
+.ft-preview.md h2 { font-size: 20px; line-height: 1.35; font-weight: 600; margin: 28px 0 10px; }
+.ft-preview.md h3 { font-size: 16px; line-height: 1.4; font-weight: 600; margin: 22px 0 8px; }
+.ft-preview.md p { margin: 0 0 14px; }
+.ft-preview.md ul, .ft-preview.md ol { padding-left: 24px; margin: 8px 0 16px; }
+.ft-preview.md li { margin: 4px 0; }
 .ft-preview.md pre {
   background: var(--surface-2);
   border: 1px solid var(--border);
@@ -5267,7 +5427,7 @@ textarea:focus, select:focus, input:focus {
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: 12px;
-  margin: 8px 0 12px;
+  margin: 14px 0 18px;
 }
 .ft-preview.md code {
   background: var(--surface-2);
@@ -5281,11 +5441,18 @@ textarea:focus, select:focus, input:focus {
   border-left: 3px solid var(--border);
   padding: 2px 12px;
   color: var(--muted);
-  margin: 6px 0 10px;
+  margin: 14px 0 18px;
 }
 .ft-preview.md a { color: var(--accent); text-decoration: underline; }
-.ft-preview.md table { border-collapse: collapse; margin: 8px 0 12px; font-size: 13px; }
-.ft-preview.md th, .ft-preview.md td { border: 1px solid var(--border); padding: 4px 10px; }
+.ft-preview.md table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 14px 0 18px;
+  font-size: 13px;
+}
+.ft-preview.md th, .ft-preview.md td { border: 1px solid var(--border); padding: 6px 10px; }
 .ft-preview.md th { background: var(--surface-2); font-weight: 600; text-align: left; }
 .ft-image-wrap {
   flex: 1;
@@ -5300,8 +5467,48 @@ textarea:focus, select:focus, input:focus {
 .ft-image-wrap img {
   max-width: 100%;
   max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
   background: repeating-conic-gradient(#eee 0% 25%, #f9f9f9 0% 50%) 50% / 20px 20px;
   border: 1px solid var(--border);
   border-radius: 4px;
+}
+
+@container (max-width: 640px) {
+  .ft-split { flex-direction: column; }
+  .ft-split > .ft-editor-pane,
+  .ft-split > .ft-preview { flex-basis: 50%; }
+  .ft-split > .ft-preview {
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 768px) {
+  .ws-canvas-body { margin: 0; }
+  .ws-canvas-main { padding: 0; }
+  .ws-canvas-body.with-files .ws-canvas-main { border-left: 0; }
+  .fp-panel {
+    position: absolute;
+    inset: 0;
+    z-index: var(--z-side-panel);
+    width: 100%;
+    height: 100%;
+    border-right: 0;
+    box-shadow: 0 12px 36px rgba(44, 40, 32, 0.14);
+  }
+  .fp-head { min-height: 48px; }
+  .fp-close { width: 40px; height: 40px; }
+  .fp-row { min-height: 40px; }
+  .ft-toolbar { min-height: 46px; padding-left: 12px; }
+  .ft-preview { padding: 20px 16px 32px; }
+  .ft-preview.code { padding: 16px 14px 28px; }
+  .ft-preview.md h1 { font-size: 22px; }
+  .ft-preview.md h2 { font-size: 18px; margin-top: 24px; }
+}
+
+@media (max-width: 420px) {
+  .ft-mode-btn { padding-left: 8px; padding-right: 8px; }
+  .ws-canvas-action { gap: 4px; font-size: 11px; }
 }

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -14,7 +14,18 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Copy, RefreshCw, Trash2, X } from 'lucide-react';
+import {
+  Copy,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  GripVertical,
+  Plus,
+  RefreshCw,
+  SquareTerminal,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { api, basename, type SessionListItem, type Workspace as Wk } from '../lib/api';
 import {
   useCanvas,
@@ -263,17 +274,21 @@ export function Workspace() {
           </span>
         </div>
         <div className="ws-canvas-actions">
-          <button className="ghost small" onClick={() => setGitOpen(true)}>
-            Git
+          <button className="ghost small ws-canvas-action" onClick={() => setGitOpen(true)} title="Source control">
+            <GitBranch size={14} aria-hidden="true" />
+            <span>Git</span>
           </button>
-          <button className="ghost small" onClick={() => canvas.addTerminal()}>
-            + Terminal
+          <button className="ghost small ws-canvas-action" onClick={() => canvas.addTerminal()} title="Open terminal">
+            <SquareTerminal size={14} aria-hidden="true" />
+            <span>Terminal</span>
           </button>
-          <button className="ghost small" onClick={() => setFilesOpen(true)}>
-            Files
+          <button className="ghost small ws-canvas-action" onClick={() => setFilesOpen(true)} title="Browse files">
+            <FolderOpen size={14} aria-hidden="true" />
+            <span>Files</span>
           </button>
-          <button className="ghost small" onClick={handleNewSession}>
-            + New Session
+          <button className="ghost small ws-canvas-action" onClick={handleNewSession} title="New session">
+            <Plus size={14} aria-hidden="true" />
+            <span>Session</span>
           </button>
         </div>
       </header>
@@ -288,7 +303,8 @@ export function Workspace() {
             focusedPath={canvas.focusedSid && isFileSid(canvas.focusedSid) ? filePath(canvas.focusedSid) : ''}
             onOpen={(p) => {
               canvas.addFile(p);
-              // Keep the panel open so the user can browse more files.
+              // A phone-sized canvas needs the full width for the artifact.
+              if (typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(max-width: 768px)').matches) setFilesOpen(false);
             }}
           />
         )}
@@ -478,7 +494,13 @@ function SortableTile({
       ref={setRef}
       className={`ws-tile${isFocused ? ' focused' : ''}${isDragging ? ' dragging' : ''}${isRunning ? ' running' : ''}`}
       style={style}
+      role="group"
+      tabIndex={0}
+      aria-label={`${isFile ? 'File' : isTerminal ? 'Terminal' : 'Session'}: ${label}`}
       onClick={() => {
+        if (!isFocused) onFocus();
+      }}
+      onFocus={() => {
         if (!isFocused) onFocus();
       }}
     >
@@ -490,8 +512,12 @@ function SortableTile({
         </div>
       )}
       <div className="ws-tile-grip" {...attributes} {...listeners} title="Drag to reorder">
-        <span className="ws-tile-grip-dots">⋮⋮</span>
-        <span className="ws-tile-grip-label">{label}</span>
+        <span className="ws-tile-grip-dots" aria-hidden="true"><GripVertical size={14} /></span>
+        <span className="ws-tile-grip-label">
+          {isFile ? (
+            <span className="ws-tile-kind"><FileText size={13} aria-hidden="true" /> File</span>
+          ) : label}
+        </span>
         {!isDraft && !isTerminal && !isFile && (
         <button
           className="ws-tile-action"


### PR DESCRIPTION
## Summary

- Refine workspace and artifact tile chrome to establish a quieter two-level file header, stable toolbar, reading measure, and stronger Markdown hierarchy.
- Add Lucide workspace/file affordances, keyboard focus treatment, touch-sized tile actions, and neutral charcoal dark-mode surfaces.
- Make the Files panel a full-width mobile overlay and stack Split mode vertically in narrow artifact containers.

## Verification

- `pnpm build`
- `pnpm --filter @macaron/web test` (40 passing)
- Browser smoke at 1440x900, 1024-class desktop, 768x1024, and 390x844 in light and dark themes.
- Verified Preview, Split, Edit, desktop Files column, mobile Files overlay, no horizontal overflow, and touch close targets.

[MAC-9075](https://multica.macaron.xin/issues/bb2e4708-f9ac-4c89-87e9-5408df1936f3 "参考 Claude App 优化 Macaron Artifacts 子窗口的视觉层次")
