### PR TITLE
add event-level session replay

### DIFF
--- a/server/src/lib/codex-store.ts
+++ b/server/src/lib/codex-store.ts
@@ -224,9 +224,11 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
   let cwd = '';
   let gitBranch = '';
   const messages: Message[] = [];
+  const replayMessages: Message[] = [];
   // Track the last assistant message so subsequent tool_use / thinking
   // blocks land on the same bubble instead of forcing a new one.
   let currentAssistant: Message | null = null;
+  let sourceLine = 0;
   const ensureAssistant = (): Message => {
     if (currentAssistant) return currentAssistant;
     const m: Message = { role: 'assistant', blocks: [] };
@@ -236,6 +238,7 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
   };
 
   for (const line of raw.split('\n')) {
+    sourceLine++;
     const t = line.trim();
     if (!t) continue;
     let o: { type?: string; payload?: unknown; timestamp?: string };
@@ -262,7 +265,9 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
             role: 'user',
             blocks: [{ kind: 'text', text }],
             timestamp: o.timestamp,
+            sourceLine,
           });
+          replayMessages.push(messages[messages.length - 1]!);
         }
       } else if (kind === 'agent_message') {
         const text = String((p as { message?: string }).message || '').trim();
@@ -270,11 +275,16 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
         const m = ensureAssistant();
         m.blocks.push({ kind: 'text', text });
         m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'text', text }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'agent_reasoning') {
         const text = String((p as { text?: string }).text || '').trim();
         if (!text) continue;
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'thinking', text });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'thinking', text }], timestamp: o.timestamp, sourceLine });
       }
       continue;
     }
@@ -298,7 +308,10 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
           try { input = JSON.parse(input); } catch { /* keep as string */ }
         }
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'tool_use', id: callId, name, input });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_use', id: callId, name, input }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'function_call_output') {
         const callId = String(p.call_id || '');
         let text = '';
@@ -309,27 +322,36 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
           text = o2.output || o2.content || o2.text || JSON.stringify(output);
         }
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({
           kind: 'tool_result',
           toolUseId: callId,
           text: text.slice(0, 8000),
         });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_result', toolUseId: callId, text: text.slice(0, 8000) }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'custom_tool_call') {
         const name = String(p.name || 'custom');
         const callId = String(p.call_id || `codex-${messages.length}`);
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'tool_use', id: callId, name, input: p.input ?? {} });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_use', id: callId, name, input: p.input ?? {} }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'custom_tool_call_output') {
         const callId = String(p.call_id || '');
         const text = typeof p.output === 'string'
           ? p.output
           : JSON.stringify(p.output ?? '').slice(0, 8000);
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({
           kind: 'tool_result',
           toolUseId: callId,
           text: text.slice(0, 8000),
         });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_result', toolUseId: callId, text: text.slice(0, 8000) }], timestamp: o.timestamp, sourceLine });
       }
       // response_item / message / reasoning duplicate the event_msg
       // stream we already consumed — skip.
@@ -344,6 +366,7 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
     cwd,
     gitBranch,
     messages,
+    replayMessages,
     truncated: false,
     totalBytes: st.size,
   };

--- a/server/src/lib/session-store.ts
+++ b/server/src/lib/session-store.ts
@@ -594,7 +594,9 @@ async function parseTranscriptFile(filePath: string): Promise<{
   let thinkChars = 0;
   let toolCallChars = 0;
   let toolResultChars = 0;
+  let sourceLine = 0;
   for (const line of raw.split('\n')) {
+    sourceLine++;
     if (!line.trim()) continue;
     try {
       const o = JSON.parse(line);
@@ -609,6 +611,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
           blocks: [{ kind: 'system_event', eventType: 'summary', text: o.summary }],
           timestamp: o.timestamp,
           uuid: o.uuid,
+          sourceLine,
         });
         continue;
       }
@@ -636,6 +639,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
                 blocks: [{ kind: 'system_event', eventType: 'resume', text: t }],
                 timestamp: o.timestamp,
                 uuid: o.uuid,
+                sourceLine,
               });
             }
           }
@@ -685,6 +689,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
           model: o.message?.model,
           timestamp: o.timestamp,
           uuid: o.uuid,
+          sourceLine,
         });
         if (o.type === 'assistant' && o.message?.usage) {
           const u = o.message.usage;
@@ -758,6 +763,7 @@ export async function readSessionMessages(project: string, sid: string): Promise
     cwd,
     gitBranch,
     messages,
+    replayMessages: messages,
     truncated,
     totalBytes,
     latestUsage,

--- a/server/test/session-store.test.ts
+++ b/server/test/session-store.test.ts
@@ -68,6 +68,14 @@ test('tail-truncated sessions keep the flat context bar instead of estimating a 
   assert.equal(detail.contextBreakdown, undefined);
 });
 
+test('messages preserve jsonl source order for stable replay', async () => {
+  await writeSession('replay', [stringUserLine, assistantLine]);
+  const detail = await readSessionMessages(PROJECT, 'replay');
+  assert.deepEqual(detail.messages.map((message) => message.sourceLine), [1, 2]);
+  assert.deepEqual(detail.messages.map((message) => message.timestamp), ['2026-07-07T00:00:00Z', '2026-07-07T00:00:01Z']);
+  assert.equal(detail.replayMessages, detail.messages);
+});
+
 test('project cwd resolution prefers a live session and otherwise uses the trusted registry fallback', async () => {
   const cwdProject = 'cwd-resolution';
   const cwdProjectDir = path.join(CLAUDE_PROJECTS, cwdProject);

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -57,6 +57,7 @@ export type Message = {
   model?: string;
   timestamp?: string;
   uuid?: string;
+  sourceLine?: number;
 };
 
 // Token usage snapshot taken from the last assistant message's `usage`
@@ -91,6 +92,7 @@ export type SessionDetail = {
   cwd: string;
   gitBranch?: string;
   messages: Message[];
+  replayMessages?: Message[];
   truncated?: boolean;
   totalBytes?: number;
   latestUsage?: UsageSnapshot;

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -15,6 +15,7 @@ import type { CodexRuntimeOverride } from './api';
 import { sendCodexMessage, startCodexThread, subscribeCodexLive, type CodexStreamEvent } from './stream';
 import { CodexComposer, type ComposerImage } from './CodexComposer';
 import { notify } from '../lib/notify';
+import { useReplay } from '../components/ReplayControls';
 
 // GenuiPreview + its vendored runtime (~500KB gzip) is behind a lazy
 // import so the default codex bundle stays small. First render_ui in a
@@ -486,7 +487,8 @@ export function CodexChat(props: CodexChatProps = {}) {
     };
   }, [sid, isNew, refreshKey]);
 
-  const diskHistory = useMemo(() => (detail ? historyToItems(detail) : []), [detail]);
+  const replay = useReplay(detail?.replayMessages ?? detail?.messages ?? [], isNew || sending);
+  const diskHistory = useMemo(() => detail ? historyToItems({ ...detail, messages: replay.messages }) : [], [detail, replay.messages]);
   const history = useMemo(
     () => reconcileHistoryWithLive(diskHistory, live),
     [diskHistory, live],
@@ -618,6 +620,7 @@ export function CodexChat(props: CodexChatProps = {}) {
       {!hideBar && (
         <div className="cx-main-head">
           <div className="cx-main-head-title">{title}</div>
+          <div className="cx-main-head-replay">{replay.controls}</div>
           {!isNew && (
             <>
               <span className="cx-main-head-dot">·</span>

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -318,6 +318,12 @@ body {
   font-size: 12px;
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 }
+.cx-main-head-replay { margin-left: auto; }
+.cx-main-head-replay .replay-controls { display: flex; align-items: center; gap: 5px; }
+.cx-main-head-replay .replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--cx-border); border-radius: 7px; background: transparent; color: var(--cx-muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
+.cx-main-head-replay .replay-button:hover { background: var(--cx-hover); color: var(--cx-text); }
+.cx-main-head-replay input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--cx-accent, #C96442); }
+.cx-main-head-replay .replay-count { color: var(--cx-muted); font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; font-size: 11px; white-space: nowrap; }
 .cx-main-scroll {
   flex: 1;
   overflow-y: auto;

--- a/web/src/components/ReplayControls.tsx
+++ b/web/src/components/ReplayControls.tsx
@@ -1,0 +1,52 @@
+import { Pause, Play, RotateCcw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import type { Message } from '@macaron/shared';
+
+const SPEEDS = [1, 2, 5] as const;
+const MAX_DELAY_MS = 2_000;
+
+function eventTime(message: Message, fallback: number): number {
+  const timestamp = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
+  return Number.isFinite(timestamp) ? timestamp : fallback;
+}
+
+export function useReplay(messages: Message[], disabled = false) {
+  const [active, setActive] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [cursor, setCursor] = useState(messages.length);
+  const [speed, setSpeed] = useState<(typeof SPEEDS)[number]>(1);
+  const signature = `${messages.length}:${messages.at(-1)?.sourceLine ?? ''}:${messages.at(-1)?.timestamp ?? ''}`;
+  const timeline = useMemo(() => messages.map((message, index) => ({ message, time: eventTime(message, index) })), [signature]);
+
+  useEffect(() => {
+    setActive(false);
+    setPlaying(false);
+    setCursor(messages.length);
+  }, [signature]);
+
+  useEffect(() => {
+    if (!active || !playing) return;
+    if (cursor >= timeline.length) { setPlaying(false); return; }
+    const previous = cursor > 0 ? timeline[cursor - 1]!.time : timeline[cursor]!.time;
+    const delay = Math.min(MAX_DELAY_MS, Math.max(0, timeline[cursor]!.time - previous)) / speed;
+    const timer = window.setTimeout(() => setCursor((value) => value + 1), delay);
+    return () => window.clearTimeout(timer);
+  }, [active, cursor, playing, speed, timeline]);
+
+  const start = () => { setActive(true); setCursor(0); setPlaying(true); };
+  const stop = () => { setActive(false); setPlaying(false); setCursor(messages.length); };
+  return {
+    messages: active ? messages.slice(0, cursor) : messages,
+    controls: disabled || messages.length < 2 ? null : (
+      <div className="replay-controls" role="group" aria-label="Session replay">
+        <button className="replay-button" onClick={active ? () => setPlaying((value) => !value) : start} title={active && playing ? 'Pause replay' : 'Play replay'} aria-label={active && playing ? 'Pause replay' : 'Play replay'}>
+          {active && playing ? <Pause size={14} aria-hidden="true" /> : <Play size={14} aria-hidden="true" />}
+        </button>
+        {active && <button className="replay-button" onClick={stop} title="Exit replay" aria-label="Exit replay"><RotateCcw size={14} aria-hidden="true" /></button>}
+        <input type="range" min={0} max={messages.length} value={active ? cursor : messages.length} onChange={(event) => { setActive(true); setPlaying(false); setCursor(Number(event.target.value)); }} aria-label="Replay position" />
+        <span className="replay-count">{active ? cursor : messages.length}/{messages.length}</span>
+        <button className="replay-button replay-speed" onClick={() => setSpeed(SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length]!)} title="Replay speed">{speed}×</button>
+      </div>
+    ),
+  };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -598,6 +598,12 @@ textarea:focus, select:focus, input:focus {
   font-size: 11.5px;
   color: var(--muted);
 }
+.replay-controls { display: flex; align-items: center; gap: 5px; min-width: 0; }
+.replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--border); border-radius: 7px; background: transparent; color: var(--muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
+.replay-button:hover { background: var(--surface-2); color: var(--text); }
+.replay-controls input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--accent); }
+.replay-count { color: var(--muted); font-family: var(--font-mono); font-size: 11px; white-space: nowrap; }
+.replay-speed { width: 34px; font-size: 11px; }
 .load-earlier {
   align-self: center;
   padding: 6px 14px;

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
 import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
+import { useReplay } from '../components/ReplayControls';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -1927,7 +1928,8 @@ export function Session(props: SessionProps = {}) {
     };
   }, [commitSnapshot, fetchSnapshot, isPending, liveSubscriptionGen, sid, onPendingConsumed]);
 
-  const rawItems = useMemo(() => (data ? flatten(data.messages) : []), [data]);
+  const replay = useReplay(data?.replayMessages ?? data?.messages ?? [], isNew || sending || polling || handoffPending);
+  const rawItems = useMemo(() => flatten(replay.messages), [replay.messages]);
   // Collapse consecutive read-only tool operations (Read / Grep / Glob /
   // cat / grep / ls / …) into a single summary badge, mirroring Claude
   // Code CLI's `⏺ Searching for N patterns, reading M files, listing K
@@ -2609,6 +2611,7 @@ export function Session(props: SessionProps = {}) {
             {data?.gitBranch && <span className="sess-branch">{data.gitBranch}</span>}
           </div>
           <div className="session-bar-right">
+            {replay.controls}
             {!isNew && (
               <button
                 className="ghost small"


### PR DESCRIPTION
## Summary
- preserve JSONL source order and expose replay-specific message events
- replay Codex text, reasoning, and tool events without its duplicate persisted records
- add play/pause, scrubbing, exit, and 1x/2x/5x controls to Claude and Codex sessions
- cap long idle gaps at two seconds

## Testing
- 
- local tests/typecheck unavailable because this runtime has Node 18 but no pnpm/corepack/bun; CI is the source of truth

Closes [MAC-9120](https://multica.macaron.xin/issues/3400b928-485b-4fe3-9c98-6cdec0344a48 "调研 Claude Code 与 Codex Session 消息时间戳及回放可行性")