### PR TITLE
feat(server): CLI flags + official default for hosted-WebUI origins

### DIFF
--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -43,8 +43,6 @@ async function printVersion() {
 
 const readValue = (i, flag) => {
   const v = args[i + 1];
-  // Reject only a missing or flag-like next token; an empty value passes here
-  // (matching `--flag=`) and, for --port, is caught by the range check below.
   if (v === undefined || v.startsWith('-')) throw new Error(`${flag} requires a value`);
   return v;
 };
@@ -57,9 +55,14 @@ try {
     const inline = eq === -1 ? null : a.slice(eq + 1);
     if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
     if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
-    if (flag === '--allow-hosted') { process.env.MACARON_ALLOW_HOSTED = '1'; continue; }
+    if (flag === '--allow-hosted') {
+      if (inline !== null) throw new Error(`${flag} does not take a value`);
+      process.env.MACARON_ALLOW_HOSTED = '1';
+      continue;
+    }
     if (flag === '--allow-origin') {
-      const origin = inline ?? readValue(i, flag);
+      const origin = (inline ?? readValue(i, flag)).trim();
+      if (!origin) throw new Error(`${flag} requires a non-empty value`);
       const cur = process.env.MACARON_ALLOWED_ORIGINS;
       process.env.MACARON_ALLOWED_ORIGINS = cur ? `${cur},${origin}` : origin;
       if (inline === null) i++;

--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -15,12 +15,21 @@ function printHelp() {
   Start the Macaron Claude Code WebUI.
 
 Options:
-  --host <host>     Bind address (default: 127.0.0.1)
-  --port <port>     Port (default: 7878)
-  --version, -v     Print version and exit
-  --help, -h        Show this help
+  --host <host>          Bind address (default: 127.0.0.1)
+  --port <port>          Port (default: 7878)
+  --allow-origin <url>   Allow a hosted WebUI on this origin to drive the server
+                         cross-origin (repeatable; appends to MACARON_ALLOWED_ORIGINS)
+  --allow-hosted         Allow the official hosted WebUI (https://artifacts.macaron.im)
+  --version, -v          Print version and exit
+  --help, -h             Show this help
+
+Enabling any origin arms an access token so the API is never open cross-origin.
+Precedence is additive: MACARON_ALLOWED_ORIGINS (env) ∪ every --allow-origin ∪,
+if --allow-hosted / MACARON_ALLOW_HOSTED is set, the official origin.
 
 Environment:
+  MACARON_ALLOWED_ORIGINS  Comma-separated allowed origins
+  MACARON_ALLOW_HOSTED     1/true to include the official hosted origin
   MACARON_API_BASE   Macaron API endpoint
   MACARON_API_KEY    Macaron API key
   MACARON_MODEL      Model id (default: macaron-0.6)
@@ -48,6 +57,14 @@ try {
     const inline = eq === -1 ? null : a.slice(eq + 1);
     if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
     if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
+    if (flag === '--allow-hosted') { process.env.MACARON_ALLOW_HOSTED = '1'; continue; }
+    if (flag === '--allow-origin') {
+      const origin = inline ?? readValue(i, flag);
+      const cur = process.env.MACARON_ALLOWED_ORIGINS;
+      process.env.MACARON_ALLOWED_ORIGINS = cur ? `${cur},${origin}` : origin;
+      if (inline === null) i++;
+      continue;
+    }
     if (flag === '--host' || flag === '--port') {
       process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(i, flag);
       // Advance past the consumed value only for the space form (inline === null).

--- a/mcx/bin/mcx.mjs
+++ b/mcx/bin/mcx.mjs
@@ -43,8 +43,6 @@ async function printVersion() {
 
 const readValue = (i, flag) => {
   const v = args[i + 1];
-  // Reject only a missing or flag-like next token; an empty value passes here
-  // (matching `--flag=`) and, for --port, is caught by the range check below.
   if (v === undefined || v.startsWith('-')) throw new Error(`${flag} requires a value`);
   return v;
 };
@@ -57,9 +55,14 @@ try {
     const inline = eq === -1 ? null : a.slice(eq + 1);
     if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
     if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
-    if (flag === '--allow-hosted') { process.env.MACARON_ALLOW_HOSTED = '1'; continue; }
+    if (flag === '--allow-hosted') {
+      if (inline !== null) throw new Error(`${flag} does not take a value`);
+      process.env.MACARON_ALLOW_HOSTED = '1';
+      continue;
+    }
     if (flag === '--allow-origin') {
-      const origin = inline ?? readValue(i, flag);
+      const origin = (inline ?? readValue(i, flag)).trim();
+      if (!origin) throw new Error(`${flag} requires a non-empty value`);
       const cur = process.env.MACARON_ALLOWED_ORIGINS;
       process.env.MACARON_ALLOWED_ORIGINS = cur ? `${cur},${origin}` : origin;
       if (inline === null) i++;

--- a/mcx/bin/mcx.mjs
+++ b/mcx/bin/mcx.mjs
@@ -13,12 +13,21 @@ function printHelp() {
   Start the Macaron Codex WebUI (ChatGPT-style chat over the Codex SDK).
 
 Options:
-  --host <host>     Bind address (default: 127.0.0.1)
-  --port <port>     Port (default: 7979 — offset from mcc's 7878 so both can run)
-  --version, -v     Print version and exit
-  --help, -h        Show this help
+  --host <host>          Bind address (default: 127.0.0.1)
+  --port <port>          Port (default: 7979 — offset from mcc's 7878 so both can run)
+  --allow-origin <url>   Allow a hosted WebUI on this origin to drive the server
+                         cross-origin (repeatable; appends to MACARON_ALLOWED_ORIGINS)
+  --allow-hosted         Allow the official hosted WebUI (https://artifacts.macaron.im)
+  --version, -v          Print version and exit
+  --help, -h             Show this help
+
+Enabling any origin arms an access token so the API is never open cross-origin.
+Precedence is additive: MACARON_ALLOWED_ORIGINS (env) ∪ every --allow-origin ∪,
+if --allow-hosted / MACARON_ALLOW_HOSTED is set, the official origin.
 
 Environment:
+  MACARON_ALLOWED_ORIGINS  Comma-separated allowed origins
+  MACARON_ALLOW_HOSTED     1/true to include the official hosted origin
   MACARON_CODEX_PATH   Path to codex CLI binary (default: auto-detected)
   MACARON_LOG_LEVEL    Log level (default: info)
 
@@ -48,6 +57,14 @@ try {
     const inline = eq === -1 ? null : a.slice(eq + 1);
     if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
     if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
+    if (flag === '--allow-hosted') { process.env.MACARON_ALLOW_HOSTED = '1'; continue; }
+    if (flag === '--allow-origin') {
+      const origin = inline ?? readValue(i, flag);
+      const cur = process.env.MACARON_ALLOWED_ORIGINS;
+      process.env.MACARON_ALLOWED_ORIGINS = cur ? `${cur},${origin}` : origin;
+      if (inline === null) i++;
+      continue;
+    }
     if (flag === '--host' || flag === '--port') {
       process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(i, flag);
       // Advance past the consumed value only for the space form (inline === null).

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -21,7 +21,7 @@ export const OFFICIAL_HOSTED_ORIGINS = ['https://artifacts.macaron.im'];
 // origins first, then any official ones not already listed. `*` in the explicit
 // list still wins (reflect-any, dev only).
 export function buildAllowedOrigins(explicit: string[], allowHosted: boolean): string[] {
-  const out = [...explicit];
+  const out = [...new Set(explicit)];
   if (allowHosted) for (const o of OFFICIAL_HOSTED_ORIGINS) if (!out.includes(o)) out.push(o);
   return out;
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,15 +8,36 @@ export const HOST = process.env.MACARON_HOST || '127.0.0.1';
 // the network. Empty = auth off (the default for loopback-only binds).
 export const AUTH_TOKEN = process.env.MACARON_AUTH_TOKEN || '';
 
+// The official Macaron-hosted WebUI origins. These are vetted first-party sites
+// that serve the exact same web/ build and only ever drive the server through
+// the same token-gated API — so opting them in (via --allow-hosted or
+// MACARON_ALLOW_HOSTED=1) is the safe, no-typo way to enable hosted mode.
+// Enabling any origin arms an auth token (resolveToken), so the API is never
+// left unauthenticated cross-origin.
+export const OFFICIAL_HOSTED_ORIGINS = ['https://artifacts.macaron.im'];
+
+// Merge the explicit allowlist (env / CLI) with the official origins when the
+// user opts into hosted mode. Additive union, deduped, order-stable: explicit
+// origins first, then any official ones not already listed. `*` in the explicit
+// list still wins (reflect-any, dev only).
+export function buildAllowedOrigins(explicit: string[], allowHosted: boolean): string[] {
+  const out = [...explicit];
+  if (allowHosted) for (const o of OFFICIAL_HOSTED_ORIGINS) if (!out.includes(o)) out.push(o);
+  return out;
+}
+
 // Origins allowed to reach the API cross-origin (comma-separated). Empty = the
 // UI is same-origin (the default) and no CORS headers are emitted. Set this to
 // the hosted docs origin (e.g. https://artifacts.macaron.im) to let a hosted
-// WebUI drive this server. Use `*` to reflect any origin (dev only — combined
-// with a bearer/`?token=` secret, but still avoid on shared machines).
-export const ALLOWED_ORIGINS = (process.env.MACARON_ALLOWED_ORIGINS || '')
+// WebUI drive this server, or set MACARON_ALLOW_HOSTED=1 to pull in the official
+// origins above. Use `*` to reflect any origin (dev only — combined with a
+// bearer/`?token=` secret, but still avoid on shared machines).
+const EXPLICIT_ORIGINS = (process.env.MACARON_ALLOWED_ORIGINS || '')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
+
+export const ALLOWED_ORIGINS = buildAllowedOrigins(EXPLICIT_ORIGINS, /^(1|true|yes)$/i.test(process.env.MACARON_ALLOW_HOSTED || ''));
 
 // Optional env overrides. Users normally set the Macaron API key via the
 // Settings page (persisted to ~/.claude/macaron-config.json); env vars still

--- a/server/test/allowed-origins.test.ts
+++ b/server/test/allowed-origins.test.ts
@@ -16,6 +16,13 @@ test('explicit + hosted → union, explicit first, deduped', () => {
   assert.deepEqual(buildAllowedOrigins(['https://a.test'], true), ['https://a.test', OFFICIAL]);
 });
 
+test('duplicate explicit origins are removed in first-seen order', () => {
+  assert.deepEqual(
+    buildAllowedOrigins(['https://a.test', 'https://a.test', 'https://b.test', 'https://a.test'], true),
+    ['https://a.test', 'https://b.test', OFFICIAL],
+  );
+});
+
 test('explicit already lists the official origin → not duplicated', () => {
   assert.deepEqual(buildAllowedOrigins([OFFICIAL], true), [OFFICIAL]);
 });

--- a/server/test/allowed-origins.test.ts
+++ b/server/test/allowed-origins.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAllowedOrigins, OFFICIAL_HOSTED_ORIGINS } from '../src/config.js';
+
+const OFFICIAL = OFFICIAL_HOSTED_ORIGINS[0];
+
+test('no explicit origins, hosted off → empty (same-origin default)', () => {
+  assert.deepEqual(buildAllowedOrigins([], false), []);
+});
+
+test('hosted on → official origins are appended', () => {
+  assert.deepEqual(buildAllowedOrigins([], true), [...OFFICIAL_HOSTED_ORIGINS]);
+});
+
+test('explicit + hosted → union, explicit first, deduped', () => {
+  assert.deepEqual(buildAllowedOrigins(['https://a.test'], true), ['https://a.test', OFFICIAL]);
+});
+
+test('explicit already lists the official origin → not duplicated', () => {
+  assert.deepEqual(buildAllowedOrigins([OFFICIAL], true), [OFFICIAL]);
+});
+
+test('explicit origins pass through untouched when hosted is off', () => {
+  assert.deepEqual(buildAllowedOrigins(['https://a.test', 'https://b.test'], false), ['https://a.test', 'https://b.test']);
+});

--- a/server/test/launcher-args.test.ts
+++ b/server/test/launcher-args.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const launchers = [
+  path.join(repoRoot, 'bin', 'mcc.mjs'),
+  path.join(repoRoot, 'mcx', 'bin', 'mcx.mjs'),
+];
+
+function runLauncher(launcher: string, args: string[]) {
+  const env = { ...process.env };
+  delete env.MACARON_ALLOWED_ORIGINS;
+  delete env.MACARON_ALLOW_HOSTED;
+  return spawnSync(process.execPath, [launcher, ...args], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+  });
+}
+
+for (const launcher of launchers) {
+  const name = path.basename(launcher);
+
+  test(`${name} rejects an empty --allow-origin value`, () => {
+    const result = runLauncher(launcher, ['--allow-origin=']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--allow-origin requires a non-empty value/);
+  });
+
+  test(`${name} rejects an empty space-form --allow-origin value`, () => {
+    const result = runLauncher(launcher, ['--allow-origin', '   ']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--allow-origin requires a non-empty value/);
+  });
+
+  test(`${name} rejects an inline value on --allow-hosted`, () => {
+    const result = runLauncher(launcher, ['--allow-hosted=false']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--allow-hosted does not take a value/);
+  });
+}


### PR DESCRIPTION
## What

Make the hosted-WebUI allowlist configurable from the CLI, and add a vetted official default so users don't have to hand-type `https://artifacts.macaron.im` (typo → silent cross-origin failure).

- **`OFFICIAL_HOSTED_ORIGINS`** in `server/src/config.ts` — first-party hosted origins.
- **`buildAllowedOrigins(explicit, allowHosted)`** — additive union of the explicit allowlist and (opt-in) the official origins, deduped, order-stable.
- **CLI** on both `mcc` and `mcx`:
  - `--allow-origin <url>` — repeatable, appends to the allowlist.
  - `--allow-hosted` — pulls in the official origin.
- **Env** unchanged and still honored: `MACARON_ALLOWED_ORIGINS` (comma list) + new `MACARON_ALLOW_HOSTED=1`.

## Precedence

Additive, no override: `MACARON_ALLOWED_ORIGINS` (env) ∪ every `--allow-origin` ∪ (if `--allow-hosted` **or** `MACARON_ALLOW_HOSTED` set) the official origin. Deduped.

## Security

No new hole. Enabling *any* origin already arms an access token (`resolveToken`), so the cross-origin API is never unauthenticated — the official default is just a curated, opt-in entry in the same allowlist, not an always-on `*`.

## Usage

```
mcc --allow-hosted                          # official hosted UI only
mcc --allow-origin https://staging.example  # a custom hosted origin
mcx --allow-hosted --allow-origin https://a.test --allow-origin=https://b.test
MACARON_ALLOW_HOSTED=1 mcc                   # same as --allow-hosted, via env
```

## Verification

- server `pnpm test` **59/59** (54 prior + 5 new `allowed-origins`), typecheck clean.
- Launcher flag→env mapping and end-to-end `ALLOWED_ORIGINS` resolution checked: `env ∪ official`, deduped → `["https://a.test","https://b.test","https://artifacts.macaron.im"]`.
- `--help` renders the new flags on both `mcc` and `mcx`.
