### PR TITLE
add responsive Codex and Claude Code layouts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
-import { Menu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import { Sidebar } from './components/Sidebar';
 import { Toast } from './components/Toast';
 import { NotifyStack } from './components/NotifyStack';
@@ -11,18 +11,99 @@ import { ShortcutsHelp } from './components/ShortcutsHelp';
 export function App() {
   const [navOpen, setNavOpen] = useState(false);
   const location = useLocation();
-  // Tapping a workspace/session in the drawer navigates; close it on every route change.
-  useEffect(() => { setNavOpen(false); }, [location.pathname]);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const keepDrawerOpen = Boolean(
+    (location.state as { keepClaudeDrawerOpen?: boolean } | null)?.keepClaudeDrawerOpen,
+  );
+
+  useEffect(() => {
+    if (!keepDrawerOpen) setNavOpen(false);
+  }, [location.pathname, keepDrawerOpen]);
+
+  useEffect(() => {
+    const onResize = () => {
+      if (window.innerWidth > 768) setNavOpen(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    if (!navOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setNavOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+      const focusable = Array.from(drawer.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), select:not([disabled]), textarea:not([disabled]), input:not([disabled])',
+      ));
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    closeRef.current?.focus();
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      if (window.innerWidth <= 768) toggleRef.current?.focus();
+    };
+  }, [navOpen]);
+
   return (
     <>
-      <button className="mobile-nav-toggle" aria-label="Toggle navigation" onClick={() => setNavOpen((v) => !v)}>
-        <Menu size={20} aria-hidden="true" />
-      </button>
-      <div className={`sb-drawer${navOpen ? ' open' : ''}`}>
-        <Sidebar />
+      {!navOpen && (
+        <button
+          ref={toggleRef}
+          type="button"
+          className="mobile-nav-toggle"
+          aria-label="Open navigation"
+          aria-controls="claude-navigation"
+          aria-expanded="false"
+          onClick={() => setNavOpen(true)}
+        >
+          <Menu size={20} aria-hidden="true" />
+        </button>
+      )}
+      <div
+        ref={drawerRef}
+        id="claude-navigation"
+        className={`sb-drawer${navOpen ? ' open' : ''}`}
+        role={navOpen ? 'dialog' : undefined}
+        aria-modal={navOpen || undefined}
+        aria-label={navOpen ? 'Navigation' : undefined}
+      >
+        <Sidebar onNavigate={() => setNavOpen(false)} />
+        <button
+          ref={closeRef}
+          type="button"
+          className="mobile-nav-close"
+          aria-label="Close navigation"
+          onClick={() => setNavOpen(false)}
+        >
+          <X size={18} aria-hidden="true" />
+        </button>
       </div>
-      {navOpen && <div className="sb-backdrop" onClick={() => setNavOpen(false)} />}
-      <main id="main">
+      {navOpen && (
+        <div
+          className="sb-backdrop"
+          role="presentation"
+          onClick={() => setNavOpen(false)}
+        />
+      )}
+      <main id="main" inert={navOpen} aria-hidden={navOpen || undefined}>
         <Outlet />
       </main>
       <Toast />

--- a/web/src/codex/CodexApp.tsx
+++ b/web/src/codex/CodexApp.tsx
@@ -1,12 +1,105 @@
-import { Outlet } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { Menu, X } from 'lucide-react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { CodexSidebar } from './CodexSidebar';
 import { NotifyStack } from '../components/NotifyStack';
 
 export function CodexApp() {
+  const [navOpen, setNavOpen] = useState(false);
+  const location = useLocation();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const keepDrawerOpen = Boolean(
+    (location.state as { keepCodexDrawerOpen?: boolean } | null)?.keepCodexDrawerOpen,
+  );
+
+  useEffect(() => {
+    if (!keepDrawerOpen) setNavOpen(false);
+  }, [location.pathname, keepDrawerOpen]);
+
+  useEffect(() => {
+    const onResize = () => {
+      if (window.innerWidth > 768) setNavOpen(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    if (!navOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setNavOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+      const focusable = Array.from(drawer.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), select:not([disabled]), textarea:not([disabled]), input:not([disabled])',
+      ));
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    closeRef.current?.focus();
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      if (window.innerWidth <= 768) toggleRef.current?.focus();
+    };
+  }, [navOpen]);
+
   return (
     <div className="cx-app">
-      <CodexSidebar />
-      <main className="cx-view"><Outlet /></main>
+      <button
+        ref={toggleRef}
+        type="button"
+        className="cx-mobile-nav-toggle"
+        aria-label="Open navigation"
+        aria-controls="cx-navigation"
+        aria-expanded={navOpen}
+        onClick={() => setNavOpen(true)}
+      >
+        <Menu size={20} aria-hidden="true" />
+      </button>
+      <div
+        ref={drawerRef}
+        id="cx-navigation"
+        className={`cx-drawer${navOpen ? ' open' : ''}`}
+        role={navOpen ? 'dialog' : undefined}
+        aria-modal={navOpen || undefined}
+        aria-label={navOpen ? 'Navigation' : undefined}
+      >
+        <CodexSidebar onNavigate={() => setNavOpen(false)} />
+        <button
+          ref={closeRef}
+          type="button"
+          className="cx-mobile-nav-close"
+          aria-label="Close navigation"
+          onClick={() => setNavOpen(false)}
+        >
+          <X size={18} aria-hidden="true" />
+        </button>
+      </div>
+      {navOpen && (
+        <button
+          type="button"
+          className="cx-mobile-nav-backdrop"
+          tabIndex={-1}
+          aria-hidden="true"
+          onClick={() => setNavOpen(false)}
+        />
+      )}
+      <main className="cx-view" inert={navOpen} aria-hidden={navOpen || undefined}><Outlet /></main>
       <NotifyStack />
     </div>
   );

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -21,7 +21,9 @@ function basename(p: string): string {
   return parts[parts.length - 1] || p;
 }
 
-export function CodexSidebar() {
+export function CodexSidebar({ onNavigate }: {
+  onNavigate?: () => void;
+} = {}) {
   const [workspaces, setWorkspaces] = useState<WsData[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [status, setStatus] = useState<'connecting' | 'ok' | 'bad'>('connecting');
@@ -135,7 +137,7 @@ export function CodexSidebar() {
 
   return (
     <aside className="cx-sidebar">
-      <Link className="cx-sb-brand" to="/">
+      <Link className="cx-sb-brand" to="/" onClick={onNavigate}>
         <img className="cx-sb-logo" src={assetUrl('/mindlab-symbol.svg')} alt="" />
         <div>
           <div className="cx-sb-brand-name">Macaron Artifacts</div>
@@ -143,7 +145,7 @@ export function CodexSidebar() {
         </div>
       </Link>
 
-      <button className="cx-sb-new" onClick={() => navigate('/')}>
+      <button className="cx-sb-new" onClick={() => { navigate('/'); onNavigate?.(); }}>
         <Plus size={14} aria-hidden="true" />
         <span>New thread</span>
       </button>
@@ -159,38 +161,46 @@ export function CodexSidebar() {
           const name = w.name || basename(w.cwd) || w.project;
           return (
             <div key={w.project} className={'cx-sb-ws' + (isExpanded ? ' open' : '')}>
-              <div
+              <button
+                type="button"
                 className={'cx-sb-ws-head' + (w.project === activeProject ? ' active' : '')}
+                aria-expanded={isExpanded}
                 onClick={() => {
                   toggle(w.project);
-                  navigate(`/w/${encodeURIComponent(w.project)}`);
+                  const target = `/w/${encodeURIComponent(w.project)}`;
+                  navigate(target, { state: { keepCodexDrawerOpen: true } });
                 }}
               >
                 <span className="cx-sb-ws-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
                 <span className="cx-sb-ws-name">{name}</span>
                 <span className="cx-sb-ws-count">{w.sessionCount}</span>
-              </div>
+              </button>
               {isExpanded && (
                 <div className="cx-sb-ws-sessions">
                   {w.sessions.map((s) => {
                     const pinned = (canvasBy[w.project] || []).includes(s.sessionId);
+                    const label = s.title || s.preview || s.sessionId.slice(0, 8);
                     return (
                       <div
                         key={s.sessionId}
                         className={'cx-sb-thread' + (pinned ? ' pinned' : '')}
-                        onClick={() => {
-                          // Click to add to canvas; re-click on pinned focuses it.
-                          if (!pinned) toggleCanvasSid(w.project, s.sessionId);
-                          else focusCanvasSid(w.project, s.sessionId);
-                          if (activeProject !== w.project) {
-                            navigate(`/w/${encodeURIComponent(w.project)}`);
-                          }
-                        }}
-                        title={s.cwd}
                       >
-                        <span className="cx-sb-thread-title">
-                          {s.title || s.preview || s.sessionId.slice(0, 8)}
-                        </span>
+                        <button
+                          type="button"
+                          className="cx-sb-thread-main"
+                          title={s.cwd}
+                          onClick={() => {
+                            // Click to add to canvas; re-click on pinned focuses it.
+                            if (!pinned) toggleCanvasSid(w.project, s.sessionId);
+                            else focusCanvasSid(w.project, s.sessionId);
+                            if (activeProject !== w.project) {
+                              navigate(`/w/${encodeURIComponent(w.project)}`);
+                            }
+                            onNavigate?.();
+                          }}
+                        >
+                          <span className="cx-sb-thread-title">{label}</span>
+                        </button>
                         <button
                           type="button"
                           className={'cx-sb-thread-pin' + (pinned ? ' pinned' : '')}
@@ -200,13 +210,17 @@ export function CodexSidebar() {
                             if (activeProject !== w.project) {
                               navigate(`/w/${encodeURIComponent(w.project)}`);
                             }
+                            onNavigate?.();
                           }}
                           title={pinned ? 'Remove from canvas' : 'Add to canvas'}
+                          aria-label={`${pinned ? 'Remove' : 'Add'} ${label} ${pinned ? 'from' : 'to'} canvas`}
                         >{pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}</button>
                         <button
+                          type="button"
                           className="cx-sb-thread-del"
                           onClick={(e) => del(e, s.sessionId)}
                           title="Delete"
+                          aria-label={`Delete ${label}`}
                         ><X size={14} aria-hidden="true" /></button>
                       </div>
                     );
@@ -223,7 +237,7 @@ export function CodexSidebar() {
 
       <div className="cx-sb-grow" />
 
-      <Link className="cx-sb-settings" to="/settings">
+      <Link className="cx-sb-settings" to="/settings" onClick={onNavigate}>
         <span><Settings size={16} aria-hidden="true" /></span>
         <span>Settings</span>
       </Link>

--- a/web/src/codex/styles.css
+++ b/web/src/codex/styles.css
@@ -55,6 +55,13 @@ body {
   overflow: hidden;
 }
 
+/* The drawer wrapper is layout-transparent on desktop so the sidebar remains
+   the first column of .cx-app. Mobile controls take over at the breakpoint. */
+.cx-drawer { display: contents; }
+.cx-mobile-nav-toggle,
+.cx-mobile-nav-close,
+.cx-mobile-nav-backdrop { display: none; }
+
 /* ---------- Sidebar ---------- */
 
 .cx-sidebar {
@@ -140,6 +147,7 @@ body {
   min-height: 0;
   padding-right: 2px;
   padding-bottom: 4px;
+  overscroll-behavior: contain;
 }
 
 /* Workspace group */
@@ -154,6 +162,11 @@ body {
   color: var(--cx-text);
   font-size: 13px;
   font-weight: 500;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
   transition: background 120ms;
 }
 .cx-sb-ws-head:hover { background: var(--cx-hover); }
@@ -193,10 +206,29 @@ body {
   gap: 6px;
   padding: 6px 10px;
   border-radius: var(--cx-radius-sm);
-  cursor: pointer;
   font-size: 12.5px;
   color: var(--cx-text-2);
   transition: background 100ms, color 100ms;
+}
+.cx-sb-thread-main {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.cx-sb-ws-head:focus-visible,
+.cx-sb-thread-main:focus-visible,
+.cx-sb-thread-pin:focus-visible,
+.cx-sb-thread-del:focus-visible {
+  outline: 2px solid var(--cx-text);
+  outline-offset: 1px;
 }
 .cx-sb-thread:hover {
   background: var(--cx-hover);
@@ -732,6 +764,7 @@ body {
 .cx-attach:hover { background: var(--cx-border); color: var(--cx-text); }
 .cx-composer textarea {
   flex: 1;
+  min-width: 0;
   border: 0;
   outline: none;
   background: transparent;
@@ -1570,3 +1603,340 @@ body {
 .cx-approval-btn:hover { background: var(--cx-sidebar); }
 .cx-approval-btn.accept, .cx-approval-btn.acceptForSession { border-color: #4a8a5a; color: #2f7d45; }
 .cx-approval-btn.decline, .cx-approval-btn.cancel { border-color: #c0524a; color: #c0524a; }
+
+/* ---------- Shared overlays used by the Codex shell ---------- */
+
+.notify-stack {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(340px, calc(100vw - 36px));
+  pointer-events: none;
+}
+.notify-card {
+  position: relative;
+  padding: 11px 30px 11px 14px;
+  border: 1px solid var(--cx-border-strong);
+  border-left: 3px solid var(--cx-text);
+  border-radius: var(--cx-radius);
+  background: var(--cx-surface);
+  color: var(--cx-text);
+  box-shadow: var(--cx-shadow-3);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  pointer-events: auto;
+  animation: cx-notify-in 180ms ease-out;
+}
+.notify-card-close {
+  position: absolute;
+  top: 6px;
+  right: 7px;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  color: var(--cx-muted);
+}
+.notify-card-close:hover { background: var(--cx-hover); color: var(--cx-text); }
+.notify-card-title { font-size: 13px; font-weight: 600; }
+.notify-card-body {
+  margin-top: 2px;
+  color: var(--cx-text-2);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+@keyframes cx-notify-in {
+  from { opacity: 0; transform: translateX(12px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(24, 24, 27, 0.34);
+  backdrop-filter: blur(2px);
+  animation: cx-confirm-fade 120ms ease;
+}
+.confirm-dialog {
+  width: min(100%, 460px);
+  padding: 22px 24px 18px;
+  border: 1px solid var(--cx-border);
+  border-radius: var(--cx-radius-lg);
+  background: var(--cx-surface);
+  box-shadow: 0 18px 60px rgba(24, 24, 27, 0.25);
+  animation: cx-confirm-pop 160ms cubic-bezier(0.2, 0.8, 0.3, 1.1);
+}
+.confirm-title {
+  margin-bottom: 10px;
+  color: var(--cx-text);
+  font-size: 16px;
+  font-weight: 600;
+}
+.confirm-body {
+  margin-bottom: 18px;
+  color: var(--cx-text-2);
+  font-size: 13.5px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+.confirm-body code {
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: var(--cx-code);
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+}
+.confirm-actions { display: flex; justify-content: flex-end; gap: 10px; }
+.confirm-actions .ghost,
+.confirm-actions .primary,
+.confirm-actions .danger {
+  padding: 8px 18px;
+  border: 1px solid var(--cx-border-strong);
+  border-radius: 9px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+.confirm-actions .ghost { background: transparent; color: var(--cx-text); }
+.confirm-actions .ghost:hover { background: var(--cx-hover); }
+.confirm-actions .primary { background: var(--cx-text); color: var(--cx-surface); }
+.confirm-actions .danger { border-color: var(--cx-bad); background: var(--cx-bad); color: #fff; }
+.confirm-actions .danger:hover { background: #a12e2e; }
+.confirm-actions button:focus-visible { outline: 2px solid var(--cx-text); outline-offset: 2px; }
+@keyframes cx-confirm-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes cx-confirm-pop {
+  from { opacity: 0; transform: translateY(3px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ---------- Responsive / mobile ---------- */
+
+@media (max-width: 768px) {
+  .cx-app {
+    grid-template-columns: minmax(0, 1fr);
+    height: 100dvh;
+  }
+
+  .cx-mobile-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: calc(8px + env(safe-area-inset-top));
+    left: calc(10px + env(safe-area-inset-left));
+    z-index: 40;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid var(--cx-border-strong);
+    border-radius: var(--cx-radius);
+    background: var(--cx-surface);
+    color: var(--cx-text);
+    box-shadow: var(--cx-shadow-2);
+    cursor: pointer;
+  }
+  .cx-mobile-nav-toggle:focus-visible,
+  .cx-mobile-nav-close:focus-visible {
+    outline: 2px solid var(--cx-text);
+    outline-offset: 2px;
+  }
+
+  .cx-drawer {
+    display: block;
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 60;
+    width: min(86vw, 320px);
+    height: 100dvh;
+    transform: translateX(-100%);
+    visibility: hidden;
+    box-shadow: 0 0 36px rgba(24, 24, 27, 0.18);
+    overscroll-behavior: contain;
+    transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 220ms;
+  }
+  .cx-drawer.open {
+    transform: translateX(0);
+    visibility: visible;
+    transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .cx-drawer .cx-sidebar {
+    width: 100%;
+    height: 100dvh;
+    padding-top: calc(14px + env(safe-area-inset-top));
+    padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    padding-left: calc(12px + env(safe-area-inset-left));
+  }
+  .cx-drawer .cx-sb-brand { padding-right: 46px; }
+  .cx-mobile-nav-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: calc(24px + env(safe-area-inset-top));
+    right: 20px;
+    z-index: 1;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 0;
+    border-radius: var(--cx-radius-sm);
+    background: transparent;
+    color: var(--cx-muted);
+    cursor: pointer;
+  }
+  .cx-mobile-nav-close:hover { background: var(--cx-hover); color: var(--cx-text); }
+  .cx-mobile-nav-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background: rgba(24, 24, 27, 0.32);
+    cursor: pointer;
+  }
+
+  .cx-main-head {
+    height: calc(56px + env(safe-area-inset-top));
+    padding: env(safe-area-inset-top) 16px 0 calc(62px + env(safe-area-inset-left));
+    gap: 8px;
+  }
+  .cx-main-head-title,
+  .cx-main-head-sub,
+  .cx-main-head-branch { min-width: 0; }
+  .cx-main-head-sub,
+  .cx-main-head-branch {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .cx-thread-body { padding: 16px 16px 40px; }
+  .cx-msg { padding: 12px 0; }
+  .cx-msg-imgs img { max-width: 100%; height: auto; }
+  .cx-home {
+    min-height: 100%;
+    padding: 64px 22px 24px;
+  }
+  .cx-home-title { font-size: 25px; }
+  .cx-home-sub { font-size: 14px; }
+
+  .cx-composer-wrap {
+    padding: 12px 12px calc(12px + env(safe-area-inset-bottom));
+    background: linear-gradient(180deg, rgba(250, 250, 250, 0), var(--cx-bg) 28%);
+  }
+  .cx-composer {
+    padding: 8px 10px 8px 12px;
+    border-radius: 16px;
+  }
+  .cx-composer-row { gap: 6px; }
+  .cx-composer textarea {
+    font-size: 16px;
+    padding-inline: 0;
+  }
+  .cx-composer-foot {
+    margin-top: 8px;
+    display: block;
+  }
+  .cx-composer-pickers {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    width: 100%;
+    gap: 6px;
+  }
+  .cx-runtime-chips { display: contents; }
+  .cx-provider-chip {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    justify-content: center;
+  }
+  .cx-composer-hint { display: none; }
+
+  .cx-settings {
+    padding: calc(68px + env(safe-area-inset-top)) 16px calc(40px + env(safe-area-inset-bottom));
+  }
+  .cx-settings-grid { grid-template-columns: minmax(0, 1fr); gap: 14px; }
+  .cx-settings-list { position: static; }
+  .cx-field-row { grid-template-columns: minmax(0, 1fr); gap: 0; }
+  .cx-settings-section { padding: 16px; }
+  .cx-section-head { align-items: flex-start; flex-wrap: wrap; }
+
+  .cx-canvas {
+    padding: calc(12px + env(safe-area-inset-top)) 12px calc(24px + env(safe-area-inset-bottom));
+  }
+  .cx-canvas-head {
+    min-height: 44px;
+    margin-bottom: 12px;
+    padding-left: calc(50px + env(safe-area-inset-left));
+    align-items: center;
+  }
+  .cx-canvas-title {
+    flex-wrap: wrap;
+    gap: 2px 8px;
+  }
+  .cx-canvas-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+    grid-auto-rows: auto !important;
+    gap: 12px;
+  }
+  .cx-tile {
+    grid-column: 1 / -1 !important;
+    grid-row: auto !important;
+    width: 100%;
+    min-height: 440px;
+    height: min(700px, calc(100dvh - 120px));
+  }
+  .cx-tile-resize { display: none; }
+  .cx-tile-body .cx-composer-wrap {
+    padding: 8px 10px calc(10px + env(safe-area-inset-bottom));
+  }
+  .notify-stack {
+    top: calc(10px + env(safe-area-inset-top));
+    right: 12px;
+    width: calc(100vw - 24px);
+  }
+  .confirm-dialog { padding: 20px 18px 16px; }
+}
+
+@media (max-width: 420px) {
+  .cx-main-head-dot,
+  .cx-main-head-sub,
+  .cx-main-head-branch { display: none; }
+  .cx-canvas-title {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 340px) {
+  .cx-composer-pickers { grid-template-columns: minmax(0, 1fr); }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .cx-sb-thread-pin,
+  .cx-sb-thread-del { visibility: visible; }
+  .cx-tile-action { opacity: 1; }
+  .cx-tile-resize { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cx-drawer,
+  .cx-drawer.open { transition: none; }
+  .notify-card,
+  .confirm-backdrop,
+  .confirm-dialog { animation: none; }
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -41,7 +41,9 @@ function sessStatus(mtime: number): 'completed' | 'running' {
   return Date.now() - mtime < 60_000 ? 'running' : 'completed';
 }
 
-export function Sidebar() {
+export function Sidebar({ onNavigate }: {
+  onNavigate?: () => void;
+} = {}) {
   const [workspaces, setWorkspaces] = useState<WsData[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [status, setStatus] = useState<'connecting' | 'ok' | 'bad'>('connecting');
@@ -157,6 +159,7 @@ export function Sidebar() {
     const project = encodeClaudeProjectName(cwd);
     setPendingCwd(project, cwd);
     navigate(`/w/${encodeURIComponent(project)}`);
+    onNavigate?.();
   };
 
 
@@ -348,7 +351,7 @@ export function Sidebar() {
 
   return (
     <aside className="sidebar-v2">
-      <Link className="sb-brand" to="/">
+      <Link className="sb-brand" to="/" onClick={onNavigate}>
         <img className="sb-logo" src={assetUrl('/mindlab-symbol.svg')} alt="" />
         <div>
           <div className="sb-brand-name">Macaron Artifacts</div>
@@ -359,13 +362,18 @@ export function Sidebar() {
       <button
         type="button"
         className="sb-search"
-        onClick={() => window.dispatchEvent(new CustomEvent('macaron:open-search'))}
+        onClick={() => {
+          onNavigate?.();
+          window.requestAnimationFrame(() => {
+            window.dispatchEvent(new CustomEvent('macaron:open-search'));
+          });
+        }}
         title="Search Claude sessions"
       >
         <span className="sb-search-icon"><Search size={16} aria-hidden="true" /></span>
         <span className="sb-search-label">Search sessions</span>
       </button>
-      <Link className={'sb-nav-link' + (location.pathname === '/examples' ? ' active' : '')} to="/examples">
+      <Link className={'sb-nav-link' + (location.pathname === '/examples' ? ' active' : '')} to="/examples" onClick={onNavigate}>
         <span>Examples</span>
       </Link>
 
@@ -375,7 +383,10 @@ export function Sidebar() {
           <button
             type="button"
             className="sb-new-project"
-            onClick={() => setShowNewProject(true)}
+            onClick={() => {
+              onNavigate?.();
+              setShowNewProject(true);
+            }}
             title="New project (create dir or clone a repo)"
             aria-label="New project"
           >
@@ -395,22 +406,32 @@ export function Sidebar() {
             <div key={w.project} className={'sb-ws' + (isActive ? ' active' : '')}>
               <div
                 className="sb-ws-head"
-                onClick={() => {
-                  toggleExpand(w.project);
-                  navigate(`/w/${encodeURIComponent(w.project)}`);
-                }}
                 onContextMenu={(e) => wsMenu(w, e)}
               >
-                <span className="sb-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
-                <span className="sb-ws-name">{name}</span>
-                <span className="sb-spacer" />
-                {runCount > 0 && !isExpanded && (
-                  <span className="sb-badge sb-badge-running">{runCount}</span>
-                )}
                 <button
+                  type="button"
+                  className="sb-ws-main"
+                  aria-expanded={isExpanded}
+                  onClick={() => {
+                    toggleExpand(w.project);
+                    navigate(`/w/${encodeURIComponent(w.project)}`, {
+                      state: { keepClaudeDrawerOpen: true },
+                    });
+                  }}
+                >
+                  <span className="sb-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
+                  <span className="sb-ws-name">{name}</span>
+                  <span className="sb-spacer" />
+                  {runCount > 0 && !isExpanded && (
+                    <span className="sb-badge sb-badge-running">{runCount}</span>
+                  )}
+                </button>
+                <button
+                  type="button"
                   className="sb-dots"
                   onClick={(e) => wsMenu(w, e)}
                   title="Workspace actions"
+                  aria-label={`${name} actions`}
                 >
                   ···
                 </button>
@@ -424,49 +445,53 @@ export function Sidebar() {
                       <div
                         key={s.sessionId}
                         className={'sb-sess' + (pinned ? ' pinned' : '')}
-                        onClick={() => {
-                          // First click adds to canvas. Subsequent click on a
-                          // pinned row focuses it (and navigates so the URL
-                          // matches — canvas view handles the sid).
-                          if (!pinned) toggleCanvasSid(w.project, s.sessionId);
-                          else focusCanvasSid(w.project, s.sessionId);
-                          if (activeProject !== w.project) {
-                            navigate(`/w/${encodeURIComponent(w.project)}`);
-                          }
-                          // Ask the matching tile to scroll into view + focus
-                          // its composer. Custom event fires regardless of
-                          // whether the focused sid actually changed, so
-                          // re-clicking the same row still re-scrolls.
-                          window.dispatchEvent(
-                            new CustomEvent('macaron:focus-tile', {
-                              detail: { project: w.project, sid: s.sessionId },
-                            }),
-                          );
-                        }}
                         onContextMenu={(e) => sessMenu(w, s, e)}
                       >
-                        <span className={'sb-sess-dot sb-sess-dot-' + st} />
                         {renamingSid === s.sessionId ? (
-                          <input
-                            className="sb-sess-rename"
-                            value={renameDraft}
-                            autoFocus
-                            placeholder={s.preview || s.sessionId.slice(0, 8)}
-                            onClick={(e) => e.stopPropagation()}
-                            onChange={(e) => setRenameDraft(e.target.value)}
-                            onBlur={() => commitRename(w.project, s.sessionId)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') commitRename(w.project, s.sessionId);
-                              else if (e.key === 'Escape') {
-                                renameDoneRef.current = true;
-                                setRenamingSid('');
-                              }
-                            }}
-                          />
+                          <div className="sb-sess-main">
+                            <span className={'sb-sess-dot sb-sess-dot-' + st} />
+                            <input
+                              className="sb-sess-rename"
+                              value={renameDraft}
+                              autoFocus
+                              placeholder={s.preview || s.sessionId.slice(0, 8)}
+                              onClick={(e) => e.stopPropagation()}
+                              onChange={(e) => setRenameDraft(e.target.value)}
+                              onBlur={() => commitRename(w.project, s.sessionId)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') commitRename(w.project, s.sessionId);
+                                else if (e.key === 'Escape') {
+                                  renameDoneRef.current = true;
+                                  setRenamingSid('');
+                                }
+                              }}
+                            />
+                          </div>
                         ) : (
-                          <span className="sb-sess-name">
-                            {s.label || s.preview || s.sessionId.slice(0, 8)}
-                          </span>
+                          <button
+                            type="button"
+                            className="sb-sess-main"
+                            onClick={() => {
+                              // First click adds to canvas. Subsequent clicks
+                              // focus the existing tile.
+                              if (!pinned) toggleCanvasSid(w.project, s.sessionId);
+                              else focusCanvasSid(w.project, s.sessionId);
+                              if (activeProject !== w.project) {
+                                navigate(`/w/${encodeURIComponent(w.project)}`);
+                              }
+                              window.dispatchEvent(
+                                new CustomEvent('macaron:focus-tile', {
+                                  detail: { project: w.project, sid: s.sessionId },
+                                }),
+                              );
+                              onNavigate?.();
+                            }}
+                          >
+                            <span className={'sb-sess-dot sb-sess-dot-' + st} />
+                            <span className="sb-sess-name">
+                              {s.label || s.preview || s.sessionId.slice(0, 8)}
+                            </span>
+                          </button>
                         )}
                         <button
                           type="button"
@@ -477,9 +502,10 @@ export function Sidebar() {
                             if (activeProject !== w.project) {
                               navigate(`/w/${encodeURIComponent(w.project)}`);
                             }
+                            onNavigate?.();
                           }}
                           title={pinned ? 'Remove from canvas' : 'Add to canvas'}
-                          aria-label={pinned ? 'Remove from canvas' : 'Add to canvas'}
+                          aria-label={`${pinned ? 'Remove' : 'Add'} ${s.label || s.preview || s.sessionId.slice(0, 8)} ${pinned ? 'from' : 'to'} canvas`}
                         >
                           {pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
                         </button>
@@ -500,14 +526,19 @@ export function Sidebar() {
       </div>
 
       <div className="sb-tools">
-        <Link className="sb-settings-link" to="/usage">
+        <Link className="sb-settings-link" to="/usage" onClick={onNavigate}>
           <span>Usage</span>
         </Link>
 
         <button
           type="button"
           className="sb-settings-link sb-shortcuts-btn"
-          onClick={() => window.dispatchEvent(new CustomEvent('macaron:shortcuts'))}
+          onClick={() => {
+            onNavigate?.();
+            window.requestAnimationFrame(() => {
+              window.dispatchEvent(new CustomEvent('macaron:shortcuts'));
+            });
+          }}
           title="Keyboard shortcuts"
         >
           <span>Shortcuts</span>
@@ -515,7 +546,7 @@ export function Sidebar() {
           <kbd className="sb-shortcuts-kbd" aria-hidden="true">?</kbd>
         </button>
 
-        <Link className="sb-settings-link" to="/settings">
+        <Link className="sb-settings-link" to="/settings" onClick={onNavigate}>
           <span>Settings</span>
         </Link>
       </div>
@@ -546,6 +577,7 @@ export function Sidebar() {
             setShowNewProject(false);
             loadData();
             navigate(`/w/${encodeURIComponent(project)}`);
+            onNavigate?.();
           }}
         />
       )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -101,7 +101,7 @@
 html, body, #root { height: 100%; margin: 0; }
 #root {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px minmax(0, 1fr);
 }
 body {
   font-family: var(--font-sans);
@@ -185,7 +185,7 @@ body {
 .status.bad::before { color: var(--bad); }
 
 /* ---------- main ---------- */
-main { background: var(--bg); overflow: auto; height: 100vh; }
+main { min-width: 0; background: var(--bg); overflow: auto; height: 100vh; }
 .view {
   max-width: 1080px;
   margin: 0 auto;
@@ -4418,10 +4418,45 @@ textarea:focus, select:focus, input:focus {
 .sb-drawer { display: contents; }
 .mobile-nav-toggle { display: none; }
 .sb-backdrop { display: none; }
+.mobile-nav-close { display: none; }
+
+/* The V2 rows use semantic buttons for keyboard and touch access. Keep the
+   buttons visually identical to the old row treatment while preserving the
+   row's flex geometry. */
+.sb-ws-main,
+.sb-sess-main {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+  gap: 8px;
+  border: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.sb-ws-main {
+  padding: 0;
+  background: transparent;
+}
+.sb-sess-main {
+  padding: 0;
+  background: transparent;
+  overflow: hidden;
+}
+.sb-ws-main:focus-visible,
+.sb-sess-main:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 5px;
+}
+.sb-sess-main .sb-sess-name { flex: 1; min-width: 0; }
 
 @media (max-width: 768px) {
   /* Single column: the sidebar leaves the flow and slides in as an overlay. */
-  #root { grid-template-columns: 1fr; }
+  #root { grid-template-columns: minmax(0, 1fr); }
 
   .mobile-nav-toggle {
     display: flex;
@@ -4559,6 +4594,135 @@ textarea:focus, select:focus, input:focus {
   }
   .ws-tile-grip { min-height: 48px; padding-top: 4px; padding-bottom: 4px; }
   .ws-tile-grip-dots { opacity: 0.72; }
+}
+
+/* ---------- responsive refinements ----------
+   Several legacy views share these primitives; the mobile canvas also needs
+   to override inline grid spans without changing JS resize math. */
+@media (max-width: 768px) {
+  .mobile-nav-toggle {
+    min-width: 40px;
+    min-height: 40px;
+    padding: 0;
+  }
+
+  .sb-drawer {
+    width: min(86vw, 320px);
+    max-width: 100vw;
+  }
+  .mobile-nav-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: calc(10px + env(safe-area-inset-top));
+    right: 10px;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    z-index: 1;
+  }
+  .mobile-nav-close:focus-visible,
+  .mobile-nav-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .sb-drawer .sb-brand { margin-right: 58px; }
+  .sb-backdrop {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    cursor: pointer;
+  }
+
+  .sb-ws-head {
+    gap: 6px;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  .sb-ws-main,
+  .sb-sess-main {
+    min-height: 44px;
+  }
+  .sb-ws-main { padding: 0 0 0 16px; }
+  .sb-dots,
+  .sb-sess-pin {
+    width: 40px;
+    height: 40px;
+    min-width: 40px;
+    min-height: 40px;
+    opacity: 1;
+  }
+  .sb-dots { margin-right: 8px; }
+  .sb-sess {
+    gap: 6px;
+    padding-left: 0;
+    padding-right: 8px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+  .sb-sess-main { padding-left: 32px; }
+  .sb-search,
+  .sb-nav-link,
+  .sb-settings-link {
+    min-height: 44px;
+  }
+  .sb-new-project { min-height: 40px; }
+
+  .ws-canvas-grid-v2 {
+    grid-auto-rows: auto !important;
+  }
+  .ws-tile {
+    grid-column: 1 / -1 !important;
+    grid-row: auto !important;
+    min-height: min(440px, calc(100dvh - 132px));
+    height: min(680px, calc(100dvh - 132px));
+  }
+
+  .session-input textarea,
+  .ws-tile-body .session-input textarea {
+    font-size: 16px;
+  }
+  .icon-btn,
+  .send-btn,
+  .send-now-btn,
+  .queue-btn,
+  .stop-btn {
+    min-width: 40px;
+    min-height: 40px;
+  }
+  .home-ws-chip,
+  .home-target,
+  .home-target select,
+  .provider-chip-label {
+    min-width: 0;
+  }
+
+  .confirm-backdrop {
+    padding: 12px;
+    overflow-y: auto;
+  }
+  .confirm-dialog,
+  .pr-dialog,
+  .np-dialog,
+  .dir-picker,
+  .shortcuts-dialog {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    max-height: calc(100dvh - 24px);
+    overflow-y: auto;
+  }
+
 }
 
 /* ---------- git panel ---------- */
@@ -5520,4 +5684,16 @@ textarea:focus, select:focus, input:focus {
 @media (max-width: 420px) {
   .ft-mode-btn { padding-left: 8px; padding-right: 8px; }
   .ws-canvas-action { gap: 4px; font-size: 11px; }
+}
+
+@media (max-width: 768px) {
+  /* This view is declared after the shared responsive block above. Repeat its
+     viewport-safe sizing here so the later home rules cannot restore 100vh. */
+  .home-view {
+    min-height: 100dvh;
+    height: 100dvh;
+    padding: calc(24px + env(safe-area-inset-top))
+      16px calc(24px + env(safe-area-inset-bottom));
+  }
+  .home-inner { min-width: 0; margin: auto 0; }
 }


### PR DESCRIPTION
## Summary

- add accessible off-canvas navigation and responsive layouts to both the Codex and Claude Code web shells
- keep Claude workspace expansion usable inside the mobile drawer while session selection closes and focuses the canvas
- make mobile canvas tiles, composer controls, dialogs, and home layout fit dynamic viewports without horizontal overflow
- preserve the desktop two-column layout and existing Codex behavior

## Verification

- `corepack pnpm --filter @macaron/web test` (53 passed)
- `corepack pnpm --filter @macaron/web build`
- `corepack pnpm --filter @macaron/server build`
- `corepack pnpm --filter @macaron/server typecheck`
- browser smoke at 1440x900, 769x900, 768x900, and 390x844
- verified Claude drawer dialog semantics, focus trap/restoration, close button, Escape/backdrop dismissal, workspace/session navigation, New Project portal, 44px navigation targets, and zero horizontal overflow

`@macaron/web` typecheck still reports existing vendor/type-environment failures in `partial-react`, `partial-tsx`, and `web/src/macaron-vendor`; no changed file appears in the error set.

Closes [MAC-9153](https://multica.macaron.xin/issues/fbab4103-1bc9-4777-a99b-1a0d44e4e2ca "为参考界面实现响应式设计")