### PR TITLE
add event-level session replay

### DIFF
--- a/server/src/lib/codex-store.ts
+++ b/server/src/lib/codex-store.ts
@@ -224,9 +224,11 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
   let cwd = '';
   let gitBranch = '';
   const messages: Message[] = [];
+  const replayMessages: Message[] = [];
   // Track the last assistant message so subsequent tool_use / thinking
   // blocks land on the same bubble instead of forcing a new one.
   let currentAssistant: Message | null = null;
+  let sourceLine = 0;
   const ensureAssistant = (): Message => {
     if (currentAssistant) return currentAssistant;
     const m: Message = { role: 'assistant', blocks: [] };
@@ -236,6 +238,7 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
   };
 
   for (const line of raw.split('\n')) {
+    sourceLine++;
     const t = line.trim();
     if (!t) continue;
     let o: { type?: string; payload?: unknown; timestamp?: string };
@@ -262,7 +265,9 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
             role: 'user',
             blocks: [{ kind: 'text', text }],
             timestamp: o.timestamp,
+            sourceLine,
           });
+          replayMessages.push(messages[messages.length - 1]!);
         }
       } else if (kind === 'agent_message') {
         const text = String((p as { message?: string }).message || '').trim();
@@ -270,11 +275,16 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
         const m = ensureAssistant();
         m.blocks.push({ kind: 'text', text });
         m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'text', text }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'agent_reasoning') {
         const text = String((p as { text?: string }).text || '').trim();
         if (!text) continue;
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'thinking', text });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'thinking', text }], timestamp: o.timestamp, sourceLine });
       }
       continue;
     }
@@ -298,7 +308,10 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
           try { input = JSON.parse(input); } catch { /* keep as string */ }
         }
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'tool_use', id: callId, name, input });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_use', id: callId, name, input }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'function_call_output') {
         const callId = String(p.call_id || '');
         let text = '';
@@ -309,27 +322,36 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
           text = o2.output || o2.content || o2.text || JSON.stringify(output);
         }
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({
           kind: 'tool_result',
           toolUseId: callId,
           text: text.slice(0, 8000),
         });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_result', toolUseId: callId, text: text.slice(0, 8000) }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'custom_tool_call') {
         const name = String(p.name || 'custom');
         const callId = String(p.call_id || `codex-${messages.length}`);
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({ kind: 'tool_use', id: callId, name, input: p.input ?? {} });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_use', id: callId, name, input: p.input ?? {} }], timestamp: o.timestamp, sourceLine });
       } else if (kind === 'custom_tool_call_output') {
         const callId = String(p.call_id || '');
         const text = typeof p.output === 'string'
           ? p.output
           : JSON.stringify(p.output ?? '').slice(0, 8000);
         const m = ensureAssistant();
+        m.timestamp ??= o.timestamp;
+        m.sourceLine ??= sourceLine;
         m.blocks.push({
           kind: 'tool_result',
           toolUseId: callId,
           text: text.slice(0, 8000),
         });
+        replayMessages.push({ role: 'assistant', blocks: [{ kind: 'tool_result', toolUseId: callId, text: text.slice(0, 8000) }], timestamp: o.timestamp, sourceLine });
       }
       // response_item / message / reasoning duplicate the event_msg
       // stream we already consumed — skip.
@@ -344,6 +366,7 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
     cwd,
     gitBranch,
     messages,
+    replayMessages,
     truncated: false,
     totalBytes: st.size,
   };

--- a/server/src/lib/session-store.ts
+++ b/server/src/lib/session-store.ts
@@ -594,7 +594,9 @@ async function parseTranscriptFile(filePath: string): Promise<{
   let thinkChars = 0;
   let toolCallChars = 0;
   let toolResultChars = 0;
+  let sourceLine = 0;
   for (const line of raw.split('\n')) {
+    sourceLine++;
     if (!line.trim()) continue;
     try {
       const o = JSON.parse(line);
@@ -609,6 +611,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
           blocks: [{ kind: 'system_event', eventType: 'summary', text: o.summary }],
           timestamp: o.timestamp,
           uuid: o.uuid,
+          sourceLine,
         });
         continue;
       }
@@ -636,6 +639,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
                 blocks: [{ kind: 'system_event', eventType: 'resume', text: t }],
                 timestamp: o.timestamp,
                 uuid: o.uuid,
+                sourceLine,
               });
             }
           }
@@ -685,6 +689,7 @@ async function parseTranscriptFile(filePath: string): Promise<{
           model: o.message?.model,
           timestamp: o.timestamp,
           uuid: o.uuid,
+          sourceLine,
         });
         if (o.type === 'assistant' && o.message?.usage) {
           const u = o.message.usage;
@@ -758,6 +763,7 @@ export async function readSessionMessages(project: string, sid: string): Promise
     cwd,
     gitBranch,
     messages,
+    replayMessages: messages,
     truncated,
     totalBytes,
     latestUsage,

--- a/server/test/session-store.test.ts
+++ b/server/test/session-store.test.ts
@@ -68,6 +68,14 @@ test('tail-truncated sessions keep the flat context bar instead of estimating a 
   assert.equal(detail.contextBreakdown, undefined);
 });
 
+test('messages preserve jsonl source order for stable replay', async () => {
+  await writeSession('replay', [stringUserLine, assistantLine]);
+  const detail = await readSessionMessages(PROJECT, 'replay');
+  assert.deepEqual(detail.messages.map((message) => message.sourceLine), [1, 2]);
+  assert.deepEqual(detail.messages.map((message) => message.timestamp), ['2026-07-07T00:00:00Z', '2026-07-07T00:00:01Z']);
+  assert.equal(detail.replayMessages, detail.messages);
+});
+
 test('project cwd resolution prefers a live session and otherwise uses the trusted registry fallback', async () => {
   const cwdProject = 'cwd-resolution';
   const cwdProjectDir = path.join(CLAUDE_PROJECTS, cwdProject);

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -57,6 +57,7 @@ export type Message = {
   model?: string;
   timestamp?: string;
   uuid?: string;
+  sourceLine?: number;
 };
 
 // Token usage snapshot taken from the last assistant message's `usage`
@@ -91,6 +92,7 @@ export type SessionDetail = {
   cwd: string;
   gitBranch?: string;
   messages: Message[];
+  replayMessages?: Message[];
   truncated?: boolean;
   totalBytes?: number;
   latestUsage?: UsageSnapshot;

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -16,6 +16,7 @@ import { sendCodexMessage, startCodexThread, subscribeCodexLive, type CodexStrea
 import { CodexComposer, type ComposerImage } from './CodexComposer';
 import { notify } from '../lib/notify';
 import { useReplay } from '../components/ReplayControls';
+import { formatDuration } from '../lib/thinkingVerbs';
 
 // GenuiPreview + its vendored runtime (~500KB gzip) is behind a lazy
 // import so the default codex bundle stays small. First render_ui in a
@@ -32,7 +33,7 @@ type Item =
   | { id: string; kind: 'user'; text: string; images?: ComposerImage[] }
   | { id: string; kind: 'assistant'; text: string }
   | { id: string; kind: 'reasoning'; text: string }
-  | { id: string; kind: 'tool'; name: string; input: unknown; result?: string; isError?: boolean }
+  | { id: string; kind: 'tool'; name: string; input: unknown; result?: string; durationMs?: number; isError?: boolean }
   // GenUI render_ui tool call. Codex hands us the full `code` at
   // tool_use time (arguments are already aggregated by the CLI), so we
   // render immediately — no pending phase in practice. The tool_result
@@ -67,9 +68,10 @@ function toolInputToCmd(name: string, input: unknown): string {
 
 function historyToItems(detail: SessionDetail): Item[] {
   const out: Item[] = [];
+  const toolStartedAt = new Map<string, number>();
   let seq = 0;
   const next = () => `h-${seq++}`;
-  const walk = (blocks: Block[], role: Message['role']) => {
+  const walk = (blocks: Block[], role: Message['role'], timestamp?: string) => {
     for (const b of blocks) {
       if (b.kind === 'text' && b.text.trim()) {
         if (role === 'user') out.push({ id: next(), kind: 'user', text: b.text });
@@ -88,6 +90,7 @@ function historyToItems(detail: SessionDetail): Item[] {
           });
         } else {
           out.push({ id: b.id, kind: 'tool', name: b.name, input: b.input });
+          if (timestamp) toolStartedAt.set(b.id, Date.parse(timestamp));
         }
       } else if (b.kind === 'tool_result') {
         const target = [...out].reverse().find(
@@ -95,7 +98,12 @@ function historyToItems(detail: SessionDetail): Item[] {
             (it.kind === 'tool' && it.result === undefined && (b.toolUseId ? it.id === b.toolUseId : true))
             || (it.kind === 'genui' && it.toolUseId === b.toolUseId),
         );
-        if (target?.kind === 'tool') target.result = b.text;
+        if (target?.kind === 'tool') {
+          target.result = b.text;
+          const startedAt = toolStartedAt.get(target.id);
+          const finishedAt = timestamp ? Date.parse(timestamp) : NaN;
+          if (startedAt !== undefined && Number.isFinite(startedAt) && Number.isFinite(finishedAt) && finishedAt >= startedAt) target.durationMs = finishedAt - startedAt;
+        }
         else if (target?.kind === 'genui') {
           const flagged = b.text.startsWith('Rendered inline, but the TSX has issues');
           if (flagged) { target.status = 'error'; target.error = b.text; }
@@ -103,7 +111,7 @@ function historyToItems(detail: SessionDetail): Item[] {
       }
     }
   };
-  for (const m of detail.messages) walk(m.blocks, m.role);
+  for (const m of detail.messages) walk(m.blocks, m.role, m.timestamp);
   return out;
 }
 
@@ -220,7 +228,7 @@ function ToolCard({ it }: { it: Extract<Item, { kind: 'tool' }> }) {
         <span className="cx-tool-glyph">{toolGlyph(it.name)}</span>
         <span className="cx-tool-name">{it.name}</span>
         <span className={'cx-tool-status' + (it.isError ? ' err' : '')}>
-          {running ? 'running…' : it.isError ? 'failed' : 'done'}
+          {running ? 'running…' : it.isError ? 'failed' : 'done'}{it.durationMs != null ? ` · ${formatDuration(it.durationMs)}` : ''}
         </span>
       </div>
       <div className="cx-tool-cmd">{cmd}</div>

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -38,7 +38,7 @@ type Item =
   // tool_use time (arguments are already aggregated by the CLI), so we
   // render immediately — no pending phase in practice. The tool_result
   // (checkGenUI diagnostics) may flip `status` to 'error' with details.
-  | { id: string; kind: 'genui'; toolUseId: string; code: string; status: 'ready' | 'error'; error?: string }
+  | { id: string; kind: 'genui'; toolUseId: string; code: string; status: 'ready' | 'error'; streaming?: boolean; error?: string }
   // Codex-native plan card (turn/plan/updated). One per thread, replaced in
   // place as new plan snapshots arrive.
   | { id: string; kind: 'plan'; steps: Array<{ step: string; status: CodexPlanStatus }>; explanation?: string | null }
@@ -80,13 +80,15 @@ function historyToItems(detail: SessionDetail): Item[] {
         out.push({ id: next(), kind: 'reasoning', text: b.text });
       } else if (b.kind === 'tool_use') {
         if (isRenderUiTool(b.name)) {
-          const code = String((b.input as { code?: unknown } | null)?.code || '');
+           const input = b.input as { code?: unknown; _replayStreaming?: boolean } | null;
+           const code = String(input?.code || '');
           out.push({
             id: `genui-${b.id}`,
             kind: 'genui',
             toolUseId: b.id,
-            code,
-            status: 'ready',
+             code,
+             status: 'ready',
+             streaming: input?._replayStreaming,
           });
         } else {
           out.push({ id: b.id, kind: 'tool', name: b.name, input: b.input });
@@ -255,7 +257,7 @@ function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
         {it.status === 'error' && <span className="cx-genui-status err">diagnostics failed</span>}
       </div>
       <Suspense fallback={<div className="cx-genui-loading">Loading GenUI runtime…</div>}>
-        <GenuiPreview code={it.code} done />
+        <GenuiPreview code={it.code} done={!it.streaming} />
       </Suspense>
       {it.status === 'error' && it.error && (
         <details className="cx-genui-details">

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -15,6 +15,7 @@ import type { CodexRuntimeOverride } from './api';
 import { sendCodexMessage, startCodexThread, subscribeCodexLive, type CodexStreamEvent } from './stream';
 import { CodexComposer, type ComposerImage } from './CodexComposer';
 import { notify } from '../lib/notify';
+import { useReplay } from '../components/ReplayControls';
 
 // GenuiPreview + its vendored runtime (~500KB gzip) is behind a lazy
 // import so the default codex bundle stays small. First render_ui in a
@@ -486,7 +487,8 @@ export function CodexChat(props: CodexChatProps = {}) {
     };
   }, [sid, isNew, refreshKey]);
 
-  const diskHistory = useMemo(() => (detail ? historyToItems(detail) : []), [detail]);
+  const replay = useReplay(detail?.replayMessages ?? detail?.messages ?? [], isNew || sending);
+  const diskHistory = useMemo(() => detail ? historyToItems({ ...detail, messages: replay.messages }) : [], [detail, replay.messages]);
   const history = useMemo(
     () => reconcileHistoryWithLive(diskHistory, live),
     [diskHistory, live],
@@ -618,6 +620,7 @@ export function CodexChat(props: CodexChatProps = {}) {
       {!hideBar && (
         <div className="cx-main-head">
           <div className="cx-main-head-title">{title}</div>
+          <div className="cx-main-head-replay">{replay.controls}</div>
           {!isNew && (
             <>
               <span className="cx-main-head-dot">·</span>

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -322,6 +322,10 @@ body {
 .cx-main-head-replay .replay-controls { display: flex; align-items: center; gap: 5px; }
 .cx-main-head-replay .replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--cx-border); border-radius: 7px; background: transparent; color: var(--cx-muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
 .cx-main-head-replay .replay-button:hover { background: var(--cx-hover); color: var(--cx-text); }
+.cx-main-head-replay .replay-settings-menu { border-color: var(--cx-border); background: var(--cx-panel); box-shadow: var(--cx-shadow); }
+.cx-main-head-replay .replay-settings-menu label { color: var(--cx-text); }
+.cx-main-head-replay .replay-settings-menu select { border-color: var(--cx-border); background: var(--cx-panel); color: var(--cx-text); }
+.cx-main-head-replay .replay-settings-menu span { color: var(--cx-muted); }
 .cx-main-head-replay input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--cx-accent, #C96442); }
 .cx-main-head-replay .replay-count { color: var(--cx-muted); font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; font-size: 11px; white-space: nowrap; }
 .cx-main-scroll {

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -318,6 +318,12 @@ body {
   font-size: 12px;
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 }
+.cx-main-head-replay { margin-left: auto; }
+.cx-main-head-replay .replay-controls { display: flex; align-items: center; gap: 5px; }
+.cx-main-head-replay .replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--cx-border); border-radius: 7px; background: transparent; color: var(--cx-muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
+.cx-main-head-replay .replay-button:hover { background: var(--cx-hover); color: var(--cx-text); }
+.cx-main-head-replay input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--cx-accent, #C96442); }
+.cx-main-head-replay .replay-count { color: var(--cx-muted); font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; font-size: 11px; white-space: nowrap; }
 .cx-main-scroll {
   flex: 1;
   overflow-y: auto;

--- a/web/src/components/ReplayControls.tsx
+++ b/web/src/components/ReplayControls.tsx
@@ -1,7 +1,7 @@
-import { Pause, Play, RotateCcw } from 'lucide-react';
+import { Pause, Play, RotateCcw, Settings2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { Message } from '@macaron/shared';
-import { createReplayTimeline, replayFrame } from '../lib/replay';
+import { createReplayTimeline, replayFrame, type ReplayTiming } from '../lib/replay';
 
 const SPEEDS = [1, 2, 5] as const;
 
@@ -10,8 +10,9 @@ export function useReplay(messages: Message[], disabled = false) {
   const [playing, setPlaying] = useState(false);
   const [position, setPosition] = useState(0);
   const [speed, setSpeed] = useState<(typeof SPEEDS)[number]>(1);
+  const [timing, setTiming] = useState<ReplayTiming>('natural');
   const signature = `${messages.length}:${messages.at(-1)?.sourceLine ?? ''}:${messages.at(-1)?.timestamp ?? ''}`;
-  const timeline = useMemo(() => createReplayTimeline(messages), [signature]);
+  const timeline = useMemo(() => createReplayTimeline(messages, timing), [signature, timing]);
   const duration = timeline.at(-1)?.end ?? 0;
   const visibleMessages = useMemo(() => active ? replayFrame(timeline, position) : messages, [active, messages, position, timeline]);
 
@@ -48,6 +49,18 @@ export function useReplay(messages: Message[], disabled = false) {
         <button className="replay-button" onClick={active ? () => setPlaying((value) => !value) : start} title={active && playing ? 'Pause replay' : 'Play replay'} aria-label={active && playing ? 'Pause replay' : 'Play replay'}>
           {active && playing ? <Pause size={14} aria-hidden="true" /> : <Play size={14} aria-hidden="true" />}
         </button>
+        <details className="replay-settings">
+          <summary className="replay-button" title="Replay timing" aria-label="Replay timing"><Settings2 size={14} aria-hidden="true" /></summary>
+          <div className="replay-settings-menu">
+            <label htmlFor="replay-timing">Timing</label>
+            <select id="replay-timing" value={timing} onChange={(event) => { setTiming(event.target.value as ReplayTiming); setPosition(0); setPlaying(false); }}>
+              <option value="exact">Exact</option>
+              <option value="natural">Natural (log)</option>
+              <option value="compact">Compact (2s max)</option>
+            </select>
+            <span>{timing === 'exact' ? 'Original event timing' : timing === 'natural' ? 'Long waits use a logarithmic curve' : 'Every wait is capped at 2 seconds'}</span>
+          </div>
+        </details>
         {active && <button className="replay-button" onClick={stop} title="Exit replay" aria-label="Exit replay"><RotateCcw size={14} aria-hidden="true" /></button>}
         <input type="range" min={0} max={Math.max(1, duration)} value={active ? position : duration} onChange={(event) => { setActive(true); setPlaying(false); setPosition(Number(event.target.value)); }} aria-label="Replay position" />
         <span className="replay-count">{visibleMessages.length}/{messages.length}</span>

--- a/web/src/components/ReplayControls.tsx
+++ b/web/src/components/ReplayControls.tsx
@@ -1,50 +1,56 @@
 import { Pause, Play, RotateCcw } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { Message } from '@macaron/shared';
+import { createReplayTimeline, replayFrame } from '../lib/replay';
 
 const SPEEDS = [1, 2, 5] as const;
-const MAX_DELAY_MS = 2_000;
-
-function eventTime(message: Message, fallback: number): number {
-  const timestamp = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
-  return Number.isFinite(timestamp) ? timestamp : fallback;
-}
 
 export function useReplay(messages: Message[], disabled = false) {
   const [active, setActive] = useState(false);
   const [playing, setPlaying] = useState(false);
-  const [cursor, setCursor] = useState(messages.length);
+  const [position, setPosition] = useState(0);
   const [speed, setSpeed] = useState<(typeof SPEEDS)[number]>(1);
   const signature = `${messages.length}:${messages.at(-1)?.sourceLine ?? ''}:${messages.at(-1)?.timestamp ?? ''}`;
-  const timeline = useMemo(() => messages.map((message, index) => ({ message, time: eventTime(message, index) })), [signature]);
+  const timeline = useMemo(() => createReplayTimeline(messages), [signature]);
+  const duration = timeline.at(-1)?.end ?? 0;
+  const visibleMessages = useMemo(() => active ? replayFrame(timeline, position) : messages, [active, messages, position, timeline]);
 
   useEffect(() => {
     setActive(false);
     setPlaying(false);
-    setCursor(messages.length);
+    setPosition(0);
   }, [signature]);
 
   useEffect(() => {
     if (!active || !playing) return;
-    if (cursor >= timeline.length) { setPlaying(false); return; }
-    const previous = cursor > 0 ? timeline[cursor - 1]!.time : timeline[cursor]!.time;
-    const delay = Math.min(MAX_DELAY_MS, Math.max(0, timeline[cursor]!.time - previous)) / speed;
-    const timer = window.setTimeout(() => setCursor((value) => value + 1), delay);
-    return () => window.clearTimeout(timer);
-  }, [active, cursor, playing, speed, timeline]);
+    let animationFrame = 0;
+    let previous = performance.now();
+    const tick = (now: number) => {
+      const delta = now - previous;
+      previous = now;
+      setPosition((value) => Math.min(duration, value + delta * speed));
+      animationFrame = window.requestAnimationFrame(tick);
+    };
+    animationFrame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [active, duration, playing, speed]);
 
-  const start = () => { setActive(true); setCursor(0); setPlaying(true); };
-  const stop = () => { setActive(false); setPlaying(false); setCursor(messages.length); };
+  useEffect(() => {
+    if (active && playing && position >= duration) setPlaying(false);
+  }, [active, duration, playing, position]);
+
+  const start = () => { setActive(true); setPosition(0); setPlaying(true); };
+  const stop = () => { setActive(false); setPlaying(false); setPosition(0); };
   return {
-    messages: active ? messages.slice(0, cursor) : messages,
+    messages: visibleMessages,
     controls: disabled || messages.length < 2 ? null : (
       <div className="replay-controls" role="group" aria-label="Session replay">
         <button className="replay-button" onClick={active ? () => setPlaying((value) => !value) : start} title={active && playing ? 'Pause replay' : 'Play replay'} aria-label={active && playing ? 'Pause replay' : 'Play replay'}>
           {active && playing ? <Pause size={14} aria-hidden="true" /> : <Play size={14} aria-hidden="true" />}
         </button>
         {active && <button className="replay-button" onClick={stop} title="Exit replay" aria-label="Exit replay"><RotateCcw size={14} aria-hidden="true" /></button>}
-        <input type="range" min={0} max={messages.length} value={active ? cursor : messages.length} onChange={(event) => { setActive(true); setPlaying(false); setCursor(Number(event.target.value)); }} aria-label="Replay position" />
-        <span className="replay-count">{active ? cursor : messages.length}/{messages.length}</span>
+        <input type="range" min={0} max={Math.max(1, duration)} value={active ? position : duration} onChange={(event) => { setActive(true); setPlaying(false); setPosition(Number(event.target.value)); }} aria-label="Replay position" />
+        <span className="replay-count">{visibleMessages.length}/{messages.length}</span>
         <button className="replay-button replay-speed" onClick={() => setSpeed(SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length]!)} title="Replay speed">{speed}×</button>
       </div>
     ),

--- a/web/src/components/ReplayControls.tsx
+++ b/web/src/components/ReplayControls.tsx
@@ -1,0 +1,52 @@
+import { Pause, Play, RotateCcw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import type { Message } from '@macaron/shared';
+
+const SPEEDS = [1, 2, 5] as const;
+const MAX_DELAY_MS = 2_000;
+
+function eventTime(message: Message, fallback: number): number {
+  const timestamp = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
+  return Number.isFinite(timestamp) ? timestamp : fallback;
+}
+
+export function useReplay(messages: Message[], disabled = false) {
+  const [active, setActive] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [cursor, setCursor] = useState(messages.length);
+  const [speed, setSpeed] = useState<(typeof SPEEDS)[number]>(1);
+  const signature = `${messages.length}:${messages.at(-1)?.sourceLine ?? ''}:${messages.at(-1)?.timestamp ?? ''}`;
+  const timeline = useMemo(() => messages.map((message, index) => ({ message, time: eventTime(message, index) })), [signature]);
+
+  useEffect(() => {
+    setActive(false);
+    setPlaying(false);
+    setCursor(messages.length);
+  }, [signature]);
+
+  useEffect(() => {
+    if (!active || !playing) return;
+    if (cursor >= timeline.length) { setPlaying(false); return; }
+    const previous = cursor > 0 ? timeline[cursor - 1]!.time : timeline[cursor]!.time;
+    const delay = Math.min(MAX_DELAY_MS, Math.max(0, timeline[cursor]!.time - previous)) / speed;
+    const timer = window.setTimeout(() => setCursor((value) => value + 1), delay);
+    return () => window.clearTimeout(timer);
+  }, [active, cursor, playing, speed, timeline]);
+
+  const start = () => { setActive(true); setCursor(0); setPlaying(true); };
+  const stop = () => { setActive(false); setPlaying(false); setCursor(messages.length); };
+  return {
+    messages: active ? messages.slice(0, cursor) : messages,
+    controls: disabled || messages.length < 2 ? null : (
+      <div className="replay-controls" role="group" aria-label="Session replay">
+        <button className="replay-button" onClick={active ? () => setPlaying((value) => !value) : start} title={active && playing ? 'Pause replay' : 'Play replay'} aria-label={active && playing ? 'Pause replay' : 'Play replay'}>
+          {active && playing ? <Pause size={14} aria-hidden="true" /> : <Play size={14} aria-hidden="true" />}
+        </button>
+        {active && <button className="replay-button" onClick={stop} title="Exit replay" aria-label="Exit replay"><RotateCcw size={14} aria-hidden="true" /></button>}
+        <input type="range" min={0} max={messages.length} value={active ? cursor : messages.length} onChange={(event) => { setActive(true); setPlaying(false); setCursor(Number(event.target.value)); }} aria-label="Replay position" />
+        <span className="replay-count">{active ? cursor : messages.length}/{messages.length}</span>
+        <button className="replay-button replay-speed" onClick={() => setSpeed(SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length]!)} title="Replay speed">{speed}×</button>
+      </div>
+    ),
+  };
+}

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -4,7 +4,9 @@ export type ReplayTiming = 'exact' | 'natural' | 'compact';
 
 export type ReplayTimelineEntry = { message: Message; start: number; end: number; renderUICode?: string };
 
-const RENDER_UI_TOKENS_PER_SECOND = 40;
+// Historical jsonl has no token-level timing, so the stream start is
+// back-calculated from the recorded tool_use completion time at this rate.
+const RENDER_UI_TOKENS_PER_SECOND = 50;
 const CHARS_PER_TOKEN = 4;
 
 function timestamp(message: Message): number | undefined {

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -49,12 +49,21 @@ export function replayFrame(timeline: ReplayTimelineEntry[], position: number): 
       // text 之后成对落盘），反推的 streaming 起点却远早于两者。若遇到未到时间
       // 的 text 就 break，streaming 窗口内永远轮不到这条 render_ui 出现。
       const progress = (position - entry.start) / (entry.end - entry.start);
-      visible.push(withRenderUICode(entry.message, entry.renderUICode.slice(0, Math.max(1, Math.floor(entry.renderUICode.length * progress)))));
+      visible.push(withRenderUICode(entry.message, partialCodeAt(entry.renderUICode, progress)));
     }
     // end 单调递增，未到时间的普通消息之后也不会到时间，继续扫描只为找到
     // start 更早的 streaming render_ui。
   }
   return visible;
+}
+
+// 任意字符位置截断会把标识符切成半截，partial 编译基本必挂；按行边界截断
+// 后 partial-react 才能逐行 salvage 出越来越多的内容。
+function partialCodeAt(code: string, progress: number): string {
+  const target = Math.max(1, Math.floor(code.length * Math.min(1, progress)));
+  if (target >= code.length) return code;
+  const newline = code.indexOf('\n', target);
+  return code.slice(0, newline === -1 ? code.length : newline + 1);
 }
 
 function getRenderUICode(message: Message): string | undefined {

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -1,21 +1,12 @@
 import type { Message } from '@macaron/shared';
 
-const MIN_STREAM_MS = 300;
-const MAX_STREAM_MS = 2_000;
-const MS_PER_CHARACTER = 12;
-
 export type ReplayTiming = 'exact' | 'natural' | 'compact';
 
-export type ReplayTimelineEntry = { message: Message; end: number; revealStart: number; textLength: number };
+export type ReplayTimelineEntry = { message: Message; end: number };
 
 function timestamp(message: Message): number | undefined {
   const value = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
   return Number.isFinite(value) ? value : undefined;
-}
-
-function streamLength(message: Message): number {
-  if (message.role !== 'assistant') return 0;
-  return message.blocks.reduce((length, block) => length + (block.kind === 'text' || block.kind === 'thinking' ? block.text.length : 0), 0);
 }
 
 export function compressReplayGap(gap: number, timing: ReplayTiming): number {
@@ -28,34 +19,15 @@ export function compressReplayGap(gap: number, timing: ReplayTiming): number {
 export function createReplayTimeline(messages: Message[], timing: ReplayTiming = 'natural'): ReplayTimelineEntry[] {
   let elapsed = 0;
   return messages.map((message, index) => {
-    const textLength = streamLength(message);
     if (index > 0) {
       const current = timestamp(message);
       const previous = timestamp(messages[index - 1]!);
       const gap = current === undefined || previous === undefined ? 250 : compressReplayGap(Math.max(0, current - previous), timing);
-      const streamDuration = textLength ? Math.min(gap, MAX_STREAM_MS, Math.max(MIN_STREAM_MS, textLength * MS_PER_CHARACTER)) : 0;
       elapsed += gap;
-      return { message, end: elapsed, revealStart: elapsed - streamDuration, textLength };
+      return { message, end: elapsed };
     }
-    return { message, end: 0, revealStart: 0, textLength };
+    return { message, end: 0 };
   });
-}
-
-function revealMessage(message: Message, visibleCharacters: number): Message {
-  let remaining = visibleCharacters;
-  const blocks = [];
-  for (const block of message.blocks) {
-    if (block.kind !== 'text' && block.kind !== 'thinking') {
-      if (remaining > 0) blocks.push(block);
-      continue;
-    }
-    if (remaining <= 0) break;
-    const text = block.text.slice(0, remaining);
-    if (text) blocks.push({ ...block, text });
-    remaining -= block.text.length;
-    if (remaining <= 0) break;
-  }
-  return { ...message, blocks };
 }
 
 export function replayFrame(timeline: ReplayTimelineEntry[], position: number): Message[] {
@@ -64,10 +36,6 @@ export function replayFrame(timeline: ReplayTimelineEntry[], position: number): 
     if (position >= entry.end) {
       visible.push(entry.message);
       continue;
-    }
-    if (entry.textLength && position >= entry.revealStart) {
-      const progress = (position - entry.revealStart) / (entry.end - entry.revealStart);
-      visible.push(revealMessage(entry.message, Math.max(1, Math.ceil(entry.textLength * progress))));
     }
     break;
   }

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -45,11 +45,14 @@ export function replayFrame(timeline: ReplayTimelineEntry[], position: number): 
       continue;
     }
     if (entry.renderUICode && position >= entry.start) {
+      // 不能在此 break：render_ui 的落盘时间 ≈ 同一 message 的文本块（工具调用在
+      // text 之后成对落盘），反推的 streaming 起点却远早于两者。若遇到未到时间
+      // 的 text 就 break，streaming 窗口内永远轮不到这条 render_ui 出现。
       const progress = (position - entry.start) / (entry.end - entry.start);
       visible.push(withRenderUICode(entry.message, entry.renderUICode.slice(0, Math.max(1, Math.floor(entry.renderUICode.length * progress)))));
-      continue;
     }
-    break;
+    // end 单调递增，未到时间的普通消息之后也不会到时间，继续扫描只为找到
+    // start 更早的 streaming render_ui。
   }
   return visible;
 }

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -2,7 +2,10 @@ import type { Message } from '@macaron/shared';
 
 export type ReplayTiming = 'exact' | 'natural' | 'compact';
 
-export type ReplayTimelineEntry = { message: Message; end: number };
+export type ReplayTimelineEntry = { message: Message; start: number; end: number; renderUICode?: string };
+
+const RENDER_UI_TOKENS_PER_SECOND = 40;
+const CHARS_PER_TOKEN = 4;
 
 function timestamp(message: Message): number | undefined {
   const value = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
@@ -24,9 +27,11 @@ export function createReplayTimeline(messages: Message[], timing: ReplayTiming =
       const previous = timestamp(messages[index - 1]!);
       const gap = current === undefined || previous === undefined ? 250 : compressReplayGap(Math.max(0, current - previous), timing);
       elapsed += gap;
-      return { message, end: elapsed };
+      const renderUICode = getRenderUICode(message);
+      const streamDuration = renderUICode ? compressReplayGap(renderUICode.length / CHARS_PER_TOKEN / RENDER_UI_TOKENS_PER_SECOND * 1_000, timing) : 0;
+      return { message, start: Math.max(0, elapsed - streamDuration), end: elapsed, renderUICode };
     }
-    return { message, end: 0 };
+    return { message, start: 0, end: 0 };
   });
 }
 
@@ -37,7 +42,24 @@ export function replayFrame(timeline: ReplayTimelineEntry[], position: number): 
       visible.push(entry.message);
       continue;
     }
+    if (entry.renderUICode && position >= entry.start) {
+      const progress = (position - entry.start) / (entry.end - entry.start);
+      visible.push(withRenderUICode(entry.message, entry.renderUICode.slice(0, Math.max(1, Math.floor(entry.renderUICode.length * progress)))));
+      continue;
+    }
     break;
   }
   return visible;
+}
+
+function getRenderUICode(message: Message): string | undefined {
+  for (const block of message.blocks) {
+    if (block.kind !== 'tool_use' || !(block.name === 'mcp:macaron/render_ui' || block.name.endsWith('__render_ui'))) continue;
+    const code = (block.input as { code?: unknown } | null)?.code;
+    if (typeof code === 'string' && code) return code;
+  }
+}
+
+function withRenderUICode(message: Message, code: string): Message {
+  return { ...message, blocks: message.blocks.map((block) => block.kind === 'tool_use' && (block.name === 'mcp:macaron/render_ui' || block.name.endsWith('__render_ui')) ? { ...block, input: { ...(block.input as Record<string, unknown>), code } } : block) };
 }

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -1,9 +1,10 @@
 import type { Message } from '@macaron/shared';
 
-const MAX_GAP_MS = 2_000;
 const MIN_STREAM_MS = 300;
 const MAX_STREAM_MS = 2_000;
 const MS_PER_CHARACTER = 12;
+
+export type ReplayTiming = 'exact' | 'natural' | 'compact';
 
 export type ReplayTimelineEntry = { message: Message; end: number; revealStart: number; textLength: number };
 
@@ -17,14 +18,21 @@ function streamLength(message: Message): number {
   return message.blocks.reduce((length, block) => length + (block.kind === 'text' || block.kind === 'thinking' ? block.text.length : 0), 0);
 }
 
-export function createReplayTimeline(messages: Message[]): ReplayTimelineEntry[] {
+export function compressReplayGap(gap: number, timing: ReplayTiming): number {
+  if (timing === 'exact') return gap;
+  if (timing === 'compact') return Math.min(2_000, gap);
+  if (gap <= 2_000) return gap;
+  return 2_000 + 2_000 * Math.log(gap / 2_000);
+}
+
+export function createReplayTimeline(messages: Message[], timing: ReplayTiming = 'natural'): ReplayTimelineEntry[] {
   let elapsed = 0;
   return messages.map((message, index) => {
     const textLength = streamLength(message);
     if (index > 0) {
       const current = timestamp(message);
       const previous = timestamp(messages[index - 1]!);
-      const gap = current === undefined || previous === undefined ? 250 : Math.min(MAX_GAP_MS, Math.max(0, current - previous));
+      const gap = current === undefined || previous === undefined ? 250 : compressReplayGap(Math.max(0, current - previous), timing);
       const streamDuration = textLength ? Math.min(MAX_STREAM_MS, Math.max(MIN_STREAM_MS, textLength * MS_PER_CHARACTER)) : 0;
       elapsed += Math.max(gap, streamDuration);
       return { message, end: elapsed, revealStart: elapsed - streamDuration, textLength };

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -61,5 +61,5 @@ function getRenderUICode(message: Message): string | undefined {
 }
 
 function withRenderUICode(message: Message, code: string): Message {
-  return { ...message, blocks: message.blocks.map((block) => block.kind === 'tool_use' && (block.name === 'mcp:macaron/render_ui' || block.name.endsWith('__render_ui')) ? { ...block, input: { ...(block.input as Record<string, unknown>), code } } : block) };
+  return { ...message, blocks: message.blocks.map((block) => block.kind === 'tool_use' && (block.name === 'mcp:macaron/render_ui' || block.name.endsWith('__render_ui')) ? { ...block, input: { ...(block.input as Record<string, unknown>), code, _replayStreaming: true } } : block) };
 }

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -33,8 +33,8 @@ export function createReplayTimeline(messages: Message[], timing: ReplayTiming =
       const current = timestamp(message);
       const previous = timestamp(messages[index - 1]!);
       const gap = current === undefined || previous === undefined ? 250 : compressReplayGap(Math.max(0, current - previous), timing);
-      const streamDuration = textLength ? Math.min(MAX_STREAM_MS, Math.max(MIN_STREAM_MS, textLength * MS_PER_CHARACTER)) : 0;
-      elapsed += Math.max(gap, streamDuration);
+      const streamDuration = textLength ? Math.min(gap, MAX_STREAM_MS, Math.max(MIN_STREAM_MS, textLength * MS_PER_CHARACTER)) : 0;
+      elapsed += gap;
       return { message, end: elapsed, revealStart: elapsed - streamDuration, textLength };
     }
     return { message, end: 0, revealStart: 0, textLength };

--- a/web/src/lib/replay.ts
+++ b/web/src/lib/replay.ts
@@ -1,0 +1,67 @@
+import type { Message } from '@macaron/shared';
+
+const MAX_GAP_MS = 2_000;
+const MIN_STREAM_MS = 300;
+const MAX_STREAM_MS = 2_000;
+const MS_PER_CHARACTER = 12;
+
+export type ReplayTimelineEntry = { message: Message; end: number; revealStart: number; textLength: number };
+
+function timestamp(message: Message): number | undefined {
+  const value = message.timestamp ? new Date(message.timestamp).getTime() : NaN;
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function streamLength(message: Message): number {
+  if (message.role !== 'assistant') return 0;
+  return message.blocks.reduce((length, block) => length + (block.kind === 'text' || block.kind === 'thinking' ? block.text.length : 0), 0);
+}
+
+export function createReplayTimeline(messages: Message[]): ReplayTimelineEntry[] {
+  let elapsed = 0;
+  return messages.map((message, index) => {
+    const textLength = streamLength(message);
+    if (index > 0) {
+      const current = timestamp(message);
+      const previous = timestamp(messages[index - 1]!);
+      const gap = current === undefined || previous === undefined ? 250 : Math.min(MAX_GAP_MS, Math.max(0, current - previous));
+      const streamDuration = textLength ? Math.min(MAX_STREAM_MS, Math.max(MIN_STREAM_MS, textLength * MS_PER_CHARACTER)) : 0;
+      elapsed += Math.max(gap, streamDuration);
+      return { message, end: elapsed, revealStart: elapsed - streamDuration, textLength };
+    }
+    return { message, end: 0, revealStart: 0, textLength };
+  });
+}
+
+function revealMessage(message: Message, visibleCharacters: number): Message {
+  let remaining = visibleCharacters;
+  const blocks = [];
+  for (const block of message.blocks) {
+    if (block.kind !== 'text' && block.kind !== 'thinking') {
+      if (remaining > 0) blocks.push(block);
+      continue;
+    }
+    if (remaining <= 0) break;
+    const text = block.text.slice(0, remaining);
+    if (text) blocks.push({ ...block, text });
+    remaining -= block.text.length;
+    if (remaining <= 0) break;
+  }
+  return { ...message, blocks };
+}
+
+export function replayFrame(timeline: ReplayTimelineEntry[], position: number): Message[] {
+  const visible: Message[] = [];
+  for (const entry of timeline) {
+    if (position >= entry.end) {
+      visible.push(entry.message);
+      continue;
+    }
+    if (entry.textLength && position >= entry.revealStart) {
+      const progress = (position - entry.revealStart) / (entry.end - entry.revealStart);
+      visible.push(revealMessage(entry.message, Math.max(1, Math.ceil(entry.textLength * progress))));
+    }
+    break;
+  }
+  return visible;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -601,6 +601,13 @@ textarea:focus, select:focus, input:focus {
 .replay-controls { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--border); border-radius: 7px; background: transparent; color: var(--muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
 .replay-button:hover { background: var(--surface-2); color: var(--text); }
+.replay-settings { position: relative; }
+.replay-settings > summary { list-style: none; }
+.replay-settings > summary::-webkit-details-marker { display: none; }
+.replay-settings-menu { position: absolute; z-index: 20; top: 34px; left: 0; width: 210px; padding: 10px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); box-shadow: var(--shadow-lg); display: grid; gap: 6px; }
+.replay-settings-menu label { color: var(--text-2); font-size: 11px; font-weight: 600; }
+.replay-settings-menu select { width: 100%; padding: 6px 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); color: var(--text); }
+.replay-settings-menu span { color: var(--muted); font-size: 10px; line-height: 1.4; }
 .replay-controls input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--accent); }
 .replay-count { color: var(--muted); font-family: var(--font-mono); font-size: 11px; white-space: nowrap; }
 .session-replay-bar { display: flex; justify-content: flex-end; padding: 6px 10px; border-bottom: 1px solid var(--border); background: var(--surface); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -603,6 +603,7 @@ textarea:focus, select:focus, input:focus {
 .replay-button:hover { background: var(--surface-2); color: var(--text); }
 .replay-controls input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--accent); }
 .replay-count { color: var(--muted); font-family: var(--font-mono); font-size: 11px; white-space: nowrap; }
+.session-replay-bar { display: flex; justify-content: flex-end; padding: 6px 10px; border-bottom: 1px solid var(--border); background: var(--surface); }
 .replay-speed { width: 34px; font-size: 11px; }
 .load-earlier {
   align-self: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -598,6 +598,12 @@ textarea:focus, select:focus, input:focus {
   font-size: 11.5px;
   color: var(--muted);
 }
+.replay-controls { display: flex; align-items: center; gap: 5px; min-width: 0; }
+.replay-button { width: 28px; height: 28px; padding: 0; border: 1px solid var(--border); border-radius: 7px; background: transparent; color: var(--muted); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
+.replay-button:hover { background: var(--surface-2); color: var(--text); }
+.replay-controls input[type='range'] { width: clamp(72px, 12vw, 150px); accent-color: var(--accent); }
+.replay-count { color: var(--muted); font-family: var(--font-mono); font-size: 11px; white-space: nowrap; }
+.replay-speed { width: 34px; font-size: 11px; }
 .load-earlier {
   align-self: center;
   padding: 6px 14px;

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -192,7 +192,7 @@ export function flatten(messages: Message[]): Item[] {
         } else if (isRenderUITool(b.name)) {
           // Claude writes the TSX directly into the tool_use input.code field;
           // jsonl persists it. We use that as the rendered code immediately.
-          const input = (b.input || {}) as { code?: string; prompt?: string };
+          const input = (b.input || {}) as { code?: string; prompt?: string; _replayStreaming?: boolean };
           const code = typeof input.code === 'string' ? input.code : '';
           const prompt = code
             ? `${code.split('\n')[0] || ''} … (${code.length} chars)`
@@ -208,7 +208,7 @@ export function flatten(messages: Message[]): Item[] {
             toolUseId,
             prompt,
             code: code || undefined,
-            status: code ? 'ready' : 'pending',
+            status: code && !input._replayStreaming ? 'ready' : 'pending',
           };
           out.push(it);
           const pending = { item: it as PairedTool, ts: m.timestamp };

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
 import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
+import { useReplay } from '../components/ReplayControls';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
   api,
@@ -1927,7 +1928,8 @@ export function Session(props: SessionProps = {}) {
     };
   }, [commitSnapshot, fetchSnapshot, isPending, liveSubscriptionGen, sid, onPendingConsumed]);
 
-  const rawItems = useMemo(() => (data ? flatten(data.messages) : []), [data]);
+  const replay = useReplay(data?.replayMessages ?? data?.messages ?? [], isNew || sending || polling || handoffPending);
+  const rawItems = useMemo(() => flatten(replay.messages), [replay.messages]);
   // Collapse consecutive read-only tool operations (Read / Grep / Glob /
   // cat / grep / ls / …) into a single summary badge, mirroring Claude
   // Code CLI's `⏺ Searching for N patterns, reading M files, listing K
@@ -2609,6 +2611,7 @@ export function Session(props: SessionProps = {}) {
             {data?.gitBranch && <span className="sess-branch">{data.gitBranch}</span>}
           </div>
           <div className="session-bar-right">
+            {replay.controls}
             {!isNew && (
               <button
                 className="ghost small"

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -2636,6 +2636,7 @@ export function Session(props: SessionProps = {}) {
           </div>
         </div>
       )}
+      {hideBar && replay.controls && <div className="session-replay-bar">{replay.controls}</div>}
 
       {/*
         flex-direction: column-reverse on .thread. DOM order must be newest →

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -6,24 +6,21 @@ import { compressReplayGap, createReplayTimeline, replayFrame } from '../src/lib
 const user = (text: string, timestamp: string): Message => ({ role: 'user', timestamp, blocks: [{ kind: 'text', text }] });
 const assistant = (text: string, timestamp: string): Message => ({ role: 'assistant', timestamp, blocks: [{ kind: 'text', text }] });
 
-test('smoothly reveals assistant text inside its replay interval', () => {
+test('reveals complete assistant text at its event timestamp', () => {
   const timeline = createReplayTimeline([user('go', '2026-01-01T00:00:00.000Z'), assistant('abcdefghij', '2026-01-01T00:00:01.000Z')]);
   assert.deepEqual(replayFrame(timeline, 0), [timeline[0]!.message]);
-  const halfway = replayFrame(timeline, 850);
-  assert.equal(halfway.length, 2);
-  assert.equal(halfway[1]!.blocks[0]!.kind, 'text');
-  assert.equal((halfway[1]!.blocks[0] as { kind: 'text'; text: string }).text, 'abcde');
+  assert.deepEqual(replayFrame(timeline, 999), [timeline[0]!.message]);
   assert.deepEqual(replayFrame(timeline, 1_000), timeline.map((entry) => entry.message));
 });
 
-test('finishes intermediate and final streaming text at their recorded event times', () => {
+test('reveals intermediate and final text only at their recorded event times', () => {
   const messages = [user('go', '2026-01-01T00:00:00.000Z'), assistant('intermediate text', '2026-01-01T00:00:00.100Z'), assistant('final response', '2026-01-01T00:00:01.000Z')];
   const timeline = createReplayTimeline(messages, 'exact');
-  assert.equal(timeline[1]!.revealStart, 0);
   assert.equal(timeline[1]!.end, 100);
   assert.equal(timeline[2]!.end, 1_000);
-  assert.equal(replayFrame(timeline, 99).length, 2);
+  assert.deepEqual(replayFrame(timeline, 99), messages.slice(0, 1));
   assert.deepEqual(replayFrame(timeline, 100).slice(0, 2), messages.slice(0, 2));
+  assert.deepEqual(replayFrame(timeline, 999), messages.slice(0, 2));
   assert.deepEqual(replayFrame(timeline, 1_000), messages);
 });
 

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -13,6 +13,25 @@ test('reveals complete assistant text at its event timestamp', () => {
   assert.deepEqual(replayFrame(timeline, 1_000), timeline.map((entry) => entry.message));
 });
 
+test('predicts render_ui generation from code size and streams it until the recorded timestamp', () => {
+  const code = 'x'.repeat(640); // 160 estimated tokens at 40 tokens/second.
+  const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'mcp__macaron__render_ui', input: { code } }] }];
+  const timeline = createReplayTimeline(messages, 'exact');
+  assert.equal(timeline[1]!.start, 1_000);
+  assert.equal(replayFrame(timeline, 999).length, 1);
+  const halfway = replayFrame(timeline, 3_000);
+  assert.equal(halfway.length, 2);
+  assert.equal(((halfway[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string }).code.length, 320);
+  assert.deepEqual(replayFrame(timeline, 5_000), messages);
+});
+
+test('does not mock streaming for non-render_ui tools', () => {
+  const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'Read', input: { code: 'x'.repeat(640) } }] }];
+  const timeline = createReplayTimeline(messages, 'exact');
+  assert.equal(replayFrame(timeline, 4_999).length, 1);
+  assert.deepEqual(replayFrame(timeline, 5_000), messages);
+});
+
 test('reveals intermediate and final text only at their recorded event times', () => {
   const messages = [user('go', '2026-01-01T00:00:00.000Z'), assistant('intermediate text', '2026-01-01T00:00:00.100Z'), assistant('final response', '2026-01-01T00:00:01.000Z')];
   const timeline = createReplayTimeline(messages, 'exact');

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { Message } from '@macaron/shared';
-import { createReplayTimeline, replayFrame } from '../src/lib/replay';
+import { compressReplayGap, createReplayTimeline, replayFrame } from '../src/lib/replay';
 
 const user = (text: string, timestamp: string): Message => ({ role: 'user', timestamp, blocks: [{ kind: 'text', text }] });
 const assistant = (text: string, timestamp: string): Message => ({ role: 'assistant', timestamp, blocks: [{ kind: 'text', text }] });
@@ -16,9 +16,16 @@ test('smoothly reveals assistant text inside its replay interval', () => {
   assert.deepEqual(replayFrame(timeline, 1_000), timeline.map((entry) => entry.message));
 });
 
-test('caps long event gaps while preserving non-text event boundaries', () => {
+test('offers exact, logarithmic, and compact replay timing', () => {
+  assert.equal(compressReplayGap(60_000, 'exact'), 60_000);
+  assert.equal(compressReplayGap(60_000, 'compact'), 2_000);
+  assert.equal(Math.round(compressReplayGap(60_000, 'natural')), 8_802);
+  assert.equal(compressReplayGap(1_000, 'natural'), 1_000);
+});
+
+test('compact timing caps long event gaps while preserving non-text event boundaries', () => {
   const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:01:00.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'Read', input: {} }] }];
-  const timeline = createReplayTimeline(messages);
+  const timeline = createReplayTimeline(messages, 'compact');
   assert.equal(timeline[1]!.end, 2_000);
   assert.equal(replayFrame(timeline, 1_999).length, 1);
   assert.deepEqual(replayFrame(timeline, 2_000), messages);

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -14,7 +14,7 @@ test('reveals complete assistant text at its event timestamp', () => {
 });
 
 test('predicts render_ui generation from code size and streams it until the recorded timestamp', () => {
-  const code = 'x'.repeat(640); // 160 estimated tokens at 50 tokens/second.
+  const code = Array.from({ length: 20 }, () => 'x'.repeat(31)).join('\n') + '\n'; // 640 chars, 160 estimated tokens at 50 tokens/second.
   const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'mcp__macaron__render_ui', input: { code } }] }];
   const timeline = createReplayTimeline(messages, 'exact');
   assert.equal(timeline[1]!.start, 1_800);
@@ -22,7 +22,9 @@ test('predicts render_ui generation from code size and streams it until the reco
   const halfway = replayFrame(timeline, 3_400);
   assert.equal(halfway.length, 2);
   const halfwayInput = (halfway[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string; _replayStreaming: boolean };
-  assert.equal(halfwayInput.code.length, 320);
+  // Partial frames snap to the next line boundary so partial-react never sees half an identifier.
+  assert.equal(halfwayInput.code.length, 352);
+  assert.ok(halfwayInput.code.endsWith('\n'));
   assert.equal(halfwayInput._replayStreaming, true);
   assert.deepEqual(replayFrame(timeline, 5_000), messages);
 });
@@ -32,7 +34,7 @@ test('streams render_ui before its paired text becomes due', () => {
   // at message completion, so the paired text's end ≈ the render_ui end while
   // the back-calculated stream starts far earlier. The frame must include the
   // streaming render_ui even though the paired text is not due yet.
-  const code = 'x'.repeat(640);
+  const code = Array.from({ length: 20 }, () => 'x'.repeat(31)).join('\n') + '\n';
   const messages: Message[] = [
     user('go', '2026-01-01T00:00:00.000Z'),
     { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'text', text: '先说一句' }] },

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -21,7 +21,9 @@ test('predicts render_ui generation from code size and streams it until the reco
   assert.equal(replayFrame(timeline, 999).length, 1);
   const halfway = replayFrame(timeline, 3_000);
   assert.equal(halfway.length, 2);
-  assert.equal(((halfway[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string }).code.length, 320);
+  const halfwayInput = (halfway[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string; _replayStreaming: boolean };
+  assert.equal(halfwayInput.code.length, 320);
+  assert.equal(halfwayInput._replayStreaming, true);
   assert.deepEqual(replayFrame(timeline, 5_000), messages);
 });
 

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -14,12 +14,12 @@ test('reveals complete assistant text at its event timestamp', () => {
 });
 
 test('predicts render_ui generation from code size and streams it until the recorded timestamp', () => {
-  const code = 'x'.repeat(640); // 160 estimated tokens at 40 tokens/second.
+  const code = 'x'.repeat(640); // 160 estimated tokens at 50 tokens/second.
   const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'mcp__macaron__render_ui', input: { code } }] }];
   const timeline = createReplayTimeline(messages, 'exact');
-  assert.equal(timeline[1]!.start, 1_000);
-  assert.equal(replayFrame(timeline, 999).length, 1);
-  const halfway = replayFrame(timeline, 3_000);
+  assert.equal(timeline[1]!.start, 1_800);
+  assert.equal(replayFrame(timeline, 1_799).length, 1);
+  const halfway = replayFrame(timeline, 3_400);
   assert.equal(halfway.length, 2);
   const halfwayInput = (halfway[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string; _replayStreaming: boolean };
   assert.equal(halfwayInput.code.length, 320);

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -27,6 +27,27 @@ test('predicts render_ui generation from code size and streams it until the reco
   assert.deepEqual(replayFrame(timeline, 5_000), messages);
 });
 
+test('streams render_ui before its paired text becomes due', () => {
+  // Real Claude transcripts flush a text block and its tool_use block together
+  // at message completion, so the paired text's end ≈ the render_ui end while
+  // the back-calculated stream starts far earlier. The frame must include the
+  // streaming render_ui even though the paired text is not due yet.
+  const code = 'x'.repeat(640);
+  const messages: Message[] = [
+    user('go', '2026-01-01T00:00:00.000Z'),
+    { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'text', text: '先说一句' }] },
+    { role: 'assistant', timestamp: '2026-01-01T00:00:05.010Z', blocks: [{ kind: 'tool_use', id: '1', name: 'mcp__macaron__render_ui', input: { code } }] },
+  ];
+  const timeline = createReplayTimeline(messages, 'exact');
+  const mid = replayFrame(timeline, 3_000);
+  assert.equal(mid.length, 2); // user + streaming render_ui; paired text not yet visible
+  assert.equal((mid[1]!.blocks[0] as { kind: string }).kind, 'tool_use');
+  const midInput = (mid[1]!.blocks[0] as Extract<Message['blocks'][number], { kind: 'tool_use' }>).input as { code: string; _replayStreaming: boolean };
+  assert.equal(midInput._replayStreaming, true);
+  assert.ok(midInput.code.length > 0 && midInput.code.length < code.length);
+  assert.equal(replayFrame(timeline, 5_010).length, 3);
+});
+
 test('does not mock streaming for non-render_ui tools', () => {
   const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'Read', input: { code: 'x'.repeat(640) } }] }];
   const timeline = createReplayTimeline(messages, 'exact');

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -16,6 +16,17 @@ test('smoothly reveals assistant text inside its replay interval', () => {
   assert.deepEqual(replayFrame(timeline, 1_000), timeline.map((entry) => entry.message));
 });
 
+test('finishes intermediate and final streaming text at their recorded event times', () => {
+  const messages = [user('go', '2026-01-01T00:00:00.000Z'), assistant('intermediate text', '2026-01-01T00:00:00.100Z'), assistant('final response', '2026-01-01T00:00:01.000Z')];
+  const timeline = createReplayTimeline(messages, 'exact');
+  assert.equal(timeline[1]!.revealStart, 0);
+  assert.equal(timeline[1]!.end, 100);
+  assert.equal(timeline[2]!.end, 1_000);
+  assert.equal(replayFrame(timeline, 99).length, 2);
+  assert.deepEqual(replayFrame(timeline, 100).slice(0, 2), messages.slice(0, 2));
+  assert.deepEqual(replayFrame(timeline, 1_000), messages);
+});
+
 test('offers exact, logarithmic, and compact replay timing', () => {
   assert.equal(compressReplayGap(60_000, 'exact'), 60_000);
   assert.equal(compressReplayGap(60_000, 'compact'), 2_000);

--- a/web/test/replay.test.ts
+++ b/web/test/replay.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { Message } from '@macaron/shared';
+import { createReplayTimeline, replayFrame } from '../src/lib/replay';
+
+const user = (text: string, timestamp: string): Message => ({ role: 'user', timestamp, blocks: [{ kind: 'text', text }] });
+const assistant = (text: string, timestamp: string): Message => ({ role: 'assistant', timestamp, blocks: [{ kind: 'text', text }] });
+
+test('smoothly reveals assistant text inside its replay interval', () => {
+  const timeline = createReplayTimeline([user('go', '2026-01-01T00:00:00.000Z'), assistant('abcdefghij', '2026-01-01T00:00:01.000Z')]);
+  assert.deepEqual(replayFrame(timeline, 0), [timeline[0]!.message]);
+  const halfway = replayFrame(timeline, 850);
+  assert.equal(halfway.length, 2);
+  assert.equal(halfway[1]!.blocks[0]!.kind, 'text');
+  assert.equal((halfway[1]!.blocks[0] as { kind: 'text'; text: string }).text, 'abcde');
+  assert.deepEqual(replayFrame(timeline, 1_000), timeline.map((entry) => entry.message));
+});
+
+test('caps long event gaps while preserving non-text event boundaries', () => {
+  const messages: Message[] = [user('go', '2026-01-01T00:00:00.000Z'), { role: 'assistant', timestamp: '2026-01-01T00:01:00.000Z', blocks: [{ kind: 'tool_use', id: '1', name: 'Read', input: {} }] }];
+  const timeline = createReplayTimeline(messages);
+  assert.equal(timeline[1]!.end, 2_000);
+  assert.equal(replayFrame(timeline, 1_999).length, 1);
+  assert.deepEqual(replayFrame(timeline, 2_000), messages);
+});


### PR DESCRIPTION
## Summary
- preserve JSONL source order and expose replay-specific message events
- replay Codex text, reasoning, and tool events without its duplicate persisted records
- add play/pause, scrubbing, exit, and 1x/2x/5x controls to Claude and Codex sessions
- cap long idle gaps at two seconds

## Testing
- local tests/typecheck unavailable because this runtime has Node 18 but no pnpm/corepack/bun; package publish CI passed on the equivalent commit in #163

Closes [MAC-9120](https://multica.macaron.xin/issues/3400b928-485b-4fe3-9c98-6cdec0344a48 "调研 Claude Code 与 Codex Session 消息时间戳及回放可行性")