### PR TITLE
feat: add Kimi Code engine support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "macaron",
       "source": "./",
-      "description": "Macaron artifacts for Claude Code and Codex — streaming GenUI builder, model switcher, and visual session manager."
+      "description": "Macaron artifacts for Claude Code, Codex, and Kimi Code — streaming GenUI builder, model switcher, and visual session manager."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "macaron",
-  "description": "Macaron artifacts for Claude Code and Codex — streaming GenUI builder, model switcher, and visual session manager.",
+  "description": "Macaron artifacts for Claude Code, Codex, and Kimi Code — streaming GenUI builder, model switcher, and visual session manager.",
   "author": {
     "name": "Mindverse",
     "url": "https://macaron.im"

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -30,7 +30,8 @@ jobs:
       # web/dist and run without Vite at runtime — no separate build step needed.
       # Force long-form URLs because compact URLs require npm repository metadata;
       # these are only published through pkg.pr.new, and --bin shows a CLI command.
-      # Publish both `mcc` (root, `.`, Claude) and `mcx` (Codex) — two independent,
-      # self-contained packages, each with its own bundle. `npx mcx@…` works bare
-      # (bin name = package name) and pulls in only mcx.
-      - run: pnpm exec pkg-pr-new publish --no-compact --bin . ./mcx
+      # Publish `mcc` (root, `.`, Claude), `mcx` (Codex) and `mkx` (Kimi) — three
+      # independent, self-contained packages, each with its own bundle.
+      # `npx mcx@…` / `npx mkx@…` work bare (bin name = package name) and pull
+      # in only that package.
+      - run: pnpm exec pkg-pr-new publish --no-compact --bin . ./mcx ./mkx

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 
 # Claude Code local
 .claude/settings.local.json
+.vercel
+.env*

--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "plugins": [
+    {
+      "id": "macaron",
+      "displayName": "Macaron",
+      "source": "./"
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "macaron",
+  "version": "0.6.0",
+  "description": "Macaron WebUI for Kimi Code — visual session manager, GenUI builder, and multi-provider streaming chat over your ~/.kimi-code/sessions/. Also available for Claude Code and Codex.",
+  "author": {
+    "name": "Mindverse",
+    "url": "https://macaron.im"
+  },
+  "homepage": "https://macaron.im",
+  "repository": "https://github.com/mindverse-ltd/macaron-artifacts",
+  "license": "MIT",
+  "keywords": ["macaron", "genui", "webui", "session-manager", "kimi"],
+  "skills": "./skills/",
+  "commands": "./commands-kimi/",
+  "interface": {
+    "displayName": "Macaron",
+    "shortDescription": "Visual session manager + streaming GenUI for Kimi Code.",
+    "longDescription": "Macaron opens a local WebUI that mirrors your Kimi Code sessions from ~/.kimi-code/sessions/ — browse workspaces, pin sessions to a canvas, continue any turn, and preview streaming GenUI TSX artifacts. Also bundles the genui-builder skill so Kimi Code can author renderable UI from a prompt.",
+    "developerName": "Mindverse",
+    "websiteURL": "https://macaron.im"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Macaron Artifacts
 
-Macaron Artifacts publishes the plugin manifests, local WebUI runtime, GenUI tooling, and docs for running Macaron with Claude Code and Codex.
+Macaron Artifacts publishes the plugin manifests, local WebUI runtime, GenUI tooling, and docs for running Macaron with Claude Code, Codex, and Kimi Code.
 
 1. **Visual sessions** — browse workspaces and sessions with previews, then continue a turn from the browser.
 2. **Live chat** — stream thinking, tool calls, and GenUI previews from supported agent runtimes.
@@ -42,23 +42,34 @@ codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
+### Kimi Code
+
+In a Kimi Code session, install from the GitHub URL, then reload to activate:
+
+```
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
+/reload
+```
+
 ### Run without installing
 
-Two independent packages, each self-contained (its own prebuilt server + web bundles) — `mcc` (Claude WebUI, port `7878`) and `mcx` (Codex WebUI, port `7979`). Install one, get only that one. Launch either in one command, no plugin install needed:
+Three independent packages, each self-contained (its own prebuilt server + web bundles) — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Install one, get only that one. Launch any of them in one command, no plugin install needed:
 
 ```bash
 bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
 bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
-`npx` works the same way — bin name = package name for both:
+`npx` works the same way — bin name = package name for all three:
 
 ```bash
 npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
 npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
-Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/mindverse-ltd/macaron-artifacts/commits/main)). Both accept `--host` / `--port`; run with `--help` for the full list.
+Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/mindverse-ltd/macaron-artifacts/commits/main)). All three accept `--host` / `--port`; run with `--help` for the full list.
 
 Verify:
 
@@ -78,6 +89,8 @@ Inside Claude Code:
 The slash command starts the local server (`node server/dist/index.js`, port `7878` by default) and opens `http://localhost:7878` in your browser. Pass a custom port with `/macaron 8080`.
 
 Inside Codex, ask it to open the Macaron WebUI. The Codex-side default port is `7979`.
+
+Inside Kimi Code, run `/macaron:macaron`. The Kimi-side default port is `7980`.
 
 ### Views
 
@@ -113,8 +126,12 @@ Remote requests must then present the token; localhost stays frictionless (loopb
 
 ```
 .claude-plugin/                   plugin manifest + marketplace (install from GitHub)
+.kimi-plugin/                     Kimi Code plugin manifest
 commands/macaron.md               /macaron slash command
+commands-kimi/                    Kimi Code slash commands (/macaron:macaron)
 skills/genui-builder/             bundled GenUI authoring skill
+skills/macaron-webui-kimi/        Kimi Code WebUI skill
+mkx/                              self-contained Kimi launcher package (port 7980)
 start.sh                          one-time npm install + build, boots server in background
 shared/                           domain types + SSE protocol (server ↔ web)
 server/                           Fastify API, Claude Agent SDK runner, provider relay
@@ -126,3 +143,4 @@ site/                             Fumadocs docs + landing site (standalone, not 
 
 - Built and tested against **Node 22**.
 - Claude Code stores project directories as `~/.claude/projects/-<encoded-path>`; hyphens in the original folder name are ambiguous (we display the best-guess decoded path).
+- Kimi Code stores sessions under `~/.kimi-code/sessions/<workDirKey>/<sessionId>/` (one bucket per working directory), with `~/.kimi-code/session_index.jsonl` as a fast sessionId → directory index.

--- a/commands-kimi/macaron.md
+++ b/commands-kimi/macaron.md
@@ -1,0 +1,32 @@
+---
+description: Launch the Macaron WebUI (GenUI builder, model switcher, session manager)
+---
+
+This command is invoked as `/macaron:macaron`. It starts the Macaron WebUI server backed by your Kimi Code sessions in `~/.kimi-code/sessions/`.
+
+The optional port is supplied to you as `$ARGUMENTS` (whatever the user typed after the command). If it is empty, use 7980 — the Kimi-side default, so it doesn't collide with the Claude Code (7878) or Codex (7979) flavors of this launcher.
+
+First, resolve the plugin root: this command file lives at `<plugin root>/commands-kimi/macaron.md`, so the plugin root is two directories up from this file. The launcher script is at `<plugin root>/start.sh`.
+
+The plugin arrives as source (no committed `dist/`) — `start.sh` uses `corepack pnpm` to install and build on first launch (~60s), then reuses the cached build on subsequent launches. When invoked from a plugin cache directory (which the host can prune under us), it transparently mirrors source into `~/.macaron/runtime/<version>/` and runs from there so `node_modules` / `dist` survive. Port collisions, install / build retries, and URL printing are all handled inside the script. **Do NOT** rm node_modules, run npm install, run npm run build, or otherwise "prepare" the plugin before invoking `start.sh` — call it once and let it print. If it errors out, follow the `[macaron] fix: <command>` lines it prints on stderr and try again.
+
+Run exactly this and nothing else (with the resolved plugin root substituted). `MACARON_ENGINE=kimi` selects the Kimi Code UI, and `MACARON_FOREGROUND=1` anchors the server to this shell — backgrounded children get killed when the outer script returns, so the server would disappear seconds after launch:
+
+```bash
+MACARON_ENGINE=kimi MACARON_FOREGROUND=1 MACARON_PORT="${1:-7980}" bash "<plugin root>/start.sh"
+```
+
+The server stays in the foreground indefinitely. This is expected — do NOT kill it after launch.
+
+After the server prints `Macaron WebUI (engine=kimi): http://localhost:<port>`, run `open "http://localhost:<port>"` to launch the browser, then quote the URL verbatim to the user (don't paraphrase it) and briefly summarize what's there:
+
+- **Dashboard** — all workspaces from `~/.kimi-code/sessions/`, sorted by last activity
+- **Workspace** — one project's sessions with previews; start a new session from here
+- **Session** — full transcript (tool calls, live GenUI previews) + follow-up chat
+- **Settings** — manage model providers (Kimi, Anthropic-compatible, OpenAI-compatible, …) and pick the active one
+
+If `start.sh` prints an error:
+
+- **Port busy**: report the error verbatim and ask the user for a free port to retry.
+- **Install / build failed**: `start.sh` prints one or more `[macaron] fix: <command>` lines on stderr. Run each printed fix command in order and retry `start.sh` after each; report the outcome to the user.
+- **Anything else**: quote the raw stderr, then check `/tmp/macaron-plugin.log` for the server-side tail before proposing next steps.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,9 +1,10 @@
 # Macaron Artifacts
 
-A local WebUI that ships as a plugin for **both** Claude Code and Codex — you can install one or both, and they run side-by-side:
+A local WebUI that ships as a plugin for Claude Code, Codex, and Kimi Code — install any of them, and they run side-by-side:
 
 - Claude → <http://localhost:7878>
 - Codex → <http://localhost:7979>
+- Kimi → <http://localhost:7980>
 
 ## Install
 
@@ -25,25 +26,36 @@ codex plugin add macaron@macaron
 
 Open it in a session with `open macaron web ui`.
 
+### Kimi Code
+
+```
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
+/reload
+```
+
+Open it in a session with `/macaron:macaron`.
+
 ### No plugin — one-liner via bunx / npx
 
-Two independent packages, each shipping its own prebuilt server + web assets:
-`mcc` (Claude WebUI on port `7878`) and `mcx` (Codex WebUI on port `7979`).
-Install neither; run whichever you want directly:
+Three independent packages, each shipping its own prebuilt server + web assets:
+`mcc` (Claude WebUI on port `7878`), `mcx` (Codex WebUI on port `7979`), and `mkx` (Kimi WebUI on port `7980`).
+Install none of them; run whichever you want directly:
 
 ```bash
 bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
 bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
-`npx` works the same — both packages have `bin` name == package name:
+`npx` works the same — all three packages have `bin` name == package name:
 
 ```bash
 npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
 npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
-Replace `<sha>` with any commit on `main`. Both bins accept `--host` / `--port`; run with `--help` for the full flag list.
+Replace `<sha>` with any commit on `main`. Each launcher just boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run with `--help` for the full flag list.
 
 ## Using the WebUI
 
@@ -53,7 +65,7 @@ Once open:
 - On the canvas: drag the grip to reorder tiles, drag the SE corner to resize, click a tile to focus.
 - Composer: **Enter** sends · **Shift+Enter** newline · **↑ / ↓** cycles prompt history · paste an image to attach it directly.
 
-First time on the Codex side, open **Settings** and fill in your Base URL / API key / Model.
+First time on the Codex side, open **Settings** and fill in your Base URL / API key / Model. Same on the Kimi side if you want a custom provider — by default it uses your ambient Kimi Code login.
 
 ## Update
 
@@ -70,6 +82,10 @@ codex plugin marketplace upgrade macaron   # pull the latest version
 codex plugin remove macaron@macaron
 codex plugin add macaron@macaron           # reinstall
 ```
+
+### Kimi Code
+
+Open `/plugins`, select `macaron` on the **Installed** tab, and press `Enter` to install the available update — then `/reload`.
 
 ## Feedback
 

--- a/mkx/README.md
+++ b/mkx/README.md
@@ -1,0 +1,15 @@
+# mkx
+
+Launcher for the **Macaron Kimi Code WebUI** (ChatGPT-style chat over the Kimi Code CLI).
+
+Self-contained — ships its own prebuilt server + web bundles, installs nothing from `mcc`. Run without installing:
+
+```bash
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi → http://localhost:7980
+# or
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>
+```
+
+Sessions are discovered from `~/.kimi-code/sessions/` (honors `KIMI_CODE_HOME`); provider settings persist to `~/.kimi-code/macaron-kimi-config.json`.
+
+Accepts `--host` / `--port`; run with `--help` for the full list.

--- a/mkx/bin/mkx.mjs
+++ b/mkx/bin/mkx.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// mkx — Macaron Kimi Code WebUI launcher. Boots the same server as mcc but serves
+// the kimi SPA (kimi.html) at `/` instead of the claude SPA. Shipped as its
+// own self-contained package (own server/dist + web/dist + deps) so
+// `npx mkx@…` installs only mkx — no mcc, no shared runtime.
+import { readFile } from 'node:fs/promises';
+
+const args = process.argv.slice(2);
+
+function printHelp() {
+  console.log(`Usage: mkx [options]
+
+  Start the Macaron Kimi Code WebUI (ChatGPT-style chat over the Kimi Code CLI).
+
+Options:
+  --host <host>     Bind address (default: 127.0.0.1)
+  --port <port>     Port (default: 7980 — offset from mcc's 7878 so both can run)
+  --version, -v     Print version and exit
+  --help, -h        Show this help
+
+Environment:
+  MACARON_KIMI_PATH    Path to kimi CLI binary (default: auto-detected)
+  MACARON_LOG_LEVEL    Log level (default: info)
+
+Configure the provider (base URL, API key, model, provider type) via the
+Settings page in the WebUI. Settings persist to
+~/.kimi-code/macaron-kimi-config.json.`);
+}
+
+async function printVersion() {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+  console.log(pkg.version);
+}
+
+const readValue = (i, flag) => {
+  const v = args[i + 1];
+  // Reject only a missing or flag-like next token; an empty value passes here
+  // (matching `--flag=`) and, for --port, is caught by the range check below.
+  if (v === undefined || v.startsWith('-')) throw new Error(`${flag} requires a value`);
+  return v;
+};
+
+try {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    const eq = a.indexOf('=');
+    const flag = eq === -1 ? a : a.slice(0, eq);
+    const inline = eq === -1 ? null : a.slice(eq + 1);
+    if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
+    if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
+    if (flag === '--host' || flag === '--port') {
+      process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(i, flag);
+      // Advance past the consumed value only for the space form (inline === null).
+      // `--flag=` (inline='') already has its value, so it must NOT skip the next arg.
+      if (inline === null) i++;
+      continue;
+    }
+    throw new Error(`Unknown option: ${a}`);
+  }
+
+  const port = process.env.MACARON_PORT;
+  if (port !== undefined && (!/^\d+$/.test(port) || +port < 1 || +port > 65535)) {
+    throw new Error(`Invalid port: ${port}`);
+  }
+} catch (e) {
+  console.error(`mkx: ${e.message}`);
+  process.exit(1);
+}
+
+// The one env flag that flips the SPA served at `/` from index.html to kimi.html.
+process.env.MACARON_ENGINE = 'kimi';
+// Kimi-side default port is 7980 (mcc uses 7878, mcx 7979) so all can run at once.
+process.env.MACARON_PORT ??= '7980';
+process.env.NODE_ENV ??= 'production';
+
+// Relative to this bin file → ../server/dist/index.js (ESM import() resolves
+// against import.meta.url, so it works regardless of the caller's cwd).
+await import('../server/dist/index.js');

--- a/mkx/package.json
+++ b/mkx/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "mkx",
+  "version": "0.1.0",
+  "description": "Macaron Kimi Code WebUI — ChatGPT-style chat over the Kimi Code CLI. Self-contained launcher, prebuilt server + web bundles.",
+  "type": "module",
+  "scripts": {
+    "prepack": "pnpm -w prepack && node scripts/stage.mjs"
+  },
+  "bin": {
+    "mkx": "./bin/mkx.mjs"
+  },
+  "files": [
+    "bin",
+    "server/dist/index.js",
+    "web/dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.196",
+    "@fastify/static": "^8.0.0",
+    "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@openai/codex-sdk": "^0.142.5",
+    "@unocss/autocomplete": "^66.7.5",
+    "@unocss/core": "^66.7.5",
+    "@unocss/preset-wind3": "^66.7.5",
+    "croner": "^10.0.1",
+    "fastify": "^5.2.0",
+    "ignore": "^7.0.5",
+    "node-pty": "^1.1.0",
+    "typescript": "^5.7.0",
+    "unocss-preset-animations": "^1.3.0",
+    "web-push": "^3.6.7",
+    "zod": "^4.4.3"
+  }
+}

--- a/mkx/scripts/stage.mjs
+++ b/mkx/scripts/stage.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Stage prebuilt bundles into this package so the published `mkx` tarball is
+// self-contained — no dependency on `mcc`. `prepack` builds the monorepo's
+// server + web once (at the repo root), then this copies the outputs into
+// mkx/server/dist + mkx/web/dist, mirroring what the `mcc` root package ships.
+// The launcher resolves `../server/dist/index.js` relative to bin/, so the
+// layout here must match mcc's: package root has server/dist and web/dist.
+import { cp, mkdir, rm } from 'node:fs/promises';
+
+const here = new URL('.', import.meta.url);            // mkx/scripts/
+const pkg = new URL('../', here);                       // mkx/
+const repo = new URL('../../', here);                   // repo root
+
+for (const path of ['server/dist/index.js', 'web/dist']) {
+  const dest = new URL(path, pkg);
+  await rm(dest, { recursive: true, force: true });
+  await mkdir(new URL('.', dest), { recursive: true });
+  await cp(new URL(path, repo), dest, { recursive: true });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
 
   server:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^1.2.1
+        version: 1.2.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.196
         version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
@@ -402,6 +405,11 @@ importers:
         version: 7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)
 
 packages:
+
+  '@agentclientprotocol/sdk@1.2.1':
+    resolution: {integrity: sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -2948,7 +2956,7 @@ packages:
     version: 0.0.1
 
   partial-tsx@https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47:
-    resolution: {integrity: sha512-10DVQtkhvVLLdsveOsdTti/uFpKoHyoifCougBmkwkCxbGCGnd5M6tmfSKQfOlaCtpEyaBzu+0AmkNY5XHgSBQ==, tarball: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47}
+    resolution: {tarball: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47}
     version: 0.0.1
 
   path-key@3.1.1:
@@ -3657,6 +3665,10 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@agentclientprotocol/sdk@1.2.1(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@antfu/install-pkg@1.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,57 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  mkx:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.196
+        version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@fastify/static':
+        specifier: ^8.0.0
+        version: 8.3.0
+      '@genui/diagnostics':
+        specifier: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8
+        version: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8(@unocss/autocomplete@66.7.5)(@unocss/core@66.7.5)(typescript@5.9.3)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@openai/codex-sdk':
+        specifier: ^0.142.5
+        version: 0.142.5
+      '@unocss/autocomplete':
+        specifier: ^66.7.5
+        version: 66.7.5
+      '@unocss/core':
+        specifier: ^66.7.5
+        version: 66.7.5
+      '@unocss/preset-wind3':
+        specifier: ^66.7.5
+        version: 66.7.5
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
+      fastify:
+        specifier: ^5.2.0
+        version: 5.10.0
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      unocss-preset-animations:
+        specifier: ^1.3.0
+        version: 1.3.0(@unocss/preset-wind3@66.7.5)(unocss@66.7.5(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)))
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   server:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
@@ -2897,7 +2948,7 @@ packages:
     version: 0.0.1
 
   partial-tsx@https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47:
-    resolution: {tarball: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47}
+    resolution: {integrity: sha512-10DVQtkhvVLLdsveOsdTti/uFpKoHyoifCougBmkwkCxbGCGnd5M6tmfSKQfOlaCtpEyaBzu+0AmkNY5XHgSBQ==, tarball: https://pkg.pr.new/MindLab-Research/macaron-genui-demo/partial-tsx@2c005567d2f7b564eae1bc40d1d7a10ab23a1b47}
     version: 0.0.1
 
   path-key@3.1.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'server'
   - 'web'
   - 'mcx'
+  - 'mkx'
 # partial-tsx is a URL subdep of partial-react (our own pkg.pr.new package), already pinned in the lockfile and trusted.
 # pnpm 10.26+ defaults blockExoticSubdeps=true, which blocks URL subdeps; allow it explicitly here.
 blockExoticSubdeps: false

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "test": "node --import tsx --test \"src/**/*.test.ts\" \"test/*.test.ts\""
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@fastify/static": "^8.0.0",
     "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -34,6 +34,10 @@ export const CLAUDE_AGENTS = path.join(HOME, '.claude', 'agents');
 // invoked as `/<filename-stem>` in any session.
 export const CLAUDE_COMMANDS = path.join(HOME, '.claude', 'commands');
 export const CODEX_SESSIONS = path.join(HOME, '.codex', 'sessions');
+// Kimi Code data root ($KIMI_CODE_HOME or ~/.kimi-code). Sessions live in
+// sessions/<workDirKey>/<sessionId>/ with a session_index.jsonl fast path.
+export const KIMI_HOME = process.env.KIMI_CODE_HOME || path.join(HOME, '.kimi-code');
+export const KIMI_SESSIONS = path.join(KIMI_HOME, 'sessions');
 
 // Root for the "New Project" wizard — freshly created dirs and `git clone`
 // targets land here. Overridable so ops can point it at a mounted volume.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,7 @@ import { warmWorktreeCache } from './lib/worktree-store.js';
 import { warmPermissionRulesCache } from './lib/permission-rules.js';
 import { warmShareCache } from './lib/share-store.js';
 import { warmCodexConfigCache } from './lib/codex-config.js';
+import { warmKimiConfigCache } from './lib/kimi-config.js';
 import { warmLabelsCache } from './lib/label-store.js';
 import { warmSchedulesCache } from './lib/schedule-store.js';
 import { startScheduler } from './lib/scheduler.js';
@@ -34,6 +35,7 @@ import { registerMcpRoutes } from './routes/mcp.js';
 import { registerConfigFileRoutes } from './routes/config-files.js';
 import { registerRelayRoutes } from './routes/relay.js';
 import { registerCodexRoutes } from './routes/codex.js';
+import { registerKimiRoutes } from './routes/kimi.js';
 import { registerGitRoutes } from './routes/git.js';
 import { registerShareRoutes } from './routes/share.js';
 import { registerSearchRoutes } from './routes/search.js';
@@ -129,6 +131,7 @@ await app.register(async (instance) => {
   await registerSessionRoutes(instance);
   await registerWorktreeRoutes(instance);
   await registerCodexRoutes(instance);
+  await registerKimiRoutes(instance);
   await registerGitRoutes(instance);
   await registerShareRoutes(instance);
   await registerSearchRoutes(instance);
@@ -148,12 +151,15 @@ if (existsSync(WEB_DIST)) {
     // MACARON_ENGINE=codex can steer `/` to codex.html instead.
     index: false,
   });
-  // Two SPA entries live side-by-side in web/dist: index.html (claude) and
-  // codex.html. The env decides which one is the SPA fallback for `/` and
-  // any deep-link URL, so `mcc` boots the claude UI and `mcx` boots codex
-  // from the same server binary. Static assets (JS/CSS/wasm chunks) come
-  // from the shared /assets/ folder and are shared between entries.
-  const spaEntry = process.env.MACARON_ENGINE === 'codex' ? 'codex.html' : 'index.html';
+  // Three SPA entries live side-by-side in web/dist: index.html (claude),
+  // codex.html and kimi.html. The env decides which one is the SPA fallback
+  // for `/` and any deep-link URL, so `mcc` boots the claude UI, `mcx` boots
+  // codex and `mkx` boots kimi from the same server binary. Static assets
+  // (JS/CSS/wasm chunks) come from the shared /assets/ folder and are shared
+  // between entries.
+  const spaEntry =
+    process.env.MACARON_ENGINE === 'kimi' ? 'kimi.html' :
+    process.env.MACARON_ENGINE === 'codex' ? 'codex.html' : 'index.html';
   // Explicit root — fastify-static's `index: false` refuses `/`, so own it here.
   app.get('/', (_req, reply) => reply.sendFile(spaEntry));
   app.setNotFoundHandler((req, reply) => {
@@ -175,6 +181,7 @@ try {
   await warmWorktreeCache();
   await warmPermissionRulesCache();
   await warmCodexConfigCache();
+  await warmKimiConfigCache();
   await warmLabelsCache();
   await warmSchedulesCache();
   await warmCodexTitlesCache();

--- a/server/src/lib/codex-runner.ts
+++ b/server/src/lib/codex-runner.ts
@@ -23,7 +23,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
@@ -38,44 +37,11 @@ import type {
 import { getActiveCodexProvider, getCodexConfig, type CodexRuntimeOverride } from './codex-config.js';
 import type { RunnerEvent, AttachedImage } from './claude-runner.js';
 
-// Absolute path + command for the standalone stdio MCP server that exposes
-// render_ui to the codex CLI (see server/src/macaron-mcp-stdio.ts).
-// Resolved relative to THIS file so the same lookup works whether the
-// server is running from src/ (tsx dev) or dist/ (built).
-//
-// Production: `server/dist/lib/codex-runner.js` → sibling
-//   `server/dist/macaron-mcp-stdio.js` → spawn `node <path>`.
-// Dev: `server/src/lib/codex-runner.ts` → sibling
-//   `server/src/macaron-mcp-stdio.ts` → spawn `tsx <path>` (via
-//   node_modules/.bin/tsx so we don't need a global tsx).
-const { command: MACARON_MCP_CMD, args: MACARON_MCP_ARGS } = (() => {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const jsPath = path.join(here, '..', 'macaron-mcp-stdio.js');
-  if (existsSync(jsPath)) {
-    return { command: 'node', args: [jsPath] };
-  }
-  const tsPath = path.join(here, '..', 'macaron-mcp-stdio.ts');
-  // Walk up until we find a runnable tsx binary. Under pnpm, dev bins
-  // are NOT hoisted to `<repo>/node_modules/.bin/`; they live under
-  // `<repo>/node_modules/.pnpm/node_modules/.bin/`. Also check the
-  // classic hoisted path for npm/yarn / server workspace bin.
-  let dir = here;
-  for (let i = 0; i < 6; i++) {
-    for (const rel of [
-      ['node_modules', '.bin', 'tsx'],
-      ['node_modules', '.pnpm', 'node_modules', '.bin', 'tsx'],
-    ]) {
-      const candidate = path.join(dir, ...rel);
-      if (existsSync(candidate)) return { command: candidate, args: [tsPath] };
-    }
-    dir = path.dirname(dir);
-  }
-  // Last resort: hope `tsx` is on PATH.
-  return { command: 'tsx', args: [tsPath] };
-})();
-
+// The Macaron stdio MCP path resolution now lives in macaron-mcp-path.ts so
+// kimi-runner can inject the same bridge without pulling in the codex SDK.
 // Re-exported for the app-server runner (codex-app-server.ts), which injects
 // the same Macaron stdio MCP into its thread/start config.
+import { MACARON_MCP_CMD, MACARON_MCP_ARGS } from './macaron-mcp-path.js';
 export { MACARON_MCP_CMD, MACARON_MCP_ARGS };
 
 // @openai/codex-sdk ships the `codex` binary via platform-specific optional

--- a/server/src/lib/genui-check.ts
+++ b/server/src/lib/genui-check.ts
@@ -49,16 +49,16 @@ const compilerOptions: ts.CompilerOptions = {
 // $macaron/chat is a runtime shim (.mjs, no .tsx source to map via FACADE_PATHS), so declare
 // its types ambiently — user TSX importing sendUserMessage gets real signature checking
 // instead of a TS2307.
+// NOTE: this file must stay a SCRIPT (no top-level import/export) — inside a module file
+// `declare module "x"` becomes an augmentation of an existing module instead of creating
+// one, and the TS2307 comes back. The runtime shim also installs sendUserMessage on
+// window, so a top-level (script-scoped) `interface Window` merge covers TSX that writes
+// `window.sendUserMessage(...)` instead of the preferred import — no `declare global`
+// wrapper (which would require module-ifying the file) needed.
 const AMBIENT_DECLARATIONS =
   `declare module "https://*";\ndeclare module "http://*";\n` +
   `declare module "$macaron/chat" {\n  export function sendUserMessage(prompt: string): void;\n}\n` +
-  // The runtime shim also installs sendUserMessage on window, so TSX that
-  // writes `window.sendUserMessage(...)` (instead of the preferred import)
-  // still runs fine in the browser. Declare it on Window so the type
-  // checker doesn't flag it — the import remains the recommended pattern
-  // (see macaron-render-tool.ts guidance), but "works but noisy" is worse
-  // than silent-and-consistent.
-  `declare global {\n  interface Window {\n    sendUserMessage(prompt: string): void;\n  }\n}\nexport {};\n`;
+  `interface Window {\n  sendUserMessage(prompt: string): void;\n}\n`;
 
 const toDiag = (d: ts.Diagnostic): GenUIDiagnostic => {
   const message = diagnosticMessage(ts, d);

--- a/server/src/lib/kimi-config.ts
+++ b/server/src/lib/kimi-config.ts
@@ -1,0 +1,227 @@
+// Persistent Kimi-runner config, held in ~/.kimi-code/macaron-kimi-config.json
+// (honors $KIMI_CODE_HOME).
+//
+// Data model mirrors the Codex side: a `system` built-in that passes through
+// to the user's ambient Kimi Code login (OAuth "system" provider — no env
+// overrides), plus an arbitrary list of custom providers synthesized at spawn
+// time via the KIMI_MODEL_* env family (KIMI_MODEL_NAME / _API_KEY /
+// _BASE_URL / _PROVIDER_TYPE) so the user's own ~/.kimi-code/config.toml is
+// never rewritten. One is active.
+//
+// Cache is warmed at startup so getKimiConfig() is synchronous for the
+// runner's hot path.
+
+import { promises as fs } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { KIMI_HOME } from '../config.js';
+
+export const KIMI_SYSTEM_PROVIDER_ID = 'system';
+
+export type KimiProviderType = 'kimi' | 'anthropic' | 'openai';
+
+/** Provider-level config — auth + which endpoint to hit. */
+export type KimiCustomProvider = {
+  id: string;
+  /** Human-facing name for the WebUI's ProviderPicker. */
+  name: string;
+  /** Model id sent to the endpoint (KIMI_MODEL_NAME — also the enable switch). */
+  model: string;
+  /** Endpoint root (KIMI_MODEL_BASE_URL). */
+  baseUrl: string;
+  /** Bearer token for the endpoint (KIMI_MODEL_API_KEY). */
+  apiKey: string;
+  /** Wire protocol the endpoint speaks (KIMI_MODEL_PROVIDER_TYPE). */
+  providerType: KimiProviderType;
+};
+
+export type KimiSettings = {
+  activeProviderId: string;
+  customProviders: KimiCustomProvider[];
+};
+
+const CONFIG_PATH = path.join(KIMI_HOME, 'macaron-kimi-config.json');
+
+function seededCustomProvider(): KimiCustomProvider {
+  return {
+    id: randomUUID(),
+    name: 'Macaron',
+    model: 'macaron-0.6',
+    baseUrl: 'https://pi-api-cn.macaron.xin',
+    apiKey: process.env.MACARON_KIMI_API_KEY || '',
+    providerType: 'anthropic',
+  };
+}
+
+function defaults(): KimiSettings {
+  return {
+    // Default = system so a fresh install works with the user's existing
+    // kimi CLI login without them touching Settings.
+    activeProviderId: KIMI_SYSTEM_PROVIDER_ID,
+    customProviders: [seededCustomProvider()],
+  };
+}
+
+function sanitize(p: KimiCustomProvider): KimiCustomProvider {
+  const providerType: KimiProviderType = p.providerType === 'anthropic' || p.providerType === 'openai' ? p.providerType : 'kimi';
+  return {
+    id: String(p.id || randomUUID()),
+    name: String(p.name || 'Unnamed provider').trim(),
+    model: String(p.model || '').trim(),
+    baseUrl: String(p.baseUrl || '').trim(),
+    apiKey: String(p.apiKey || ''),
+    providerType,
+  };
+}
+
+let cache: KimiSettings | null = null;
+
+async function loadFromDisk(): Promise<KimiSettings> {
+  try {
+    const raw = await fs.readFile(CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<KimiSettings>;
+    if (parsed && Array.isArray(parsed.customProviders)) {
+      return {
+        activeProviderId: parsed.activeProviderId || KIMI_SYSTEM_PROVIDER_ID,
+        customProviders: parsed.customProviders.map(sanitize),
+      };
+    }
+    return defaults();
+  } catch {
+    return defaults();
+  }
+}
+
+async function persist(): Promise<void> {
+  if (!cache) return;
+  await fs.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
+  await fs.writeFile(CONFIG_PATH, JSON.stringify(cache, null, 2), 'utf8');
+}
+
+export async function warmKimiConfigCache(): Promise<void> {
+  cache = await loadFromDisk();
+  await persist();
+}
+
+export function getKimiConfig(): KimiSettings {
+  return cache ?? defaults();
+}
+
+/** Active provider or null when the built-in `system` is selected. */
+export function getActiveKimiProvider(): KimiCustomProvider | null {
+  const s = cache ?? defaults();
+  if (s.activeProviderId === KIMI_SYSTEM_PROVIDER_ID) return null;
+  return s.customProviders.find((p) => p.id === s.activeProviderId) ?? null;
+}
+
+// Env for a spawned kimi process. A custom provider maps onto the
+// KIMI_MODEL_* family (KIMI_MODEL_NAME doubles as the enable switch); the
+// `system` builtin means ambient OAuth login, so no overrides at all.
+export function getActiveKimiProviderEnv(): Record<string, string> {
+  const p = getActiveKimiProvider();
+  if (!p || !p.model) return {};
+  const env: Record<string, string> = {
+    KIMI_MODEL_NAME: p.model,
+    KIMI_MODEL_PROVIDER_TYPE: p.providerType,
+  };
+  if (p.baseUrl) env.KIMI_MODEL_BASE_URL = p.baseUrl;
+  if (p.apiKey) env.KIMI_MODEL_API_KEY = p.apiKey;
+  return env;
+}
+
+export async function setActiveKimiProvider(id: string): Promise<KimiSettings> {
+  if (!cache) cache = await loadFromDisk();
+  const isSystem = id === KIMI_SYSTEM_PROVIDER_ID;
+  const known = isSystem || cache.customProviders.some((p) => p.id === id);
+  if (!known) throw new Error(`unknown providerId: ${id}`);
+  cache.activeProviderId = id;
+  await persist();
+  return cache;
+}
+
+export async function createKimiProvider(
+  patch: Partial<KimiCustomProvider>,
+): Promise<KimiCustomProvider> {
+  if (!cache) cache = await loadFromDisk();
+  const seed = seededCustomProvider();
+  const created = sanitize({ ...seed, ...patch, id: randomUUID() });
+  cache.customProviders.push(created);
+  await persist();
+  return created;
+}
+
+export async function updateKimiProvider(
+  id: string,
+  patch: Partial<KimiCustomProvider>,
+): Promise<KimiCustomProvider> {
+  if (!cache) cache = await loadFromDisk();
+  const idx = cache.customProviders.findIndex((p) => p.id === id);
+  if (idx < 0) throw new Error(`unknown providerId: ${id}`);
+  const next = sanitize({ ...cache.customProviders[idx]!, ...patch, id });
+  cache.customProviders[idx] = next;
+  await persist();
+  return next;
+}
+
+export async function deleteKimiProvider(id: string): Promise<KimiSettings> {
+  if (!cache) cache = await loadFromDisk();
+  cache.customProviders = cache.customProviders.filter((p) => p.id !== id);
+  if (cache.activeProviderId === id) cache.activeProviderId = KIMI_SYSTEM_PROVIDER_ID;
+  await persist();
+  return cache;
+}
+
+// Public projection for the WebUI. Never surfaces raw apiKey.
+export type PublicKimiProvider = Omit<KimiCustomProvider, 'apiKey'> & {
+  configured: boolean;
+};
+
+export type PublicKimiBuiltin = {
+  id: 'system';
+  name: string;
+  description: string;
+  /** Best-effort sniff of ~/.kimi-code/config.toml so the UI can show what
+   * "system default" points at. null = file missing/unparseable. */
+  detectedModel: string | null;
+};
+
+export type PublicKimiSettings = {
+  activeProviderId: string;
+  builtins: PublicKimiBuiltin[];
+  customProviders: PublicKimiProvider[];
+};
+
+async function detectSystemKimi(): Promise<{ model: string | null }> {
+  try {
+    const raw = await fs.readFile(path.join(KIMI_HOME, 'config.toml'), 'utf8');
+    // Cheap TOML sniff — we only want the default model for the info banner,
+    // so a full TOML parser is overkill.
+    const model = /^\s*default_model\s*=\s*"([^"]+)"/m.exec(raw)?.[1] ?? null;
+    return { model };
+  } catch {
+    return { model: null };
+  }
+}
+
+export async function readPublicKimiSettings(): Promise<PublicKimiSettings> {
+  const s = cache ?? defaults();
+  const sniff = await detectSystemKimi();
+  return {
+    activeProviderId: s.activeProviderId,
+    builtins: [
+      {
+        id: KIMI_SYSTEM_PROVIDER_ID,
+        name: 'System default',
+        description: sniff.model
+          ? `Uses your ambient Kimi Code login unchanged — default model ${sniff.model}.`
+          : 'Uses your ambient Kimi Code login as-is (or kimi’s built-in defaults if none).',
+        detectedModel: sniff.model,
+      },
+    ],
+    customProviders: s.customProviders.map((p) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { apiKey: _apiKey, ...rest } = p;
+      return { ...rest, configured: Boolean(p.apiKey) };
+    }),
+  };
+}

--- a/server/src/lib/kimi-runner.ts
+++ b/server/src/lib/kimi-runner.ts
@@ -1,29 +1,36 @@
-// Spawns the Kimi Code CLI (`kimi -p <prompt> --output-format stream-json`)
-// and translates its stdout JSONL into the same RunnerEvent stream shape as
-// claude-runner.ts / codex-runner.ts, so the SSE handlers and client store
-// don't need to know which engine produced the events.
+// Drives the Kimi Code CLI in ACP mode (`kimi acp` — Agent Client Protocol,
+// JSON-RPC over stdio) and translates its session/update notifications into
+// the same RunnerEvent stream shape as claude-runner.ts / codex-runner.ts, so
+// the SSE handlers and client store don't need to know which engine produced
+// the events.
 //
-// stream-json line shapes (one JSON per line):
-//   {"role":"assistant","content":"..."}                                   → delta
-//   {"role":"assistant","tool_calls":[{"id","function":{name,arguments}}]} → tool_use
-//   {"role":"tool","tool_call_id":"...","content":"..."}                   → tool_result
-//   {"role":"meta","type":"session.resume_hint","session_id":"session_…"}  → session
+// Why ACP instead of the old `kimi -p … --output-format stream-json`: ACP's
+// session/new (and session/load) accept an `mcpServers` list, which lets us
+// inject the Macaron stdio MCP bridge (render_ui) exactly like codex does.
+// The bridge tool surfaces on the wire as a tool_call whose `title` is the
+// fully-qualified `mcp__macaron__render_ui` — the same string KimiChat.tsx
+// matches to render inline GenUI.
 //
-// The meta line only arrives at stream end, so for NEW sessions we detect
-// the sid early by snapshotting the session tree before spawn and polling
-// for the new dir whose state.json workDir matches ours (kimi creates it
-// within a few hundred ms). The meta line stays as fallback.
+// Session lifecycle per turn (a fresh `kimi acp` process each call):
+//   initialize → session/new (new) | session/load (resume) → session/prompt.
+// session/load replays the prior conversation as session/update notifications
+// before returning; we gate those out so only post-prompt output reaches the
+// stream. The sessionId is known synchronously (new returns it; resume already
+// has it), so no snapshot-poll is needed.
 //
-// stream-json carries no token usage; after the process closes we sum the
-// final turn's step.end usage from the session's wire.jsonl (best effort —
-// skipped entirely when the wire can't be read).
+// ACP carries no per-turn token usage, so after the turn we sum the final
+// turn's step.end usage from the session's wire.jsonl (best effort).
 
 import { execSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
+import { Readable, Writable } from 'node:stream';
 import path from 'node:path';
+import { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } from '@agentclientprotocol/sdk';
+import type { Client, ReadTextFileRequest, ReadTextFileResponse, RequestPermissionRequest, RequestPermissionResponse, SessionNotification, WriteTextFileRequest, ContentBlock, McpServerStdio } from '@agentclientprotocol/sdk';
 import { getActiveKimiProviderEnv } from './kimi-config.js';
-import { findKimiSessionDir, findNewKimiSession, snapshotKimiSessionIds } from './kimi-store.js';
+import { findKimiSessionDir } from './kimi-store.js';
+import { MACARON_MCP_CMD, MACARON_MCP_ARGS } from './macaron-mcp-path.js';
 import type { RunnerEvent, AttachedImage } from './claude-runner.js';
 
 // Resolution order: explicit env override, common global install paths, then
@@ -52,10 +59,28 @@ export type KimiRunOptions = {
   images?: AttachedImage[];
 };
 
-// Sum the output tokens of the LAST turn recorded in the session's
-// wire.jsonl. step.end carries per-step usage keyed by turnId; the current
-// turn is the highest turnId in the file. Returns null on any failure —
-// usage is nice-to-have and must never break the stream.
+// The Macaron stdio MCP bridge, shared with codex-runner (render_ui lives here).
+const MACARON_MCP: McpServerStdio = { name: 'macaron', command: MACARON_MCP_CMD, args: MACARON_MCP_ARGS, env: [] };
+
+function buildPromptBlocks(text: string, images: AttachedImage[]): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  if (text) blocks.push({ type: 'text', text });
+  for (const img of images) {
+    const m = /^data:([^;]+);base64,(.*)$/.exec(img.dataUrl);
+    const mimeType = m?.[1] || img.mimeType || 'image/png';
+    const data = m?.[2] ?? img.dataUrl;
+    blocks.push({ type: 'image', mimeType, data });
+  }
+  // ACP requires at least one block; an image-only turn still needs text to be
+  // absent-safe on agents that assume it, so fall back to an empty text block.
+  if (blocks.length === 0) blocks.push({ type: 'text', text: '' });
+  return blocks;
+}
+
+// Sum the output tokens of the LAST turn recorded in the session's wire.jsonl.
+// step.end carries per-step usage keyed by turnId; the current turn is the
+// highest turnId in the file. Returns null on any failure — usage is
+// nice-to-have and must never break the stream.
 async function readLastTurnOutputTokens(sessionDir: string): Promise<number | null> {
   try {
     const wp = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
@@ -119,147 +144,140 @@ export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent
       finish();
       return;
     }
-    let sessionEmitted = false;
-    let pollTimer: ReturnType<typeof setInterval> | null = null;
-    const stopPoll = () => { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } };
-    try {
-      const args = ['-p', opts.prompt, '--output-format', 'stream-json'];
-      // Emit the session id as soon as we can. A resume already knows it; a
-      // new session learns it via the snapshot-diff poll / meta line below.
-      if (opts.resume) {
-        args.push('-r', opts.resume);
-        sessionEmitted = true;
-        push({ kind: 'session', sessionId: opts.resume });
-      }
-      const providerEnv = getActiveKimiProviderEnv();
-      console.log(
-        `[kimi-runner] starting  model=${providerEnv.KIMI_MODEL_NAME || '(system)'}  base=${providerEnv.KIMI_MODEL_BASE_URL || '(ambient)'}  resume=${opts.resume ? opts.resume.slice(0, 8) : '(new)'}  cwd=${opts.cwd}`,
-      );
 
-      // Snapshot BEFORE spawning so any session dir appearing afterwards is
-      // ours (matched on state.json workDir to rule out concurrent runs).
-      const before = opts.resume ? null : await snapshotKimiSessionIds();
-      const child = spawn(KIMI_BINARY, args, {
-        cwd: opts.cwd,
-        env: { ...process.env, ...providerEnv },
-        stdio: ['ignore', 'pipe', 'pipe'],
+    const providerEnv = getActiveKimiProviderEnv();
+    console.log(
+      `[kimi-runner] starting  model=${providerEnv.KIMI_MODEL_NAME || '(system)'}  base=${providerEnv.KIMI_MODEL_BASE_URL || '(ambient)'}  resume=${opts.resume ? opts.resume.slice(0, 8) : '(new)'}  cwd=${opts.cwd}`,
+    );
+    const child = spawn(KIMI_BINARY, ['acp'], {
+      cwd: opts.cwd,
+      env: { ...process.env, ...providerEnv },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stderrTail = '';
+    child.stderr.on('data', (chunk: Buffer) => { stderrTail = (stderrTail + chunk.toString('utf8')).slice(-8192); });
+
+    // While session/load replays the prior conversation, swallow its
+    // notifications — only output produced after our prompt should stream.
+    let replaying = false;
+    // Per tool call: remember its title (mcp__macaron__render_ui …) and whether
+    // we've already emitted a `tool_use` (once rawInput is available).
+    const toolTitle = new Map<string, string>();
+    const toolUseEmitted = new Set<string>();
+
+    const emitToolUseIfReady = (id: string, title: string | undefined, rawInput: unknown) => {
+      if (title) toolTitle.set(id, title);
+      if (rawInput == null || toolUseEmitted.has(id)) return;
+      toolUseEmitted.add(id);
+      push({ kind: 'tool_use', id, name: toolTitle.get(id) || 'tool', input: rawInput });
+    };
+
+    const clientImpl: Client = {
+      async sessionUpdate(params: SessionNotification): Promise<void> {
+        if (replaying) return;
+        const u = params.update;
+        switch (u.sessionUpdate) {
+          case 'agent_message_chunk': {
+            if (u.content.type === 'text' && u.content.text) push({ kind: 'delta', text: u.content.text });
+            break;
+          }
+          case 'tool_call': {
+            emitToolUseIfReady(u.toolCallId, u.title, (u as { rawInput?: unknown }).rawInput);
+            break;
+          }
+          case 'tool_call_update': {
+            const id = u.toolCallId;
+            emitToolUseIfReady(id, u.title ?? undefined, (u as { rawInput?: unknown }).rawInput);
+            if (u.status === 'completed' || u.status === 'failed') {
+              const raw = (u as { rawOutput?: unknown }).rawOutput;
+              let text = typeof raw === 'string' ? raw : raw != null ? JSON.stringify(raw) : '';
+              if (!text && Array.isArray(u.content)) {
+                text = u.content
+                  .map((c) => (c.type === 'content' && c.content.type === 'text' ? c.content.text : ''))
+                  .filter(Boolean)
+                  .join('');
+              }
+              push({ kind: 'tool_result', tool_use_id: id, text: text.slice(0, 8000), isError: u.status === 'failed' });
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      },
+      async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+        // Auto-approve — Macaron runs the agent with the user's own trust
+        // boundary, same as the codex/claude runners' approvalPolicy: never.
+        const opts2 = params.options;
+        const pick = opts2.find((o) => o.kind === 'allow_once') || opts2.find((o) => o.kind === 'allow_always') || opts2[0];
+        if (!pick) return { outcome: { outcome: 'cancelled' } };
+        return { outcome: { outcome: 'selected', optionId: pick.optionId } };
+      },
+      async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
+        let content = await fs.readFile(params.path, 'utf8');
+        if (params.line != null || params.limit != null) {
+          const lines = content.split('\n');
+          const start = Math.max(0, (params.line ?? 1) - 1);
+          content = lines.slice(start, params.limit != null ? start + params.limit : undefined).join('\n');
+        }
+        return { content };
+      },
+      async writeTextFile(params: WriteTextFileRequest): Promise<void> {
+        await fs.mkdir(path.dirname(params.path), { recursive: true });
+        await fs.writeFile(params.path, params.content, 'utf8');
+      },
+    };
+
+    const stream = ndJsonStream(
+      Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+    );
+    const conn = new ClientSideConnection(() => clientImpl, stream);
+
+    let capturedSid = '';
+    const onAbort = () => {
+      if (capturedSid) void conn.cancel({ sessionId: capturedSid }).catch(() => {});
+      child.kill('SIGTERM');
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, 3000).unref();
+    };
+
+    try {
+      await conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
       });
 
-      if (before) {
-        pollTimer = setInterval(() => {
-          void findNewKimiSession(before, opts.cwd).then((hit) => {
-            if (!hit || sessionEmitted) return;
-            sessionEmitted = true;
-            stopPoll();
-            push({ kind: 'session', sessionId: hit.sessionId });
-          }).catch(() => {});
-        }, 200);
-        pollTimer.unref();
+      if (opts.resume) {
+        capturedSid = opts.resume;
+        replaying = true;
+        await conn.loadSession({ sessionId: opts.resume, cwd: opts.cwd, mcpServers: [MACARON_MCP] });
+        replaying = false;
+        push({ kind: 'session', sessionId: capturedSid });
+      } else {
+        const res = await conn.newSession({ cwd: opts.cwd, mcpServers: [MACARON_MCP] });
+        capturedSid = res.sessionId;
+        push({ kind: 'session', sessionId: capturedSid });
       }
 
-      const onAbort = () => {
-        child.kill('SIGTERM');
-        // A hung child shouldn't pin the turn forever — escalate.
-        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, 3000).unref();
-      };
       if (opts.abortController?.signal.aborted) onAbort();
       else opts.abortController?.signal.addEventListener('abort', onAbort, { once: true });
 
-      let stderrTail = '';
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderrTail = (stderrTail + chunk.toString('utf8')).slice(-8192);
-      });
+      const result = await conn.prompt({ sessionId: capturedSid, prompt: buildPromptBlocks(opts.prompt, opts.images || []) });
+      const aborted = Boolean(opts.abortController?.signal.aborted) || result.stopReason === 'cancelled';
 
-      let capturedSid = opts.resume || '';
-      let syntheticId = 0;
-      let buf = '';
-      child.stdout.on('data', (chunk: Buffer) => {
-        buf += chunk.toString('utf8');
-        const lines = buf.split('\n');
-        buf = lines.pop() || '';
-        for (const line of lines) {
-          const t = line.trim();
-          if (!t) continue;
-          let o: {
-            role?: string;
-            type?: string;
-            content?: unknown;
-            tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: unknown } }>;
-            tool_call_id?: string;
-            is_error?: boolean;
-            session_id?: string;
-          };
-          try { o = JSON.parse(t); } catch { continue; }
-
-          if (o.role === 'meta') {
-            // Final line of every stream — the authoritative sid for NEW
-            // sessions when the snapshot-diff poll hasn't fired yet.
-            if (o.session_id && !sessionEmitted) {
-              sessionEmitted = true;
-              capturedSid = o.session_id;
-              stopPoll();
-              push({ kind: 'session', sessionId: o.session_id });
-            } else if (o.session_id) {
-              capturedSid = o.session_id;
-            }
-            continue;
-          }
-
-          if (o.role === 'assistant') {
-            if (typeof o.content === 'string' && o.content) {
-              push({ kind: 'delta', text: o.content });
-            } else if (Array.isArray(o.content)) {
-              const text = o.content
-                .map((p) => (p && typeof p === 'object' && (p as { type?: string }).type === 'text' ? String((p as { text?: string }).text || '') : ''))
-                .filter(Boolean)
-                .join('');
-              if (text) push({ kind: 'delta', text });
-            }
-            for (const call of o.tool_calls || []) {
-              const fn = call.function || {};
-              let input: unknown = fn.arguments;
-              if (typeof input === 'string') {
-                try { input = JSON.parse(input); } catch { /* keep as string */ }
-              }
-              push({ kind: 'tool_use', id: String(call.id || `kimi-${syntheticId++}`), name: String(fn.name || 'tool'), input: input ?? {} });
-            }
-            continue;
-          }
-
-          if (o.role === 'tool') {
-            const text = typeof o.content === 'string' ? o.content : JSON.stringify(o.content ?? '');
-            push({ kind: 'tool_result', tool_use_id: String(o.tool_call_id || ''), text: text.slice(0, 8000), isError: Boolean(o.is_error) });
-            continue;
-          }
-        }
-      });
-
-      const exitCode: number = await new Promise((resolve) => {
-        child.on('error', () => resolve(-1));
-        child.on('close', (code) => resolve(code ?? -1));
-      });
-      stopPoll();
-
-      const aborted = Boolean(opts.abortController?.signal.aborted);
-      if (exitCode === 0 || aborted) {
-        // Live usage meter: stream-json has none, so sum the final turn's
-        // step.end usage off the wire.jsonl the CLI just flushed.
-        if (!aborted && capturedSid) {
-          const dir = await findKimiSessionDir(capturedSid);
-          const outputTokens = dir ? await readLastTurnOutputTokens(dir) : null;
-          if (outputTokens !== null) push({ kind: 'usage', outputTokens });
-        }
-        push({ kind: 'done', exitCode: aborted ? -1 : 0 });
-      } else {
-        const detail = stderrTail.trim().split('\n').slice(-3).join('\n').trim();
-        push({ kind: 'error', error: detail || `kimi exited with code ${exitCode}` });
-        push({ kind: 'done', exitCode });
+      if (!aborted && capturedSid) {
+        const dir = await findKimiSessionDir(capturedSid);
+        const outputTokens = dir ? await readLastTurnOutputTokens(dir) : null;
+        if (outputTokens !== null) push({ kind: 'usage', outputTokens });
       }
+      push({ kind: 'done', exitCode: aborted ? -1 : 0 });
     } catch (err) {
-      push({ kind: 'error', error: (err as Error).message });
+      const detail = stderrTail.trim().split('\n').slice(-3).join('\n').trim();
+      push({ kind: 'error', error: (err as Error).message || detail || 'kimi acp failed' });
       push({ kind: 'done', exitCode: -1 });
     } finally {
-      stopPoll();
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
       finish();
     }
   })();

--- a/server/src/lib/kimi-runner.ts
+++ b/server/src/lib/kimi-runner.ts
@@ -1,0 +1,272 @@
+// Spawns the Kimi Code CLI (`kimi -p <prompt> --output-format stream-json`)
+// and translates its stdout JSONL into the same RunnerEvent stream shape as
+// claude-runner.ts / codex-runner.ts, so the SSE handlers and client store
+// don't need to know which engine produced the events.
+//
+// stream-json line shapes (one JSON per line):
+//   {"role":"assistant","content":"..."}                                   → delta
+//   {"role":"assistant","tool_calls":[{"id","function":{name,arguments}}]} → tool_use
+//   {"role":"tool","tool_call_id":"...","content":"..."}                   → tool_result
+//   {"role":"meta","type":"session.resume_hint","session_id":"session_…"}  → session
+//
+// The meta line only arrives at stream end, so for NEW sessions we detect
+// the sid early by snapshotting the session tree before spawn and polling
+// for the new dir whose state.json workDir matches ours (kimi creates it
+// within a few hundred ms). The meta line stays as fallback.
+//
+// stream-json carries no token usage; after the process closes we sum the
+// final turn's step.end usage from the session's wire.jsonl (best effort —
+// skipped entirely when the wire can't be read).
+
+import { execSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getActiveKimiProviderEnv } from './kimi-config.js';
+import { findKimiSessionDir, findNewKimiSession, snapshotKimiSessionIds } from './kimi-store.js';
+import type { RunnerEvent, AttachedImage } from './claude-runner.js';
+
+// Resolution order: explicit env override, common global install paths, then
+// `which kimi`. No bundled fallback — the kimi CLI has no SDK vendor copy.
+function detectKimiBinary(): string | undefined {
+  if (process.env.MACARON_KIMI_PATH && existsSync(process.env.MACARON_KIMI_PATH)) {
+    return process.env.MACARON_KIMI_PATH;
+  }
+  for (const p of ['/opt/homebrew/bin/kimi', '/usr/local/bin/kimi', '/usr/bin/kimi']) {
+    if (existsSync(p)) return p;
+  }
+  try {
+    const which = execSync('which kimi', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    if (which) return which;
+  } catch { /* not on PATH */ }
+  return undefined;
+}
+export const KIMI_BINARY = detectKimiBinary();
+
+export type KimiRunOptions = {
+  prompt: string;
+  cwd: string;
+  /** Resume an existing sessionId. Omit for a new session. */
+  resume?: string;
+  abortController?: AbortController;
+  images?: AttachedImage[];
+};
+
+// Sum the output tokens of the LAST turn recorded in the session's
+// wire.jsonl. step.end carries per-step usage keyed by turnId; the current
+// turn is the highest turnId in the file. Returns null on any failure —
+// usage is nice-to-have and must never break the stream.
+async function readLastTurnOutputTokens(sessionDir: string): Promise<number | null> {
+  try {
+    const wp = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+    const st = await fs.stat(wp);
+    const fh = await fs.open(wp, 'r');
+    let text: string;
+    try {
+      const cap = Math.min(st.size, 512 * 1024);
+      const buf = Buffer.alloc(cap);
+      await fh.read(buf, 0, cap, st.size - cap);
+      text = buf.toString('utf8');
+    } finally {
+      await fh.close();
+    }
+    let lastTurn = -1;
+    const usages: Array<{ turnId: number; output: number }> = [];
+    for (const line of text.split('\n')) {
+      const t = line.trim();
+      if (!t || !t.includes('"step.end"')) continue;
+      try {
+        const o = JSON.parse(t) as { type?: string; event?: { type?: string; turnId?: string; usage?: { output?: number } } };
+        const ev = o.event;
+        if (o.type !== 'context.append_loop_event' || ev?.type !== 'step.end') continue;
+        const turnId = Number(ev.turnId ?? -1);
+        if (!Number.isFinite(turnId) || turnId < 0) continue;
+        if (turnId > lastTurn) lastTurn = turnId;
+        usages.push({ turnId, output: Number(ev.usage?.output ?? 0) });
+      } catch { /* skip malformed line */ }
+    }
+    if (lastTurn < 0) return null;
+    const total = usages.filter((u) => u.turnId === lastTurn).reduce((s, u) => s + u.output, 0);
+    return total > 0 ? total : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent> {
+  const queue: RunnerEvent[] = [];
+  const waiters: Array<(v: IteratorResult<RunnerEvent>) => void> = [];
+  let ended = false;
+  const push = (ev: RunnerEvent) => {
+    const w = waiters.shift();
+    if (w) w({ value: ev, done: false });
+    else queue.push(ev);
+  };
+  const finish = () => {
+    ended = true;
+    while (waiters.length) waiters.shift()!({ value: undefined as unknown as RunnerEvent, done: true });
+  };
+  const next = (): Promise<IteratorResult<RunnerEvent>> => {
+    if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+    if (ended) return Promise.resolve({ value: undefined as unknown as RunnerEvent, done: true });
+    return new Promise((res) => waiters.push(res));
+  };
+
+  void (async () => {
+    if (!KIMI_BINARY) {
+      push({ kind: 'error', error: 'kimi CLI not found — install Kimi Code or set MACARON_KIMI_PATH' });
+      push({ kind: 'done', exitCode: -1 });
+      finish();
+      return;
+    }
+    let sessionEmitted = false;
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    const stopPoll = () => { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } };
+    try {
+      const args = ['-p', opts.prompt, '--output-format', 'stream-json'];
+      // Emit the session id as soon as we can. A resume already knows it; a
+      // new session learns it via the snapshot-diff poll / meta line below.
+      if (opts.resume) {
+        args.push('-r', opts.resume);
+        sessionEmitted = true;
+        push({ kind: 'session', sessionId: opts.resume });
+      }
+      const providerEnv = getActiveKimiProviderEnv();
+      console.log(
+        `[kimi-runner] starting  model=${providerEnv.KIMI_MODEL_NAME || '(system)'}  base=${providerEnv.KIMI_MODEL_BASE_URL || '(ambient)'}  resume=${opts.resume ? opts.resume.slice(0, 8) : '(new)'}  cwd=${opts.cwd}`,
+      );
+
+      // Snapshot BEFORE spawning so any session dir appearing afterwards is
+      // ours (matched on state.json workDir to rule out concurrent runs).
+      const before = opts.resume ? null : await snapshotKimiSessionIds();
+      const child = spawn(KIMI_BINARY, args, {
+        cwd: opts.cwd,
+        env: { ...process.env, ...providerEnv },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      if (before) {
+        pollTimer = setInterval(() => {
+          void findNewKimiSession(before, opts.cwd).then((hit) => {
+            if (!hit || sessionEmitted) return;
+            sessionEmitted = true;
+            stopPoll();
+            push({ kind: 'session', sessionId: hit.sessionId });
+          }).catch(() => {});
+        }, 200);
+        pollTimer.unref();
+      }
+
+      const onAbort = () => {
+        child.kill('SIGTERM');
+        // A hung child shouldn't pin the turn forever — escalate.
+        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, 3000).unref();
+      };
+      if (opts.abortController?.signal.aborted) onAbort();
+      else opts.abortController?.signal.addEventListener('abort', onAbort, { once: true });
+
+      let stderrTail = '';
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrTail = (stderrTail + chunk.toString('utf8')).slice(-8192);
+      });
+
+      let capturedSid = opts.resume || '';
+      let syntheticId = 0;
+      let buf = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        buf += chunk.toString('utf8');
+        const lines = buf.split('\n');
+        buf = lines.pop() || '';
+        for (const line of lines) {
+          const t = line.trim();
+          if (!t) continue;
+          let o: {
+            role?: string;
+            type?: string;
+            content?: unknown;
+            tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: unknown } }>;
+            tool_call_id?: string;
+            is_error?: boolean;
+            session_id?: string;
+          };
+          try { o = JSON.parse(t); } catch { continue; }
+
+          if (o.role === 'meta') {
+            // Final line of every stream — the authoritative sid for NEW
+            // sessions when the snapshot-diff poll hasn't fired yet.
+            if (o.session_id && !sessionEmitted) {
+              sessionEmitted = true;
+              capturedSid = o.session_id;
+              stopPoll();
+              push({ kind: 'session', sessionId: o.session_id });
+            } else if (o.session_id) {
+              capturedSid = o.session_id;
+            }
+            continue;
+          }
+
+          if (o.role === 'assistant') {
+            if (typeof o.content === 'string' && o.content) {
+              push({ kind: 'delta', text: o.content });
+            } else if (Array.isArray(o.content)) {
+              const text = o.content
+                .map((p) => (p && typeof p === 'object' && (p as { type?: string }).type === 'text' ? String((p as { text?: string }).text || '') : ''))
+                .filter(Boolean)
+                .join('');
+              if (text) push({ kind: 'delta', text });
+            }
+            for (const call of o.tool_calls || []) {
+              const fn = call.function || {};
+              let input: unknown = fn.arguments;
+              if (typeof input === 'string') {
+                try { input = JSON.parse(input); } catch { /* keep as string */ }
+              }
+              push({ kind: 'tool_use', id: String(call.id || `kimi-${syntheticId++}`), name: String(fn.name || 'tool'), input: input ?? {} });
+            }
+            continue;
+          }
+
+          if (o.role === 'tool') {
+            const text = typeof o.content === 'string' ? o.content : JSON.stringify(o.content ?? '');
+            push({ kind: 'tool_result', tool_use_id: String(o.tool_call_id || ''), text: text.slice(0, 8000), isError: Boolean(o.is_error) });
+            continue;
+          }
+        }
+      });
+
+      const exitCode: number = await new Promise((resolve) => {
+        child.on('error', () => resolve(-1));
+        child.on('close', (code) => resolve(code ?? -1));
+      });
+      stopPoll();
+
+      const aborted = Boolean(opts.abortController?.signal.aborted);
+      if (exitCode === 0 || aborted) {
+        // Live usage meter: stream-json has none, so sum the final turn's
+        // step.end usage off the wire.jsonl the CLI just flushed.
+        if (!aborted && capturedSid) {
+          const dir = await findKimiSessionDir(capturedSid);
+          const outputTokens = dir ? await readLastTurnOutputTokens(dir) : null;
+          if (outputTokens !== null) push({ kind: 'usage', outputTokens });
+        }
+        push({ kind: 'done', exitCode: aborted ? -1 : 0 });
+      } else {
+        const detail = stderrTail.trim().split('\n').slice(-3).join('\n').trim();
+        push({ kind: 'error', error: detail || `kimi exited with code ${exitCode}` });
+        push({ kind: 'done', exitCode });
+      }
+    } catch (err) {
+      push({ kind: 'error', error: (err as Error).message });
+      push({ kind: 'done', exitCode: -1 });
+    } finally {
+      stopPoll();
+      finish();
+    }
+  })();
+
+  while (true) {
+    const r = await next();
+    if (r.done) return;
+    yield r.value;
+  }
+}

--- a/server/src/lib/kimi-store.ts
+++ b/server/src/lib/kimi-store.ts
@@ -1,0 +1,434 @@
+// Read + parse Kimi Code sessions under ~/.kimi-code/sessions/<workDirKey>/
+// <sessionId>/ into our shared Session/Message shape so the WebUI can render
+// Kimi conversations with the exact same components used for Claude.
+//
+// Layout per session dir:
+//   state.json               — { createdAt, updatedAt, title, workDir, agents }
+//   agents/main/wire.jsonl   — the main agent's transcript (protocol 1.4)
+//   agents/agent-*/wire.jsonl— subagent transcripts
+// Discovery prefers ~/.kimi-code/session_index.jsonl (one {sessionId,
+// sessionDir, workDir} JSON per line) and falls back to scanning
+// sessions/wd_*/session_* when the index is missing.
+//
+// wire.jsonl line types we consume (everything else is skipped):
+//   turn.prompt / turn.steer (origin.kind === 'user')   → user message
+//   context.append_message (role user, origin 'user')   → user message
+//     (deduped — kimi mirrors every turn.prompt with an identical append)
+//   context.append_loop_event event.type:
+//     content.part {think|text} → thinking / text blocks on the assistant msg
+//     tool.call                 → tool_use (id = toolCallId, input = args)
+//     tool.result               → tool_result (paired by toolCallId)
+//     step.end                  → usage snapshot
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { Message, SessionDetail, SessionListItem, SubagentInfo, UsageSnapshot } from '@macaron/shared';
+import { KIMI_HOME, KIMI_SESSIONS } from '../config.js';
+
+type KimiState = {
+  title?: string;
+  isCustomTitle?: boolean;
+  workDir?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  agents?: Record<string, { type?: string; parentAgentId?: string | null; swarmItem?: string }>;
+};
+
+type IndexEntry = { sessionId: string; sessionDir: string; workDir: string };
+
+type SummaryCache = {
+  mtimeMs: number;
+  size: number;
+  firstUserText: string;
+  approxMessages: number;
+};
+
+const summaryCache = new Map<string, SummaryCache>();
+
+// The fast discovery path — one JSON per line, written by the CLI itself.
+// Returns null when the index is missing/unreadable so callers fall back to
+// a directory scan.
+async function readSessionIndex(): Promise<IndexEntry[] | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path.join(KIMI_HOME, 'session_index.jsonl'), 'utf8');
+  } catch {
+    return null;
+  }
+  const out: IndexEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const o = JSON.parse(t) as Partial<IndexEntry>;
+      if (o.sessionId && o.sessionDir) {
+        out.push({ sessionId: o.sessionId, sessionDir: o.sessionDir, workDir: String(o.workDir || '') });
+      }
+    } catch { /* skip malformed line */ }
+  }
+  return out;
+}
+
+// Directory-scan fallback: sessions/<workDirKey>/<sessionId>/.
+async function scanSessionDirs(): Promise<Array<{ sessionId: string; sessionDir: string }>> {
+  const out: Array<{ sessionId: string; sessionDir: string }> = [];
+  const buckets = await fs.readdir(KIMI_SESSIONS, { withFileTypes: true }).catch(() => []);
+  for (const b of buckets) {
+    if (!b.isDirectory()) continue;
+    const bp = path.join(KIMI_SESSIONS, b.name);
+    const dirs = await fs.readdir(bp, { withFileTypes: true }).catch(() => []);
+    for (const d of dirs) {
+      if (d.isDirectory() && d.name.startsWith('session_')) out.push({ sessionId: d.name, sessionDir: path.join(bp, d.name) });
+    }
+  }
+  return out;
+}
+
+// All known session dirs, index-first with a scan fallback. Stale index
+// entries (dir deleted underneath) are filtered out.
+async function discoverSessions(): Promise<Array<{ sessionId: string; sessionDir: string; workDir: string }>> {
+  const index = await readSessionIndex();
+  if (index) {
+    const checks = await Promise.all(
+      index.map(async (e) => ((await fs.stat(e.sessionDir).catch(() => null))?.isDirectory() ? e : null)),
+    );
+    return checks.filter((e): e is IndexEntry => e !== null);
+  }
+  return (await scanSessionDirs()).map((e) => ({ ...e, workDir: '' }));
+}
+
+export async function findKimiSessionDir(sid: string): Promise<string | null> {
+  const index = await readSessionIndex();
+  if (index) {
+    const hit = index.find((e) => e.sessionId === sid);
+    if (hit && (await fs.stat(hit.sessionDir).catch(() => null))?.isDirectory()) return hit.sessionDir;
+  }
+  const scanned = await scanSessionDirs();
+  return scanned.find((e) => e.sessionId === sid)?.sessionDir ?? null;
+}
+
+async function readState(sessionDir: string): Promise<KimiState> {
+  try {
+    return JSON.parse(await fs.readFile(path.join(sessionDir, 'state.json'), 'utf8')) as KimiState;
+  } catch {
+    return {};
+  }
+}
+
+// Read the wire.jsonl head — enough for the first turn.prompt + a message
+// count estimate. Kimi bakes a large system prompt into config.update and
+// full MCP tool manifests into mcp.tools_discovered lines, so the head cap
+// matches codex-store's 256KB; results are cached by (mtime, size).
+async function readSummary(filePath: string, mtimeMs: number, size: number): Promise<SummaryCache | null> {
+  const cached = summaryCache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) return cached;
+
+  const fh = await fs.open(filePath, 'r').catch(() => null);
+  if (!fh) return null;
+  try {
+    const cap = Math.min(size, 256 * 1024);
+    const buf = Buffer.alloc(cap);
+    await fh.read(buf, 0, cap, 0);
+    const text = buf.toString('utf8');
+    let firstUserText = '';
+    let approxMessages = 0;
+    // Line-by-line — the last line may be partial (we're reading only the
+    // head), so drop the tail if it doesn't end in \n.
+    const lines = text.split('\n');
+    const upto = size > cap ? lines.length - 1 : lines.length;
+    for (let i = 0; i < upto; i++) {
+      const line = lines[i]!.trim();
+      if (!line) continue;
+      let o: { type?: string; origin?: { kind?: string }; input?: unknown; event?: { type?: string; part?: { type?: string } } };
+      try { o = JSON.parse(line); } catch { continue; }
+      if ((o.type === 'turn.prompt' || o.type === 'turn.steer') && o.origin?.kind === 'user') {
+        approxMessages++;
+        if (!firstUserText) {
+          const t = inputText(o.input).trim();
+          if (t && !t.startsWith('<')) firstUserText = t;
+        }
+      } else if (o.type === 'context.append_loop_event' && o.event?.type === 'content.part' && o.event.part?.type === 'text') {
+        approxMessages++;
+      }
+    }
+    const entry: SummaryCache = { mtimeMs, size, firstUserText, approxMessages };
+    summaryCache.set(filePath, entry);
+    return entry;
+  } finally {
+    await fh.close();
+  }
+}
+
+// Concat the text parts of a turn.prompt / turn.steer `input` array.
+function inputText(input: unknown): string {
+  if (!Array.isArray(input)) return '';
+  return input
+    .map((p) => (p && typeof p === 'object' && (p as { type?: string }).type === 'text' ? String((p as { text?: string }).text || '') : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+// Concat the text parts of a context.append_message content array.
+function contentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((p) => (p && typeof p === 'object' && (p as { type?: string }).type === 'text' ? String((p as { text?: string }).text || '') : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+// Best-effort project key for a kimi session — mirrors the encoded
+// project-name convention claude-cli uses (slash → dash). Keeps the UI's
+// per-workspace grouping identical across engines.
+export function encodeKimiProjectName(cwd: string): string {
+  if (!cwd) return '';
+  return cwd.replace(/^\//, '-').replace(/\//g, '-');
+}
+
+const wirePath = (sessionDir: string) => path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+
+export async function listKimiSessions(): Promise<SessionListItem[]> {
+  const out: SessionListItem[] = [];
+  const found = await discoverSessions();
+  await Promise.all(
+    found.map(async ({ sessionId, sessionDir, workDir }) => {
+      const state = await readState(sessionDir);
+      const cwd = state.workDir || workDir;
+      const wp = wirePath(sessionDir);
+      const st = await fs.stat(wp).catch(() => null);
+      const summary = st ? await readSummary(wp, st.mtimeMs, st.size) : null;
+      // A session with no wire yet (created, no turn sent) still lists, keyed
+      // off state.json's own timestamps.
+      const mtime = st?.mtimeMs ?? (Date.parse(state.updatedAt || state.createdAt || '') || 0);
+      // Kimi auto-titles from the first prompt; "New Session"/empty means the
+      // title never landed — fall back to the first-user-message preview.
+      const title = state.title && state.title !== 'New Session' ? state.title : undefined;
+      out.push({
+        kind: 'kimi',
+        project: encodeKimiProjectName(cwd),
+        cwd,
+        sessionId,
+        preview: (summary?.firstUserText || '').slice(0, 220),
+        title,
+        messageCount: summary?.approxMessages ?? 0,
+        messageCountSuffix: '',
+        mtime,
+        size: st?.size,
+        resumeCommand: `kimi -r ${sessionId}`,
+      });
+    }),
+  );
+  out.sort((a, b) => b.mtime - a.mtime);
+  return out;
+}
+
+// Parse one wire.jsonl (main agent or a subagent's) into shared Message[].
+// Split out from readKimiSessionMessages so subagent transcripts reuse it.
+function parseWire(raw: string): { messages: Message[]; latestUsage?: UsageSnapshot } {
+  const messages: Message[] = [];
+  let latestUsage: UsageSnapshot | undefined;
+  // Track the last assistant message so subsequent tool_use / thinking
+  // blocks land on the same bubble instead of forcing a new one.
+  let currentAssistant: Message | null = null;
+  const ensureAssistant = (time?: number): Message => {
+    if (currentAssistant) return currentAssistant;
+    const m: Message = { role: 'assistant', blocks: [] };
+    if (time) m.timestamp = new Date(time).toISOString();
+    messages.push(m);
+    currentAssistant = m;
+    return m;
+  };
+  // Dedupe user turns: kimi logs every turn.prompt twice (once as the prompt
+  // itself, once mirrored into context.append_message with the same text).
+  let lastUserText = '';
+
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let o: {
+      type?: string;
+      time?: number;
+      origin?: { kind?: string };
+      input?: unknown;
+      message?: { role?: string; content?: unknown; origin?: { kind?: string }; toolCalls?: unknown };
+      event?: Record<string, unknown> & { type?: string };
+    };
+    try { o = JSON.parse(t); } catch { continue; }
+
+    if (o.type === 'turn.prompt' || o.type === 'turn.steer') {
+      if (o.origin?.kind !== 'user') continue;
+      const text = inputText(o.input).trim();
+      if (!text) continue;
+      currentAssistant = null;
+      lastUserText = text;
+      messages.push({
+        role: 'user',
+        blocks: [{ kind: 'text', text }],
+        timestamp: o.time ? new Date(o.time).toISOString() : undefined,
+      });
+      continue;
+    }
+
+    if (o.type === 'context.append_message') {
+      const m = o.message || {};
+      // Non-user origins (injection, skill_activation, system_trigger) are
+      // the kimi equivalent of claude's isMeta wrappers — never render them.
+      if (m.role !== 'user' || m.origin?.kind !== 'user') continue;
+      const text = contentText(m.content).trim();
+      if (!text || text === lastUserText) continue;
+      currentAssistant = null;
+      lastUserText = text;
+      messages.push({
+        role: 'user',
+        blocks: [{ kind: 'text', text }],
+        timestamp: o.time ? new Date(o.time).toISOString() : undefined,
+      });
+      continue;
+    }
+
+    if (o.type !== 'context.append_loop_event') continue;
+    const ev = o.event || {};
+    const kind = String(ev.type || '');
+
+    if (kind === 'content.part') {
+      const part = (ev.part || {}) as { type?: string; text?: string; think?: string };
+      if (part.type === 'think') {
+        const text = String(part.think || '').trim();
+        if (!text) continue;
+        ensureAssistant(o.time).blocks.push({ kind: 'thinking', text });
+      } else if (part.type === 'text') {
+        const text = String(part.text || '').trim();
+        if (!text) continue;
+        const m = ensureAssistant(o.time);
+        m.blocks.push({ kind: 'text', text });
+        if (o.time) m.timestamp ??= new Date(o.time).toISOString();
+      }
+      continue;
+    }
+
+    if (kind === 'tool.call') {
+      const id = String(ev.toolCallId || ev.uuid || `kimi-${messages.length}`);
+      const name = String(ev.name || 'tool');
+      ensureAssistant(o.time).blocks.push({ kind: 'tool_use', id, name, input: ev.args ?? {} });
+      continue;
+    }
+
+    if (kind === 'tool.result') {
+      const id = String(ev.toolCallId || '');
+      const result = (ev.result ?? {}) as { output?: unknown; error?: unknown; isError?: boolean; is_error?: boolean };
+      let text = '';
+      if (typeof result.output === 'string') text = result.output;
+      else if (result.output != null) text = JSON.stringify(result.output);
+      else if (result.error != null) text = typeof result.error === 'string' ? result.error : JSON.stringify(result.error);
+      const isError = Boolean(result.isError || result.is_error || result.error);
+      ensureAssistant(o.time).blocks.push({ kind: 'tool_result', toolUseId: id, text: text.slice(0, 8000), isError });
+      continue;
+    }
+
+    if (kind === 'step.end') {
+      const u = (ev.usage || {}) as { inputOther?: number; output?: number; inputCacheRead?: number; inputCacheCreation?: number };
+      latestUsage = {
+        inputTokens: u.inputOther ?? 0,
+        cacheCreationInputTokens: u.inputCacheCreation ?? 0,
+        cacheReadInputTokens: u.inputCacheRead ?? 0,
+        outputTokens: u.output ?? 0,
+      };
+      continue;
+    }
+  }
+  return { messages, latestUsage };
+}
+
+// Parse a kimi session dir into our shared SessionDetail shape.
+export async function readKimiSessionMessages(sid: string): Promise<SessionDetail> {
+  const sessionDir = await findKimiSessionDir(sid);
+  if (!sessionDir) throw new Error(`kimi session not found: ${sid}`);
+  const state = await readState(sessionDir);
+  const wp = wirePath(sessionDir);
+  const st = await fs.stat(wp).catch(() => null);
+  if (!st) throw new Error(`kimi session has no transcript: ${sid}`);
+  const raw = await fs.readFile(wp, 'utf8');
+  const { messages, latestUsage } = parseWire(raw);
+  const cwd = state.workDir || '';
+
+  return {
+    kind: 'kimi',
+    sessionId: sid,
+    project: encodeKimiProjectName(cwd),
+    cwd,
+    messages,
+    truncated: false,
+    totalBytes: st.size,
+    latestUsage,
+  };
+}
+
+// Delete a kimi session dir (state.json + all agent wires). The CLI-owned
+// session_index.jsonl keeps a stale line; discovery already filters those.
+export async function deleteKimiSession(sid: string): Promise<void> {
+  const sessionDir = await findKimiSessionDir(sid);
+  if (!sessionDir) throw new Error(`kimi session not found: ${sid}`);
+  await fs.rm(sessionDir, { recursive: true, force: true });
+  summaryCache.delete(wirePath(sessionDir));
+}
+
+// List the subagents spawned from this session. Kimi records them in
+// state.json's `agents` map (type 'sub', dirs agents/agent-*); pair each
+// with the main wire's Agent/AgentSwarm tool.call events (in order) so the
+// WebUI can link an inline Agent tool card to the child transcript.
+export async function listKimiSubagents(sid: string): Promise<SubagentInfo[]> {
+  const sessionDir = await findKimiSessionDir(sid);
+  if (!sessionDir) return [];
+  const state = await readState(sessionDir);
+  const subs = Object.entries(state.agents || {})
+    .filter(([, a]) => a?.type === 'sub')
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
+  if (subs.length === 0) return [];
+  const raw = await fs.readFile(wirePath(sessionDir), 'utf8').catch(() => '');
+  const agentCalls: Array<{ id: string; agentType: string; description: string }> = [];
+  const swarmCalls: string[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t || !t.includes('"tool.call"')) continue;
+    try {
+      const o = JSON.parse(t) as { type?: string; event?: { type?: string; name?: string; toolCallId?: string; args?: { subagent_type?: string; description?: string } } };
+      const ev = o.event;
+      if (o.type !== 'context.append_loop_event' || ev?.type !== 'tool.call') continue;
+      if (ev.name === 'Agent') {
+        agentCalls.push({ id: String(ev.toolCallId || ''), agentType: String(ev.args?.subagent_type || ''), description: String(ev.args?.description || '') });
+      } else if (ev.name === 'AgentSwarm') {
+        swarmCalls.push(String(ev.toolCallId || ''));
+      }
+    } catch { /* skip malformed line */ }
+  }
+  // A single Agent spawn maps 1:1 to its tool card; an AgentSwarm call spawns
+  // the whole batch, so every swarm agent (state.json carries `swarmItem`)
+  // links back to that same card. Best-effort, order-based.
+  let ai = 0;
+  return subs.map(([agentId, a]) => {
+    if (a?.swarmItem !== undefined) {
+      return { agentId, agentType: '', description: a.swarmItem, toolUseId: swarmCalls[0] || '' };
+    }
+    const call = agentCalls[ai++];
+    return { agentId, agentType: call?.agentType || '', description: call?.description || '', toolUseId: call?.id || '' };
+  });
+}
+
+// Snapshot every known sessionId. The runner diffs this against the tree
+// after spawning a NEW session to learn the sid before the CLI's final meta
+// line arrives (kimi only prints session.resume_hint at stream end).
+export async function snapshotKimiSessionIds(): Promise<Set<string>> {
+  return new Set((await scanSessionDirs()).map((e) => e.sessionId));
+}
+
+// Find a session dir that appeared after `since` was taken and whose
+// state.json workDir matches `cwd`. Returns null while nothing matches.
+export async function findNewKimiSession(since: Set<string>, cwd: string): Promise<{ sessionId: string; sessionDir: string } | null> {
+  for (const e of await scanSessionDirs()) {
+    if (since.has(e.sessionId)) continue;
+    const state = await readState(e.sessionDir);
+    if ((state.workDir || '') === cwd) return e;
+  }
+  return null;
+}

--- a/server/src/lib/macaron-mcp-path.ts
+++ b/server/src/lib/macaron-mcp-path.ts
@@ -1,0 +1,42 @@
+// Absolute path + command for the standalone stdio MCP server that exposes
+// render_ui (see server/src/macaron-mcp-stdio.ts). Resolved relative to THIS
+// file so the same lookup works whether the server runs from src/ (tsx dev)
+// or dist/ (built). Shared by codex-runner and kimi-runner so both inject the
+// identical Macaron MCP bridge.
+//
+// Production: `server/dist/lib/*.js` → sibling `server/dist/macaron-mcp-stdio.js`
+//   → spawn `node <path>`.
+// Dev: `server/src/lib/*.ts` → sibling `server/src/macaron-mcp-stdio.ts`
+//   → spawn `tsx <path>` (via node_modules/.bin/tsx so we don't need a global tsx).
+
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const { command: MACARON_MCP_CMD, args: MACARON_MCP_ARGS } = (() => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const jsPath = path.join(here, '..', 'macaron-mcp-stdio.js');
+  if (existsSync(jsPath)) {
+    return { command: 'node', args: [jsPath] };
+  }
+  const tsPath = path.join(here, '..', 'macaron-mcp-stdio.ts');
+  // Walk up until we find a runnable tsx binary. Under pnpm, dev bins
+  // are NOT hoisted to `<repo>/node_modules/.bin/`; they live under
+  // `<repo>/node_modules/.pnpm/node_modules/.bin/`. Also check the
+  // classic hoisted path for npm/yarn / server workspace bin.
+  let dir = here;
+  for (let i = 0; i < 6; i++) {
+    for (const rel of [
+      ['node_modules', '.bin', 'tsx'],
+      ['node_modules', '.pnpm', 'node_modules', '.bin', 'tsx'],
+    ]) {
+      const candidate = path.join(dir, ...rel);
+      if (existsSync(candidate)) return { command: candidate, args: [tsPath] };
+    }
+    dir = path.dirname(dir);
+  }
+  // Last resort: hope `tsx` is on PATH.
+  return { command: 'tsx', args: [tsPath] };
+})();
+
+export { MACARON_MCP_CMD, MACARON_MCP_ARGS };

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -5,6 +5,7 @@
 import { promises as fs } from 'node:fs';
 import { runClaude } from './claude-runner.js';
 import { runCodex } from './codex-runner.js';
+import { runKimi } from './kimi-runner.js';
 import { getActiveProviderEnv } from './settings-store.js';
 import { liveStart, livePush, liveEnd } from './live-registry.js';
 import { registerRun, endRun } from './active-runs.js';
@@ -97,6 +98,10 @@ export async function fireSchedule(schedule: Schedule, advance = true): Promise<
     let stream: AsyncGenerator<RunnerEvent>;
     if (schedule.engine === 'codex') {
       stream = runCodex({ prompt: schedule.prompt, cwd: schedule.cwd, abortController });
+    } else if (schedule.engine === 'kimi') {
+      // Headless like codex: `kimi -p` runs with auto permission and writes
+      // its own wire.jsonl, which the store picks up on the next refresh.
+      stream = runKimi({ prompt: schedule.prompt, cwd: schedule.cwd, abortController });
     } else {
       const { model, env } = getActiveProviderEnv();
       // A scheduled fire is headless — no client is attached to answer the

--- a/server/src/lib/session-watcher.ts
+++ b/server/src/lib/session-watcher.ts
@@ -2,15 +2,16 @@ import { watch } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import type { FastifyReply } from 'fastify';
 import type { SystemEvent } from '@macaron/shared';
-import { CLAUDE_PROJECTS, CODEX_SESSIONS } from '../config.js';
+import { CLAUDE_PROJECTS, CODEX_SESSIONS, KIMI_SESSIONS } from '../config.js';
 import { sseSend } from './sse.js';
 
-// Recursive fs.watch over the two transcript trees macaron already reads.
-// A terminal `claude`/`codex` run appends to a jsonl here; we debounce the
-// burst of change events and push one `sessions-changed` nudge to every
-// connected client so external sessions surface live instead of waiting for
-// the next poll. We deliberately don't parse the file — the nudge just tells
-// the client to refetch its (already cheap, mtime-cached) workspace list.
+// Recursive fs.watch over the three transcript trees macaron already reads.
+// A terminal `claude`/`codex`/`kimi` run appends to a transcript here; we
+// debounce the burst of change events and push one `sessions-changed` nudge
+// to every connected client so external sessions surface live instead of
+// waiting for the next poll. We deliberately don't parse the file — the
+// nudge just tells the client to refetch its (already cheap, mtime-cached)
+// workspace list.
 
 const subs = new Set<FastifyReply>();
 const DEBOUNCE_MS = 400;
@@ -68,5 +69,6 @@ export async function startSessionWatcher(): Promise<void> {
   await Promise.all([
     watchTree(CLAUDE_PROJECTS, 'claude'),
     watchTree(CODEX_SESSIONS, 'codex'),
+    watchTree(KIMI_SESSIONS, 'kimi'),
   ]);
 }

--- a/server/src/routes/codex.ts
+++ b/server/src/routes/codex.ts
@@ -352,8 +352,6 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
     return reply.send(await readPublicCodexSettings());
   });
 
-  // --- Engine banner -----------------------------------------------------
-
   function pickCustomProviderPatch(b: Partial<CodexCustomProvider>): Partial<CodexCustomProvider> {
     const patch: Partial<CodexCustomProvider> = {};
     if (typeof b.name === 'string') patch.name = b.name;
@@ -369,9 +367,4 @@ export async function registerCodexRoutes(app: FastifyInstance): Promise<void> {
     if (typeof b.autoCompactTokenLimit === 'number') patch.autoCompactTokenLimit = b.autoCompactTokenLimit;
     return patch;
   }
-
-
-  app.get('/api/engine', async () => ({
-    engine: process.env.MACARON_ENGINE === 'codex' ? 'codex' : 'claude',
-  }));
 }

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -14,7 +14,13 @@ export async function registerHealthRoutes(app: FastifyInstance): Promise<void> 
     };
   });
 
-  // System event stream: the server watches the claude/codex jsonl trees and
+  // Engine banner — which SPA the server is booting (MACARON_ENGINE). One
+  // handler for all engines; unset means claude.
+  app.get('/api/engine', async () => ({
+    engine: process.env.MACARON_ENGINE === 'kimi' ? 'kimi' : process.env.MACARON_ENGINE === 'codex' ? 'codex' : 'claude',
+  }));
+
+  // System event stream: the server watches the claude/codex/kimi transcript trees and
   // pushes a `sessions-changed` nudge here whenever a transcript changes on
   // disk — including sessions started outside the WebUI. Long-lived SSE; a
   // heartbeat comment keeps proxies from closing the idle connection.

--- a/server/src/routes/kimi.ts
+++ b/server/src/routes/kimi.ts
@@ -1,0 +1,291 @@
+// Kimi-only API surface. Mounted under /api/kimi/*. The claude and codex API
+// namespaces stay pure — the engines don't cross-index each other.
+//
+// Shape:
+//   GET  /api/kimi/threads                     — flat list of threads (sorted mtime desc)
+//   GET  /api/kimi/threads/:sid                — full transcript
+//   DELETE /api/kimi/threads/:sid              — delete session dir
+//   POST /api/kimi/threads                     — start a new thread (SSE)
+//   POST /api/kimi/threads/:sid/message        — resume + send (SSE)
+//   POST /api/kimi/threads/:sid/stop           — abort in-flight run
+//   GET/PUT /api/kimi/config                   — provider config CRUD
+
+import { promises as fs } from 'node:fs';
+import type { FastifyInstance } from 'fastify';
+import {
+  deleteKimiSession,
+  listKimiSessions,
+  readKimiSessionMessages,
+} from '../lib/kimi-store.js';
+import { groupWorkspaces } from '../lib/session-store.js';
+import { runKimi } from '../lib/kimi-runner.js';
+import {
+  KIMI_SYSTEM_PROVIDER_ID,
+  createKimiProvider,
+  deleteKimiProvider,
+  readPublicKimiSettings,
+  setActiveKimiProvider,
+  updateKimiProvider,
+  type KimiCustomProvider,
+} from '../lib/kimi-config.js';
+import { startSSE, sseSend, sseDone } from '../lib/sse.js';
+import { liveStart, livePush, liveEnd, liveGet } from '../lib/live-registry.js';
+import { registerRun, abortRun, endRun } from '../lib/active-runs.js';
+import type { AttachedImage } from '../lib/claude-runner.js';
+import type { SessionStreamEvent } from '@macaron/shared';
+
+type SidParams = { sid: string };
+type NewThreadBody = { text?: string; cwd?: string; images?: AttachedImage[] };
+type MessageBody = { text?: string; images?: AttachedImage[] };
+
+export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
+  // --- Threads -----------------------------------------------------------
+
+  app.get('/api/kimi/threads', async () => {
+    const threads = await listKimiSessions();
+    return { threads };
+  });
+
+  // Workspaces = kimi threads grouped by cwd (same shape as the claude
+  // /api/workspaces endpoint so the sidebar layout can mirror claude's).
+  app.get('/api/kimi/workspaces', async () => {
+    const sessions = await listKimiSessions();
+    return { workspaces: groupWorkspaces(sessions) };
+  });
+
+  app.get<{ Params: { project: string } }>(
+    '/api/kimi/workspaces/:project',
+    async ({ params }) => {
+      const sessions = await listKimiSessions();
+      const mine = sessions.filter((s) => s.project === params.project);
+      const meta =
+        groupWorkspaces(mine)[0] || {
+          project: params.project,
+          cwd: '',
+          name: params.project,
+          sessionCount: 0,
+          lastActivity: 0,
+          lastSessionId: '',
+          lastPreview: '',
+        };
+      return { workspace: meta, sessions: mine };
+    },
+  );
+
+  app.get<{ Params: SidParams }>('/api/kimi/threads/:sid', async ({ params }, reply) => {
+    try {
+      return await readKimiSessionMessages(params.sid);
+    } catch (e) {
+      return reply.status(404).send({ error: (e as Error).message });
+    }
+  });
+
+  app.delete<{ Params: SidParams }>('/api/kimi/threads/:sid', async ({ params }, reply) => {
+    try {
+      await deleteKimiSession(params.sid);
+      return { ok: true };
+    } catch (e) {
+      return reply.status(404).send({ error: (e as Error).message });
+    }
+  });
+
+  // --- Send / resume -----------------------------------------------------
+
+  const pipeKimiToSSE = (
+    reply: Parameters<typeof startSSE>[0],
+    stream: ReturnType<typeof runKimi>,
+    sid: string | null,
+    live: { cwd: string; text: string; hasImages: boolean },
+  ) => {
+    let clientGone = false;
+    reply.raw.on('close', () => { clientGone = true; });
+    const safeSend = (payload: Parameters<typeof sseSend>[1]) => {
+      if (clientGone) return;
+      try { sseSend(reply, payload); } catch { clientGone = true; }
+    };
+    let capturedSid = sid;
+    // Mirror the Claude route: the primary client is written directly, while a
+    // parallel copy of every event lands in the live registry so a browser
+    // refresh mid-turn can reattach via the snapshot-then-live /live endpoint.
+    let liveStarted = false;
+    const ensureLive = () => {
+      if (liveStarted || !capturedSid) return;
+      liveStarted = true;
+      liveStart(capturedSid, { cwd: live.cwd });
+      // Seed the user bubble for the reattach snapshot whenever the turn had
+      // any input — an image-only turn still needs its bubble.
+      if (live.text || live.hasImages) livePush(capturedSid, { type: 'user-text', text: live.text });
+    };
+    ensureLive(); // resume already knows the sid; a new thread waits for `session`
+    const relay = (payload: SessionStreamEvent) => {
+      safeSend(payload);
+      if (capturedSid) livePush(capturedSid, payload);
+    };
+    (async () => {
+      for await (const ev of stream) {
+        if (ev.kind === 'session' && !capturedSid) {
+          capturedSid = ev.sessionId;
+          ensureLive();
+          safeSend({ type: 'meta', cwd: live.cwd, sessionId: capturedSid });
+        } else if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
+        else if (ev.kind === 'tool_use') relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
+        else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
+        else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
+        else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
+        else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
+        else if (ev.kind === 'done') {
+          safeSend({ type: 'done', exitCode: ev.exitCode });
+          if (capturedSid) { liveEnd(capturedSid, { type: 'done', exitCode: ev.exitCode }); endRun(capturedSid); }
+          if (!clientGone) sseDone(reply);
+        }
+      }
+    })().catch((e: unknown) => {
+      const msg = (e as Error).message;
+      if (capturedSid) { liveEnd(capturedSid, { type: 'done', exitCode: -1, error: msg }); endRun(capturedSid); }
+      safeSend({ type: 'error', error: msg });
+      if (!clientGone) sseDone(reply);
+    });
+  };
+
+  app.post<{ Body: NewThreadBody }>('/api/kimi/threads', async (req, reply) => {
+    const text = String(req.body?.text || '').trim();
+    const images = Array.isArray(req.body?.images) ? req.body!.images! : [];
+    const cwd = String(req.body?.cwd || process.env.HOME || '/tmp');
+    if (!text && images.length === 0) {
+      return reply.status(400).send({ error: 'text or images required' });
+    }
+    try {
+      const st = await fs.stat(cwd);
+      if (!st.isDirectory()) throw new Error('cwd not a directory');
+    } catch (e) {
+      return reply.status(400).send({ error: `cwd unusable: ${cwd} (${(e as Error).message})` });
+    }
+    startSSE(reply);
+    sseSend(reply, { type: 'starting', cwd });
+    const abortController = new AbortController();
+    const stream = runKimi({ prompt: text, cwd, images, abortController });
+    // pipeKimiToSSE owns the iteration, so wrap the runner to install the abort
+    // under the sid once the first `session` event reveals it.
+    const wrapped = (async function* () {
+      for await (const ev of stream) {
+        if (ev.kind === 'session') registerRun(ev.sessionId, abortController);
+        yield ev;
+      }
+    })();
+    pipeKimiToSSE(reply, wrapped as ReturnType<typeof runKimi>, null, { cwd, text, hasImages: images.length > 0 });
+  });
+
+  app.post<{ Params: SidParams; Body: MessageBody }>(
+    '/api/kimi/threads/:sid/message',
+    async (req, reply) => {
+      const sid = req.params.sid;
+      const text = String(req.body?.text || '').trim();
+      const images = Array.isArray(req.body?.images) ? req.body!.images! : [];
+      if (!text && images.length === 0) {
+        return reply.status(400).send({ error: 'text or images required' });
+      }
+      let cwd = process.env.HOME || '/tmp';
+      try {
+        const detail = await readKimiSessionMessages(sid);
+        if (detail.cwd) cwd = detail.cwd;
+      } catch (e) {
+        return reply.status(404).send({ error: (e as Error).message });
+      }
+      startSSE(reply);
+      sseSend(reply, { type: 'meta', sessionId: sid, cwd });
+      const abortController = new AbortController();
+      registerRun(sid, abortController);
+      pipeKimiToSSE(reply, runKimi({ prompt: text, cwd, resume: sid, images, abortController }), sid, { cwd, text, hasImages: images.length > 0 });
+    },
+  );
+
+  app.post<{ Params: SidParams }>('/api/kimi/threads/:sid/stop', async ({ params }, reply) => {
+    const ok = abortRun(params.sid);
+    return reply.send({ ok, running: ok });
+  });
+
+  // SSE: reattach to a Kimi turn. Replays the current snapshot (liveGet), then
+  // forwards live events until the turn ends — so a browser refresh mid-turn
+  // picks the stream back up instead of waiting for the wire.jsonl to land on
+  // disk. Mirrors the codex route's /live handler.
+  app.get<{ Params: SidParams }>('/api/kimi/threads/:sid/live', async ({ params }, reply) => {
+    startSSE(reply);
+    const ls = liveGet(params.sid);
+    if (!ls) {
+      sseSend(reply, { type: 'live-end', reason: 'not-live' });
+      sseDone(reply);
+      return;
+    }
+    // Replay the fully-buffered transcript even when the turn already ended:
+    // the wire.jsonl is written asynchronously after `done`, so the disk
+    // history can 404 or be partial right after a turn while the complete
+    // buffer sits here for KEEP_AROUND_MS. The client reconciles any overlap.
+    for (const ev of ls.events) {
+      try { sseSend(reply, ev); } catch { return; }
+    }
+    if (ls.ended) {
+      sseDone(reply);
+      return;
+    }
+    ls.subs.add(reply);
+    reply.raw.on('close', () => ls.subs.delete(reply));
+  });
+
+  // --- Config ------------------------------------------------------------
+
+  app.get('/api/kimi/config', async () => readPublicKimiSettings());
+
+  // Switch the active provider (system or a customProviders[].id).
+  app.put<{ Body: { providerId?: string } }>('/api/kimi/config/active', async (req, reply) => {
+    const id = String(req.body?.providerId || '').trim();
+    if (!id) return reply.status(400).send({ error: 'providerId required' });
+    try {
+      await setActiveKimiProvider(id);
+    } catch (e) {
+      return reply.status(404).send({ error: (e as Error).message });
+    }
+    return reply.send(await readPublicKimiSettings());
+  });
+
+  // Create a new custom provider.
+  app.post<{ Body: Partial<KimiCustomProvider> }>('/api/kimi/config/providers', async (req, reply) => {
+    const created = await createKimiProvider(pickCustomProviderPatch(req.body || {}));
+    return reply.send({ id: created.id, settings: await readPublicKimiSettings() });
+  });
+
+  // Update an existing custom provider (partial patch — omitted fields keep
+  // their current value; apiKey is only overwritten if non-empty).
+  app.put<{ Params: { id: string }; Body: Partial<KimiCustomProvider> }>(
+    '/api/kimi/config/providers/:id',
+    async (req, reply) => {
+      const id = req.params.id;
+      if (id === KIMI_SYSTEM_PROVIDER_ID) {
+        return reply.status(400).send({ error: 'system provider is not editable' });
+      }
+      try {
+        await updateKimiProvider(id, pickCustomProviderPatch(req.body || {}));
+      } catch (e) {
+        return reply.status(404).send({ error: (e as Error).message });
+      }
+      return reply.send(await readPublicKimiSettings());
+    },
+  );
+
+  app.delete<{ Params: { id: string } }>('/api/kimi/config/providers/:id', async (req, reply) => {
+    if (req.params.id === KIMI_SYSTEM_PROVIDER_ID) {
+      return reply.status(400).send({ error: 'system provider cannot be deleted' });
+    }
+    await deleteKimiProvider(req.params.id);
+    return reply.send(await readPublicKimiSettings());
+  });
+
+  function pickCustomProviderPatch(b: Partial<KimiCustomProvider>): Partial<KimiCustomProvider> {
+    const patch: Partial<KimiCustomProvider> = {};
+    if (typeof b.name === 'string') patch.name = b.name;
+    if (typeof b.model === 'string') patch.model = b.model;
+    if (typeof b.baseUrl === 'string') patch.baseUrl = b.baseUrl;
+    if (typeof b.apiKey === 'string' && b.apiKey.length > 0) patch.apiKey = b.apiKey;
+    if (b.providerType === 'kimi' || b.providerType === 'anthropic' || b.providerType === 'openai') patch.providerType = b.providerType;
+    return patch;
+  }
+}

--- a/server/src/routes/schedules.ts
+++ b/server/src/routes/schedules.ts
@@ -26,7 +26,7 @@ function normalizeInput(b: Body): ScheduleInput | null {
   const prompt = String(b.prompt || '').trim();
   const cwd = String(b.cwd || '').trim();
   const pattern = String(b.pattern || '').trim();
-  const engine: SessionKind = b.engine === 'codex' ? 'codex' : 'claude';
+  const engine: SessionKind = b.engine === 'codex' || b.engine === 'kimi' ? b.engine : 'claude';
   if (!name || !prompt || !cwd || !pattern) return null;
   return { name, prompt, cwd, pattern, engine, oneShot: Boolean(b.oneShot) };
 }
@@ -70,7 +70,7 @@ export async function registerScheduleRoutes(app: FastifyInstance): Promise<void
       patch.pattern = b.pattern.trim();
       if (!patch.pattern) return reply.status(400).send({ error: 'pattern required' });
     }
-    if (b.engine === 'claude' || b.engine === 'codex') patch.engine = b.engine;
+    if (b.engine === 'claude' || b.engine === 'codex' || b.engine === 'kimi') patch.engine = b.engine;
     if (typeof b.oneShot === 'boolean') patch.oneShot = b.oneShot;
     try {
       if (patch.cwd !== undefined) await assertRunnableCwd(patch.cwd);

--- a/shared/src/sse.ts
+++ b/shared/src/sse.ts
@@ -49,12 +49,12 @@ export type SessionStreamEvent =
   | { type: 'followup_delta'; text: string }
   | { type: 'live-end'; reason?: string };
 
-// System-wide event stream (GET /api/events). The server watches the claude
-// and codex jsonl trees and pushes a debounced nudge whenever a transcript
-// file changes on disk — including sessions started outside the WebUI in a
-// terminal. Clients refetch their workspace list on receipt, so external
-// sessions surface live instead of on the next slow poll.
-export type SystemEvent = { type: 'sessions-changed'; engine: 'claude' | 'codex' };
+// System-wide event stream (GET /api/events). The server watches the claude,
+// codex and kimi transcript trees and pushes a debounced nudge whenever a
+// transcript file changes on disk — including sessions started outside the
+// WebUI in a terminal. Clients refetch their workspace list on receipt, so
+// external sessions surface live instead of on the next slow poll.
+export type SystemEvent = { type: 'sessions-changed'; engine: 'claude' | 'codex' | 'kimi' };
 // PTY terminal protocol, streamed over /api/terminal/.../stream (SSE).
 // `history` is the FULL scrollback snapshot (client applies reset+write, so
 // replay on (re)connect is idempotent); `output` is an incremental chunk.

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -12,10 +12,11 @@ export type Workspace = {
 
 // Which agent engine produced this session. `claude` = claude-agent-sdk
 // jsonl under ~/.claude/projects. `codex` = @openai/codex-sdk rollout files
-// under ~/.codex/sessions. Both are grouped by cwd into the same
-// Workspace list; the tile UI dispatches to the appropriate backend
-// route based on this discriminator.
-export type SessionKind = 'claude' | 'codex';
+// under ~/.codex/sessions. `kimi` = Kimi Code wire.jsonl + state.json under
+// ~/.kimi-code/sessions. All are grouped by cwd into the same Workspace
+// list; the tile UI dispatches to the appropriate backend route based on
+// this discriminator.
+export type SessionKind = 'claude' | 'codex' | 'kimi';
 
 export type SessionListItem = {
   kind: SessionKind;
@@ -28,8 +29,8 @@ export type SessionListItem = {
   // Claude-owned jsonl). Takes display precedence over `preview` when set.
   label?: string;
   // Native/generated human-readable title. Claude reads ai-title/custom-title
-  // records; Codex uses its persisted generated title. The UI prefers it over
-  // `preview` when present.
+  // records; Codex uses its persisted generated title; Kimi reads state.json.
+  // The UI prefers it over `preview` when present.
   title?: string;
   messageCount: number;
   messageCountSuffix?: string;

--- a/site/app/lib/hosted-target.ts
+++ b/site/app/lib/hosted-target.ts
@@ -2,7 +2,8 @@
 // the same-origin hosted route that opens the WebUI we host under /app, plus a
 // one-time handoff carrying the server origin and token.
 //
-// Claude Code → /app (index.html), Codex → /app/codex (codex.html). The server
+// Claude Code → /app (index.html), Codex → /app/codex (codex.html), Kimi →
+// /app/kimi (kimi.html). The server
 // and token are deliberately NOT put on the URL: the connect page stashes the
 // handoff in sessionStorage and navigates to the clean route, so the credential
 // never lands in the document GET, the docs/CDN access logs, or referrers. The
@@ -10,9 +11,9 @@
 // binds the token to that server origin, and clears it. A crafted `/app?server=…`
 // URL is inert — only the same-tab handoff is trusted — so buildTarget's
 // scheme / self-origin / public-HTTP validation cannot be bypassed.
-export type Engine = 'claude' | 'codex';
+export type Engine = 'claude' | 'codex' | 'kimi';
 
-const ROUTE: Record<Engine, string> = { claude: '/app', codex: '/app/codex' };
+const ROUTE: Record<Engine, string> = { claude: '/app', codex: '/app/codex', kimi: '/app/kimi' };
 
 // sessionStorage key the docs connect page WRITES and the hosted SPA READS.
 // Must stay identical to HANDOFF_KEY in web/src/lib/apiBase.ts.

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -55,15 +55,15 @@ export default function Connect() {
           </p>
 
           <label className="block text-sm font-medium mb-1">Interface</label>
-          <div className="grid grid-cols-2 gap-2 mb-4">
-            {(['claude', 'codex'] as const).map((e) => (
+          <div className="grid grid-cols-3 gap-2 mb-4">
+            {(['claude', 'codex', 'kimi'] as const).map((e) => (
               <button
                 key={e}
                 type="button"
                 onClick={() => setEngine(e)}
                 className={`rounded-md border px-3 py-2 text-sm font-medium transition-colors ${engine === e ? 'border-fd-primary bg-fd-primary/10 text-fd-primary' : 'border-fd-border text-fd-muted-foreground hovered:bg-fd-accent'}`}
               >
-                {e === 'claude' ? 'Claude Code' : 'Codex'}
+                {e === 'claude' ? 'Claude Code' : e === 'codex' ? 'Codex' : 'Kimi Code'}
               </button>
             ))}
           </div>
@@ -78,7 +78,7 @@ export default function Connect() {
             autoFocus
           />
           <p className="text-xs text-fd-muted-foreground mb-4">
-            Local server defaults: Claude on <code>localhost:7878</code>, Codex on <code>localhost:7979</code>.
+            Local server defaults: Claude on <code>localhost:7878</code>, Codex on <code>localhost:7979</code>, Kimi on <code>localhost:7980</code>.
           </p>
 
           <label className="block text-sm font-medium mb-1">Access token <span className="text-fd-muted-foreground font-normal">(optional if the link already has one)</span></label>

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router';
 import { Check, Clipboard, MonitorPlay, MessagesSquare, SlidersHorizontal, Wand2, Puzzle, Terminal } from 'lucide-react';
 import ClaudeCode from '@lobehub/icons/es/ClaudeCode/components/Mono';
 import Codex from '@lobehub/icons/es/Codex/components/Mono';
+import Kimi from '@lobehub/icons/es/Kimi/components/Mono';
 import { baseOptions } from '@/lib/layout.shared';
 import ChatShowcase from '@/components/chat-showcase';
 
@@ -49,13 +50,14 @@ function Command({ code }: { code: string }) {
 export function meta({}: Route.MetaArgs) {
   return [
     { title: 'Macaron Artifacts' },
-    { name: 'description', content: 'The local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code and Codex.' },
+    { name: 'description', content: 'The local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code, Codex, and Kimi Code.' },
   ];
 }
 
 // pkg.pr.new ships prebuilt tarballs per commit; __COMMIT_SHA__ is injected at build time (falls back to `<sha>`).
 const PKG = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@${__COMMIT_SHA__}`;
 const PKG_MCX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@${__COMMIT_SHA__}`;
+const PKG_MKX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@${__COMMIT_SHA__}`;
 
 export default function Home() {
   return (
@@ -63,11 +65,11 @@ export default function Home() {
       <div className="flex flex-col items-center flex-1 px-4">
         <section className="flex flex-col items-center text-center max-w-2xl pt-20 pb-16">
           <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs text-fd-muted-foreground mb-6">
-            <Terminal className="size-3.5" /> Claude Code &amp; Codex
+            <Terminal className="size-3.5" /> Claude Code &amp; Codex &amp; Kimi Code
           </span>
           <h1 className="text-4xl sm:text-5xl font-bold tracking-tight mb-4">Macaron Artifacts</h1>
           <p className="text-fd-muted-foreground text-lg mb-8">
-            The local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code and Codex — visual
+            The local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code, Codex, and Kimi Code — visual
             sessions, live chat, and generated UI, straight from your terminal.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-3">
@@ -113,6 +115,9 @@ export default function Home() {
               <TabsTrigger value="codex" className="gap-2">
                 <Codex size={16} /> Codex
               </TabsTrigger>
+              <TabsTrigger value="kimi-code" className="gap-2">
+                <Kimi size={16} /> Kimi Code
+              </TabsTrigger>
             </TabsList>
             <Tab value="claude-code">
               <Steps>
@@ -153,13 +158,33 @@ export default function Home() {
                 </Step>
               </Steps>
             </Tab>
+            <Tab value="kimi-code">
+              <Steps>
+                <Step>
+                  <p className="font-medium">Install from GitHub</p>
+                  <Command code="/plugins install https://github.com/mindverse-ltd/macaron-artifacts" />
+                  <p className="text-sm text-fd-muted-foreground">
+                    Run it in a Kimi Code session, then <code className="text-fd-foreground">/reload</code> to activate.
+                  </p>
+                </Step>
+                <Step>
+                  <p className="font-medium">Run It and Open the WebUI</p>
+                  <Command code="/macaron:macaron" />
+                  <p className="text-sm text-fd-muted-foreground">
+                    The WebUI opens on{' '}
+                    <a className="text-fd-foreground underline underline-offset-4" href="http://localhost:7980">http://localhost:7980</a>.
+                  </p>
+                </Step>
+              </Steps>
+            </Tab>
           </Tabs>
 
           <div className="mt-8 mb-4 text-sm font-medium text-fd-muted-foreground">Run Without Installing</div>
           <p className="mb-3 text-sm text-fd-muted-foreground">
-            The <code className="text-fd-foreground">pkg.pr.new</code> tarball ships prebuilt bundles and two bins —{' '}
-            <code className="text-fd-foreground">mcc</code> (Claude, port 7878) and{' '}
-            <code className="text-fd-foreground">mcx</code> (Codex, port 7979). The commands are pinned to this
+            The <code className="text-fd-foreground">pkg.pr.new</code> tarball ships prebuilt bundles and three bins —{' '}
+            <code className="text-fd-foreground">mcc</code> (Claude, port 7878),{' '}
+            <code className="text-fd-foreground">mcx</code> (Codex, port 7979) and{' '}
+            <code className="text-fd-foreground">mkx</code> (Kimi, port 7980). The commands are pinned to this
             build's commit; swap in any other commit on <code className="text-fd-foreground">main</code> to pull that build.
           </p>
           <Tabs items={['bun', 'npm']}>
@@ -177,6 +202,12 @@ export default function Home() {
                   </div>
                   <Command code={`bunx mcx@${PKG_MCX}`} />
                 </div>
+                <div>
+                  <div className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+                    <Kimi size={15} /> Kimi — <code className="text-fd-muted-foreground">mkx</code>
+                  </div>
+                  <Command code={`bunx mkx@${PKG_MKX}`} />
+                </div>
               </div>
             </Tab>
             <Tab value="npm">
@@ -192,6 +223,12 @@ export default function Home() {
                     <Codex size={15} /> Codex — <code className="text-fd-muted-foreground">mcx</code>
                   </div>
                   <Command code={`npx mcx@${PKG_MCX}`} />
+                </div>
+                <div>
+                  <div className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+                    <Kimi size={15} /> Kimi — <code className="text-fd-muted-foreground">mkx</code>
+                  </div>
+                  <Command code={`npx mkx@${PKG_MKX}`} />
                 </div>
               </div>
             </Tab>
@@ -224,7 +261,7 @@ export default function Home() {
               The bundled skill lets supported agents produce GenUI TSX from the command line.
             </Card>
             <Card icon={<Puzzle />} title="Plugin Manifests" href="/docs">
-              Ship the manifests that register Macaron Artifacts with Claude Code and Codex.
+              Ship the manifests that register Macaron Artifacts with Claude Code, Codex, and Kimi Code.
             </Card>
           </Cards>
         </section>

--- a/site/content/docs/architecture/kimi.mdx
+++ b/site/content/docs/architecture/kimi.mdx
@@ -1,0 +1,73 @@
+---
+title: Kimi Variant
+description: How the same server binary boots a Kimi Code UI and drives Kimi Code CLI instead of Claude or Codex.
+---
+
+`mkx` is not a fork. It is the **same server and the same web build** as `mcc`, booted with `MACARON_ENGINE=kimi` so it serves the Kimi SPA and drives Kimi Code. This page covers what differs from the Claude path.
+
+## Three Launchers, One Server
+
+<Tabs items={['mcc (Claude)', 'mcx (Codex)', 'mkx (Kimi)']}>
+<Tab value="mcc (Claude)">
+
+`bin/mcc.mjs` parses `--host` / `--port`, defaults to port `7878`, then `import('../server/dist/index.js')`. No engine env means the server serves `index.html`.
+
+```bash
+mcc --port 7878
+# → Claude UI at http://localhost:7878
+```
+
+</Tab>
+<Tab value="mcx (Codex)">
+
+`mcx/bin/mcx.mjs` is the same launcher shape but defaults to port `7979` and ships as its **own self-contained package** — its own `server/dist` + `web/dist` + deps — so `npx mcx@…` installs only mcx, no mcc.
+
+```bash
+mcx --port 7979
+# → Codex UI at http://localhost:7979
+```
+
+</Tab>
+<Tab value="mkx (Kimi)">
+
+`mkx/bin/mkx.mjs` sets `MACARON_ENGINE=kimi`, defaults to port `7980`, and is likewise self-contained — `npx mkx@…` installs only mkx.
+
+```bash
+mkx --port 7980
+# → Kimi UI at http://localhost:7980
+```
+
+</Tab>
+</Tabs>
+
+Because the port defaults are offset (`7878` / `7979` / `7980`), all three can run at once — one browser tab per engine, against one machine.
+
+## Talking to Kimi Code
+
+The Claude path uses the Agent SDK in-process; the Codex path spawns `codex app-server`. The Kimi path spawns the **Kimi Code CLI** per turn (`server/src/lib/kimi-runner.ts`):
+
+```bash
+kimi -p "<prompt>" --output-format stream-json   # new session
+kimi -r session_<uuid> -p "<prompt>" --output-format stream-json   # resume
+```
+
+The child runs with `cwd` set to the session's working directory, in auto-permission mode (no TUI), and exits when the turn ends. Its stdout is one JSON object per line — assistant text, `tool_calls`, tool results — which the server maps onto the shared SSE contract (`session` / `delta` / `tool_use` / `tool_result` / `done`). Aborting a turn just kills the child process.
+
+Two quirks of the stream-json transport:
+
+- **No thinking, no usage.** The stream carries neither reasoning blocks nor token counts, so the Kimi side emits no reasoning events (usage, when shown, is read from `wire.jsonl`'s `step.end` records after the fact).
+- **Late session id.** For a brand-new session the `session_id` only appears in the final `session.resume_hint` meta line. The runner therefore snapshots the workDir's session bucket before spawn and diffs it as soon as output arrives, surfacing the id early; the meta line is the fallback.
+
+## Sessions on Disk
+
+Just as the Claude side reads `~/.claude/projects/**/*.jsonl`, the Kimi side reads `~/.kimi-code/sessions/<workDirKey>/<sessionId>/` (honoring `$KIMI_CODE_HOME`), where `workDirKey` is a per-working-directory bucket like `wd_macaron_28bca57c964e`. `~/.kimi-code/session_index.jsonl` maps `sessionId` → `sessionDir` + `workDir` for fast discovery; the store falls back to scanning the `sessions/wd_*/session_*` tree when the index is missing.
+
+Each session dir holds `state.json` (`title`, `createdAt`, `updatedAt`, `workDir`, …) and the transcript at `agents/main/wire.jsonl` (subagents under `agents/agent-*/wire.jsonl`). Titles come from `state.json`, falling back to a preview of the first user message while the title is still `New Session`.
+
+## Provider Configuration
+
+<Callout type="info">
+  By default the Kimi side runs the **`system` provider**, which inherits your ambient Kimi Code login — no setup needed to start. Custom providers added under **Settings** persist to `~/.kimi-code/macaron-kimi-config.json` and are injected at spawn time through the `KIMI_MODEL_*` env family (`KIMI_MODEL_NAME` / `KIMI_MODEL_API_KEY` / `KIMI_MODEL_BASE_URL` / `KIMI_MODEL_PROVIDER_TYPE`) — an in-memory provider, so your own Kimi Code config is never rewritten.
+</Callout>
+
+Next: how all three packages are [built and published](/docs/architecture/packaging).

--- a/site/content/docs/architecture/meta.json
+++ b/site/content/docs/architecture/meta.json
@@ -7,6 +7,7 @@
     "web",
     "genui",
     "codex",
+    "kimi",
     "packaging"
   ]
 }

--- a/site/content/docs/architecture/overview.mdx
+++ b/site/content/docs/architecture/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: Overview
-description: A tour of how Macaron Artifacts fits together — one server binary, two SPA entries, and a live GenUI renderer.
+description: A tour of how Macaron Artifacts fits together — one server binary, three SPA entries, and a live GenUI renderer.
 ---
 
-Macaron Artifacts is a local WebUI for driving agent sessions from the browser. Under the hood it is a small monorepo: a **Fastify server** that fronts the Claude Agent SDK and Codex (via the `codex app-server` transport by default), a **React SPA** that renders sessions and streams turns, and a **shared** package that pins the wire contract between them. This section walks the whole system top to bottom.
+Macaron Artifacts is a local WebUI for driving agent sessions from the browser. Under the hood it is a small monorepo: a **Fastify server** that fronts the Claude Agent SDK, Codex (via the `codex app-server` transport by default), and the Kimi Code CLI, a **React SPA** that renders sessions and streams turns, and a **shared** package that pins the wire contract between them. This section walks the whole system top to bottom.
 
 <Callout title="Who this is for">
-  These pages document the *implementation*, not day-to-day usage. If you just want to install and run the WebUI, start with [Usage](/docs/usage). Come here when you want to understand how a turn flows from the browser to the SDK and back, or how the two engines share one binary.
+  These pages document the *implementation*, not day-to-day usage. If you just want to install and run the WebUI, start with [Usage](/docs/usage). Come here when you want to understand how a turn flows from the browser to the SDK and back, or how the three engines share one binary.
 </Callout>
 
 ## The Monorepo
@@ -23,6 +23,7 @@ Macaron Artifacts is a local WebUI for driving agent sessions from the browser. 
       <Folder name="src/lib">
         <File name="claude-runner.ts" />
         <File name="codex-app-server.ts" />
+        <File name="kimi-runner.ts" />
         <File name="session-store.ts" />
         <File name="codex-store.ts" />
       </Folder>
@@ -30,11 +31,13 @@ Macaron Artifacts is a local WebUI for driving agent sessions from the browser. 
         <File name="sessions.ts" />
         <File name="relay.ts" />
         <File name="codex.ts" />
+        <File name="kimi.ts" />
       </Folder>
     </Folder>
     <Folder name="web">
       <File name="index.html" />
       <File name="codex.html" />
+      <File name="kimi.html" />
       <Folder name="src">
         <File name="main.tsx" />
         <Folder name="macaron-vendor" />
@@ -46,15 +49,18 @@ Macaron Artifacts is a local WebUI for driving agent sessions from the browser. 
     <Folder name="mcx">
       <File name="bin/mcx.mjs" />
     </Folder>
+    <Folder name="mkx">
+      <File name="bin/mkx.mjs" />
+    </Folder>
   </Folder>
 </Files>
 
 - **shared** — `types.ts` holds the REST + domain types, `sse.ts` the streaming contract.
-- **server** — `index.ts` is the Fastify bootstrap, `config.ts` the ports / hosts / derived paths. Under `src/lib`, `claude-runner.ts` drives the Claude Agent SDK loop, `codex-app-server.ts` is the Codex app-server client, `session-store.ts` reads `~/.claude` transcripts and `codex-store.ts` reads `~/.codex` rollouts. `src/routes` mounts the API slices — most under `/api/*` (sessions, codex, …), plus the provider relay at `/relay/*`.
-- **web** — `index.html` is the Claude SPA entry and `codex.html` the Codex one; `src/main.tsx` bootstraps the router + GenUI runtime, `src/macaron-vendor/` is the vendored GenUI renderer.
-- **bin / mcx** — `mcc.mjs` is the Claude launcher; the `mcx` member ships its own `bin/mcx.mjs` Codex launcher.
+- **server** — `index.ts` is the Fastify bootstrap, `config.ts` the ports / hosts / derived paths. Under `src/lib`, `claude-runner.ts` drives the Claude Agent SDK loop, `codex-app-server.ts` is the Codex app-server client, `kimi-runner.ts` spawns the Kimi Code CLI per turn, `session-store.ts` reads `~/.claude` transcripts and `codex-store.ts` reads `~/.codex` rollouts. `src/routes` mounts the API slices — most under `/api/*` (sessions, codex, kimi, …), plus the provider relay at `/relay/*`.
+- **web** — `index.html` is the Claude SPA entry, `codex.html` the Codex one, and `kimi.html` the Kimi one; `src/main.tsx` bootstraps the router + GenUI runtime, `src/macaron-vendor/` is the vendored GenUI renderer.
+- **bin / mcx / mkx** — `mcc.mjs` is the Claude launcher; the `mcx` and `mkx` members each ship their own self-contained Codex / Kimi launcher.
 
-The workspace (`pnpm-workspace.yaml`) has four members: `shared`, `server`, `web`, and `mcx`. The root package is published as **`mcc`** (the Claude launcher); **`mcx`** is a second, self-contained package that ships its own copy of the built server and web bundles.
+The workspace (`pnpm-workspace.yaml`) has five members: `shared`, `server`, `web`, `mcx`, and `mkx`. The root package is published as **`mcc`** (the Claude launcher); **`mcx`** and **`mkx`** are self-contained packages that ship their own copy of the built server and web bundles.
 
 ## The Big Picture
 
@@ -72,21 +78,24 @@ Three layers, one data contract. The **shared** package sits between the other t
   </Card>
 </Cards>
 
-The Web layer has two entries that boot from the same server: the Claude UI and the Codex UI. Two cross-cutting concerns span both:
+The Web layer has three entries that boot from the same server: the Claude UI, the Codex UI, and the Kimi UI. Three cross-cutting concerns span them:
 
 <Cards>
   <Card title="Codex Variant" href="/docs/architecture/codex">
     How the same server binary boots a second SPA and drives Codex (default `codex app-server` transport) instead of Claude.
   </Card>
+  <Card title="Kimi Variant" href="/docs/architecture/kimi">
+    How the same binary boots the Kimi SPA and drives the Kimi Code CLI (`kimi -p --output-format stream-json`).
+  </Card>
   <Card title="GenUI" href="/docs/architecture/genui">
     The `render_ui` tool + vendored renderer that compile model-authored TSX to a live component as tokens stream.
   </Card>
   <Card title="Packaging" href="/docs/architecture/packaging">
-    Two publishable launchers, prebuilt bundles, and the pkg.pr.new per-commit release flow.
+    Three publishable launchers, prebuilt bundles, and the pkg.pr.new per-commit release flow.
   </Card>
 </Cards>
 
-## One Binary, Two Front Ends
+## One Binary, Three Front Ends
 
 The single most important design choice: **there is exactly one server binary**, and an environment variable decides which SPA it serves at `/`.
 
@@ -94,22 +103,22 @@ The single most important design choice: **there is exactly one server binary**,
 <Step>
 ### Launch picks the engine
 
-`mcc` runs with the default engine (Claude, port `7878`); `mcx` sets `MACARON_ENGINE=codex` and defaults to port `7979`. Both `import('../server/dist/index.js')` — the same compiled server.
+`mcc` runs with the default engine (Claude, port `7878`); `mcx` sets `MACARON_ENGINE=codex` and defaults to port `7979`; `mkx` sets `MACARON_ENGINE=kimi` and defaults to port `7980`. All three `import('../server/dist/index.js')` — the same compiled server.
 </Step>
 <Step>
 ### The server chooses an SPA entry
 
-At boot the server reads `MACARON_ENGINE` and picks `codex.html` or `index.html` as the `/` document and the SPA fallback. Static assets (JS/CSS chunks) are shared between both entries.
+At boot the server reads `MACARON_ENGINE` and picks `codex.html`, `kimi.html`, or `index.html` as the `/` document and the SPA fallback. Static assets (JS/CSS chunks) are shared between the entries.
 
 ```ts
-const spaEntry = process.env.MACARON_ENGINE === 'codex' ? 'codex.html' : 'index.html';
+const spaEntry = process.env.MACARON_ENGINE === 'codex' ? 'codex.html' : process.env.MACARON_ENGINE === 'kimi' ? 'kimi.html' : 'index.html';
 app.get('/', (_req, reply) => reply.sendFile(spaEntry));
 ```
 </Step>
 <Step>
 ### The browser loads one runtime
 
-Each HTML entry boots its own React tree — the Claude UI or the ChatGPT-style Codex UI — but both talk to the same `/api/*` surface and the same SSE contract.
+Each HTML entry boots its own React tree — the Claude UI, the ChatGPT-style Codex UI, or the Kimi UI — talking to its engine's `/api/*` namespace over the same SSE contract.
 </Step>
 </Steps>
 

--- a/site/content/docs/architecture/packaging.mdx
+++ b/site/content/docs/architecture/packaging.mdx
@@ -1,13 +1,13 @@
 ---
 title: Packaging
-description: Two publishable launchers, prebuilt bundles, the plugin manifests, and the pkg.pr.new per-commit release flow.
+description: Three publishable launchers, prebuilt bundles, the plugin manifests, and the pkg.pr.new per-commit release flow.
 ---
 
-Macaron Artifacts ships in three shapes from one repo: as **plugin manifests** for Claude Code and Codex, as two **npm-runnable launchers** (`mcc` / `mcx`), and as **prebuilt tarballs** published per commit by pkg.pr.new. This page covers how the builds and releases are wired.
+Macaron Artifacts ships in three shapes from one repo: as **plugin manifests** for Claude Code, Codex, and Kimi Code, as three **npm-runnable launchers** (`mcc` / `mcx` / `mkx`), and as **prebuilt tarballs** published per commit by pkg.pr.new. This page covers how the builds and releases are wired.
 
-## Two Packages
+## Three Packages
 
-<Tabs items={['mcc (root)', 'mcx']}>
+<Tabs items={['mcc (root)', 'mcx', 'mkx']}>
 <Tab value="mcc (root)">
 
 The repo root **is** the `mcc` package. Its `bin` is `./bin/mcc.mjs`, and `files` ships only the launcher, the bundled `server/dist/index.js`, `web/dist`, and the README. A `prepack` hook builds everything before publish:
@@ -26,22 +26,31 @@ The repo root **is** the `mcc` package. Its `bin` is `./bin/mcc.mjs`, and `files
 ```
 
 </Tab>
+<Tab value="mkx">
+
+`mkx/package.json` mirrors `mcx` exactly — bin `./bin/mkx.mjs`, same `prepack` + `scripts/stage.mjs` staging, same self-contained tarball. Only the launcher name, default port (`7980`), and `MACARON_ENGINE=kimi` differ.
+
+```json
+"prepack": "pnpm -w prepack && node scripts/stage.mjs"
+```
+
+</Tab>
 </Tabs>
 
-Both declare `engines.node >= 22` and externalize every npm dep (`bun build --packages=external`), so the server bundle stays small. The **server** imports `@macaron/shared` for types only, so it never reaches the runtime bundle; the **web** side does pull a few real runtime values from it (e.g. the `SEARCH_HL_OPEN` / `SEARCH_HL_CLOSE` highlight markers), so there the dependency is not type-only.
+All three declare `engines.node >= 22` and externalize every npm dep (`bun build --packages=external`), so the server bundle stays small. The **server** imports `@macaron/shared` for types only, so it never reaches the runtime bundle; the **web** side does pull a few real runtime values from it (e.g. the `SEARCH_HL_OPEN` / `SEARCH_HL_CLOSE` highlight markers), so there the dependency is not type-only.
 
 ## Per-Commit Releases
 
-`.github/workflows/pkg-pr-new.yml` publishes on every push to `main` and every PR. It runs the pinned binary from the lockfile (not a dlx-style unpinned fetch) and publishes **both** packages in one shot:
+`.github/workflows/pkg-pr-new.yml` publishes on every push to `main` and every PR. It runs the pinned binary from the lockfile (not a dlx-style unpinned fetch) and publishes **all three** packages in one shot:
 
 ```bash
-pnpm exec pkg-pr-new publish --no-compact --bin . ./mcx
+pnpm exec pkg-pr-new publish --no-compact --bin . ./mcx ./mkx
 ```
 
-`npm pack` fires each package's `prepack` hook, so both tarballs ship prebuilt `server/dist` + `web/dist` and run without Vite at runtime. The published URLs are pinned to the commit:
+`npm pack` fires each package's `prepack` hook, so the tarballs ship prebuilt `server/dist` + `web/dist` and run without Vite at runtime. The published URLs are pinned to the commit:
 
 <Callout title="This is what the install page links to">
-  The [Usage](/docs/usage) page's `bunx mcc@…` / `bunx mcx@…` commands carry a `<sha>` placeholder that a build-time remark plugin (`remarkCommitSha`) rewrites to the build commit's short SHA — pulled from `VERCEL_GIT_COMMIT_SHA` / `GITHUB_SHA`, or `git rev-parse` locally. When none is available (e.g. a shallow copy or a deploy without the commit env wired in), it leaves the literal `<sha>` in place rather than guessing. So the pin is only as precise as the environment the docs were built in.
+  The [Usage](/docs/usage) page's `bunx mcc@…` / `bunx mcx@…` / `bunx mkx@…` commands carry a `<sha>` placeholder that a build-time remark plugin (`remarkCommitSha`) rewrites to the build commit's short SHA — pulled from `VERCEL_GIT_COMMIT_SHA` / `GITHUB_SHA`, or `git rev-parse` locally. When none is available (e.g. a shallow copy or a deploy without the commit env wired in), it leaves the literal `<sha>` in place rather than guessing. So the pin is only as precise as the environment the docs were built in.
 </Callout>
 
 ## The Plugin Manifests
@@ -56,13 +65,19 @@ For agents that install Macaron as a plugin rather than running a tarball:
   <Folder name=".codex-plugin" defaultOpen>
     <File name="plugin.json" />
   </Folder>
+  <Folder name=".kimi-plugin" defaultOpen>
+    <File name="plugin.json" />
+  </Folder>
   <Folder name="commands">
+    <File name="macaron.md" />
+  </Folder>
+  <Folder name="commands-kimi">
     <File name="macaron.md" />
   </Folder>
   <File name="start.sh" />
 </Files>
 
-`.claude-plugin/plugin.json` carries the name / description / keywords and `marketplace.json` registers the plugin source; `.codex-plugin/plugin.json` is the Codex-side manifest. `commands/macaron.md` defines the `/macaron` slash command, and `start.sh` installs, builds, and launches on first run.
+`.claude-plugin/plugin.json` carries the name / description / keywords and `marketplace.json` registers the plugin source; `.codex-plugin/plugin.json` and `.kimi-plugin/plugin.json` are the Codex-side and Kimi-side manifests. `commands/macaron.md` defines the `/macaron` slash command, `commands-kimi/macaron.md` the Kimi-side `/macaron:macaron`, and `start.sh` installs, builds, and launches on first run.
 
 The `/macaron` command runs `start.sh`, which is the interesting piece:
 
@@ -80,7 +95,7 @@ It uses **pnpm via corepack** (ships with Node 22+), installs with `--frozen-loc
 <Step>
 ### Launch on the right port
 
-The engine (`claude` / `codex`) picks the default port (`7878` / `7979`); if `lsof` is available, any prior process on that port is killed first, then the server boots. Most setup failures (missing Node 22, a broken install) print an actionable `[macaron] fix: …` line to stderr so the launching agent can self-repair and retry — though not every path does (e.g. the post-launch health-check probe just times out).
+The engine (`claude` / `codex` / `kimi`) picks the default port (`7878` / `7979` / `7980`); if `lsof` is available, any prior process on that port is killed first, then the server boots. Most setup failures (missing Node 22, a broken install) print an actionable `[macaron] fix: …` line to stderr so the launching agent can self-repair and retry — though not every path does (e.g. the post-launch health-check probe just times out).
 </Step>
 </Steps>
 
@@ -88,4 +103,4 @@ The engine (`claude` / `codex`) picks the default port (`7878` / `7979`); if `ls
   The plugin ships as **source, not prebuilt** `dist/`. Every commit rebuilding `server/dist` + `web/dist` produced unresolvable rebase conflicts across concurrent PRs, so the build was moved to first-launch instead.
 </Callout>
 
-That's the full loop — from a commit on `main`, to a pkg.pr.new tarball or an installed plugin, to a running server that boots one of two SPAs. Back to the [Overview](/docs/architecture/overview).
+That's the full loop — from a commit on `main`, to a pkg.pr.new tarball or an installed plugin, to a running server that boots one of three SPAs. Back to the [Overview](/docs/architecture/overview).

--- a/site/content/docs/architecture/server.mdx
+++ b/site/content/docs/architecture/server.mdx
@@ -11,12 +11,12 @@ The core tunables (port, host, auth token, default model) live in `server/src/co
 
 | name | source | default | meaning |
 | --- | --- | --- | --- |
-| `PORT` | `MACARON_PORT` | `7878` | Listen port — Claude default; mcx uses `7979`. |
+| `PORT` | `MACARON_PORT` | `7878` | Listen port — Claude default; mcx uses `7979`, mkx uses `7980`. |
 | `HOST` | `MACARON_HOST` | `127.0.0.1` | Bind address. A non-loopback host auto-arms auth. |
 | `AUTH_TOKEN` | `MACARON_AUTH_TOKEN` | `""` | Shared token gating the API when reachable off-box. |
 | `MACARON_MODEL` | `MACARON_MODEL` | `macaron-0.6` | Default model id for the Macaron provider. |
 
-`CLAUDE_PROJECTS` (`~/.claude/projects`) and `CODEX_SESSIONS` (`~/.codex/sessions`) are **not** environment tunables — they are fixed paths derived from `$HOME` in `config.ts`, pointing at where Claude Code and Codex already write their transcripts and rollouts. The store layer reads them; nothing overrides them.
+`CLAUDE_PROJECTS` (`~/.claude/projects`) and `CODEX_SESSIONS` (`~/.codex/sessions`) are **not** environment tunables — they are fixed paths derived from `$HOME` in `config.ts`, pointing at where Claude Code and Codex already write their transcripts and rollouts. `KIMI_SESSIONS` (`~/.kimi-code/sessions`) works the same way, except its root honors `$KIMI_CODE_HOME` like the Kimi CLI itself. The store layer reads them; nothing overrides them.
 
 ## Boot Sequence
 
@@ -96,6 +96,6 @@ A separate `SystemEvent` stream (`GET /api/events`) pushes a debounced `sessions
 
 ## Reading Sessions From Disk
 
-The WebUI does not own a database. `session-store.ts` reads the JSONL transcripts Claude Code already writes under `~/.claude/projects/**/*.jsonl`, while `codex-store.ts` parses the Codex rollouts under `~/.codex/sessions/**`; both project into the shared session/turn types, and a `session-watcher` tails the trees for changes. This is why the WebUI shows sessions you started outside the browser.
+The WebUI does not own a database. `session-store.ts` reads the JSONL transcripts Claude Code already writes under `~/.claude/projects/**/*.jsonl`, `codex-store.ts` parses the Codex rollouts under `~/.codex/sessions/**`, and `kimi-store.ts` reads the Kimi Code `wire.jsonl` + `state.json` under `~/.kimi-code/sessions/**` (via `session_index.jsonl` when present); all three project into the shared session/turn types, and a `session-watcher` tails the trees for changes. This is why the WebUI shows sessions you started outside the browser.
 
 Next: the [web front end](/docs/architecture/web).

--- a/site/content/docs/architecture/web.mdx
+++ b/site/content/docs/architecture/web.mdx
@@ -24,7 +24,7 @@ The server picks which one is `/` at boot (see [Overview](/docs/architecture/ove
 
 ## Runtime Bootstrap
 
-The two entries bootstrap GenUI differently. The **Claude** entry (`web/src/main.tsx`) stands up the whole GenUI runtime *before* the app renders — model-authored TSX previews are core to that UI, so the globals must exist up front. The **Codex** entry (`web/src/codex/main.tsx`) deliberately does not: it stays a small chat-focused bundle and **lazy-loads** the GenUI runtime (`React.lazy` + `Suspense` in `CodexChat.tsx`, ~500 KB gzip) only when a `render_ui` card actually needs to render.
+The three entries bootstrap GenUI differently. The **Claude** entry (`web/src/main.tsx`) stands up the whole GenUI runtime *before* the app renders — model-authored TSX previews are core to that UI, so the globals must exist up front. The **Codex** and **Kimi** entries (`web/src/codex/main.tsx`, `web/src/kimi/main.tsx`) deliberately do not: they stay small chat-focused bundles and **lazy-load** the GenUI runtime (`React.lazy` + `Suspense` in their chat views, ~500 KB gzip) only when a `render_ui` card actually needs to render.
 
 The steps below describe the Claude bootstrap:
 

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: Macaron Artifacts — the local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code and Codex.
+description: Macaron Artifacts — the local WebUI, GenUI tooling, and plugin manifests for running Macaron with Claude Code, Codex, and Kimi Code.
 ---
 
-**Macaron Artifacts** publishes the plugin manifests, local WebUI runtime, GenUI tooling, and docs for running Macaron with Claude Code and Codex.
+**Macaron Artifacts** publishes the plugin manifests, local WebUI runtime, GenUI tooling, and docs for running Macaron with Claude Code, Codex, and Kimi Code.
 
 ## What You Get
 

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -1,12 +1,13 @@
 ---
 title: Usage
-description: Install the Macaron WebUI on Claude Code and Codex, open it, and drive sessions from the browser.
+description: Install the Macaron WebUI on Claude Code, Codex, and Kimi Code, open it, and drive sessions from the browser.
 ---
 
-A WebUI that installs on both Claude Code and Codex — run both at once. After install, launch it from the CLI with one line:
+A WebUI that installs on Claude Code, Codex, and Kimi Code — run all three at once. After install, launch it from the CLI with one line:
 
 - Claude → [http://localhost:7878](http://localhost:7878)
 - Codex → [http://localhost:7979](http://localhost:7979)
+- Kimi → [http://localhost:7980](http://localhost:7980)
 
 ## Install
 
@@ -28,19 +29,30 @@ codex plugin add macaron@macaron
 
 Then say `open macaron web ui` in a session to open it.
 
+### Kimi Code
+
+```
+/plugins install https://github.com/MindLab-Research/macaron-artifacts
+/reload
+```
+
+Then open it in a session with `/macaron:macaron`.
+
 ### Without Installing the Plugin — One `bunx` Line
 
-The published tarball ships the prebuilt server + web bundles as two independent packages — `mcc` (Claude WebUI, port `7878`) and `mcx` (Codex WebUI, port `7979`). Launch either in one command:
+The published tarball ships the prebuilt server + web bundles as three independent packages — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Launch any of them in one command:
 
 ```bash
 bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
 bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mkx@<sha>   # Kimi   → http://localhost:7980
 
 npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>    # Claude → http://localhost:7878
 npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
-The commands are pinned to this build's commit; swap in any other commit on `main` to pull that build. Both bins accept `--host` / `--port`; run `--help` for all flags.
+The commands are pinned to this build's commit; swap in any other commit on `main` to pull that build. Each launcher boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run `--help` for all flags.
 
 ## Using It
 
@@ -50,7 +62,7 @@ Once inside the WebUI:
 - On the canvas: drag the grip to reposition, pull the bottom-right corner to resize, click a tile to focus
 - Input box: `Enter` sends · `Shift+Enter` for a newline · `↑`/`↓` cycles history · paste an image to attach it
 
-The Codex side works out of the box: by default it uses the `system` provider, which inherits your `~/.codex/config.toml` (endpoint, model, auth). Filling in a custom Base URL / API Key / Model under **Settings** is optional — only needed to point Codex at a different provider.
+The Codex side works out of the box: by default it uses the `system` provider, which inherits your `~/.codex/config.toml` (endpoint, model, auth). Filling in a custom Base URL / API Key / Model under **Settings** is optional — only needed to point Codex at a different provider. The Kimi side likewise defaults to your ambient Kimi Code login; custom providers set under **Settings** persist to `~/.kimi-code/macaron-kimi-config.json`.
 
 ## Updating
 
@@ -67,6 +79,10 @@ codex plugin marketplace upgrade macaron   # pull the latest version
 codex plugin remove macaron@macaron
 codex plugin add macaron@macaron           # reinstall
 ```
+
+### Kimi Code
+
+Open `/plugins`, select `macaron` on the **Installed** tab, and press `Enter` to install the available update — then `/reload`.
 
 ## Feedback
 

--- a/site/host-webui.mjs
+++ b/site/host-webui.mjs
@@ -4,9 +4,10 @@
 //
 // It reuses /web's existing vite build verbatim (no source fork): the only
 // override is `--base=/app/`, which rewrites every asset URL to /app/assets/*.
-// Both SPA entries ship: index.html (Claude Code) and codex.html (Codex). Their
-// hash router keeps deep links inside the '#' fragment, so no server-side SPA
-// fallback is needed under /app — the two static HTML files are enough.
+// All three SPA entries ship: index.html (Claude Code), codex.html (Codex) and
+// kimi.html (Kimi). Their hash router keeps deep links inside the '#' fragment,
+// so no server-side SPA fallback is needed under /app — the static HTML files
+// are enough.
 //
 // Run after `react-router build`: the docs client lands in build/client, then
 // we drop web/dist alongside it at build/client/app.
@@ -38,10 +39,10 @@ execFileSync('pnpm', ['--filter', '@macaron/shared', 'build'], { cwd: repoRoot, 
 console.log('[host-webui] building /web with base=/app/ into dist-app …');
 execFileSync('pnpm', ['exec', 'vite', 'build', '--base=/app/', '--outDir=dist-app', '--emptyOutDir'], { cwd: webDir, stdio: 'inherit' });
 
-if (!existsSync(path.join(webDistApp, 'index.html')) || !existsSync(path.join(webDistApp, 'codex.html'))) {
-  throw new Error('[host-webui] web/dist-app is missing index.html or codex.html after build');
+if (!existsSync(path.join(webDistApp, 'index.html')) || !existsSync(path.join(webDistApp, 'codex.html')) || !existsSync(path.join(webDistApp, 'kimi.html'))) {
+  throw new Error('[host-webui] web/dist-app is missing index.html, codex.html or kimi.html after build');
 }
 
 if (existsSync(target)) rmSync(target, { recursive: true });
 cpSync(webDistApp, target, { recursive: true });
-console.log(`[host-webui] staged WebUI at ${path.relative(repoRoot, target)} (Claude Code: /app, Codex: /app/codex)`);
+console.log(`[host-webui] staged WebUI at ${path.relative(repoRoot, target)} (Claude Code: /app, Codex: /app/codex, Kimi: /app/kimi)`);

--- a/skills/macaron-webui-kimi/SKILL.md
+++ b/skills/macaron-webui-kimi/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: macaron-webui-kimi
+description: "Launch the Macaron WebUI — a browser-based session manager and GenUI preview for Kimi Code, backed by ~/.kimi-code/sessions/. Use when the user says any of 'open macaron', 'launch macaron', '@macaron', 'macaron webui', 'macaron web ui', 'open macaron web ui', 'open the macaron web ui', 'macaron ui', '打开 macaron', '打开 macaron web ui', '启动 macaron', or asks to browse / continue / preview Kimi Code sessions in a visual UI. 'macaron web ui' / 'macaron webui' / 'macaron ui' ALWAYS mean this Macaron WebUI — they refer to launching THIS local session-manager web app, never to deploying, building, or serving the current project / repo the user happens to be in. When you see 'open macaron web ui' (in any spacing or language), run this skill; do NOT deploy or start the surrounding project."
+---
+
+# Macaron WebUI (Kimi Code)
+
+Use this skill when the user wants to open the Macaron WebUI — a local browser app that lists Kimi Code workspaces + sessions from `~/.kimi-code/sessions/`, lets them continue any turn, and streams GenUI TSX previews.
+
+**"macaron web ui" is a proper noun, not a task.** Phrases like "open macaron web ui" / "打开 macaron web ui" / "launch the macaron ui" always mean *launch this WebUI*. They do NOT mean "deploy the current project", "build the repo I'm in", or "start a dev server for the surrounding codebase" — regardless of what project the user currently has open. If you're tempted to deploy or serve the current directory in response to one of these phrases, that's the misread this skill exists to prevent: run the bootstrap below instead.
+
+## Resolving the plugin root
+
+Resolve the plugin root from this `SKILL.md` file by going two directories up from `skills/macaron-webui-kimi/`. The launcher script is at `<plugin root>/start.sh`.
+
+## Bootstrap
+
+Run this exactly once. Two env vars matter:
+
+- `MACARON_ENGINE=kimi` — flips the SPA served at `/` from the Claude-focused UI to the Kimi-focused one. **Never omit this.** Without it the user sees the Claude Code UI, not Kimi Code.
+- `MACARON_FOREGROUND=1` — makes `start.sh` `exec node` into the foreground instead of nohup-backgrounding. Backgrounded children get killed when the outer script returns inside your shell tool, so the server would disappear seconds after launch. Foreground keeps the process anchored to the tool session and the URL is printed asynchronously before `exec` blocks.
+
+```bash
+MACARON_ENGINE=kimi MACARON_FOREGROUND=1 MACARON_PORT=7980 bash "<plugin root>/start.sh"
+```
+
+Port `7980` is the Kimi-side default so it doesn't collide with the Claude Code plugin (which uses `7878`) or the Codex plugin (`7979`). All three can run at once. If 7980 is busy, tell the user to override with `MACARON_PORT=<n>`.
+
+The script:
+- **Mirrors itself out of the plugin cache on first launch.** `~/.kimi-code/plugins/managed/…` is not a stable working directory — the host can prune it on version sync, which erases `node_modules` + `web/dist` + `server/dist` while any surviving server still listens on 7980 and returns 404s. `start.sh` detects the cache path and rsyncs source into `~/.macaron/runtime/<version>/`, then installs/builds/runs from there. Subsequent launches re-rsync (fast) and reuse the same stable runtime.
+- Uses `corepack pnpm` (Node 22+ ships corepack) to install workspace deps + build on first launch (~60s). If frozen install fails, it retries without the lock. If build fails, it prints a `[macaron] fix: <command>` line — run the printed command and retry.
+- Skips the install/build on subsequent launches if `node_modules` is present and no source file is newer than the current build.
+- Frees the port if a stale `mkx` / `mcx` / `mcc` is bound (`lsof` → `kill`).
+- Prints `Macaron WebUI (engine=kimi): http://localhost:7980` once `/api/health` answers, THEN blocks on `exec node`.
+- Stays in the foreground indefinitely. This is expected — do NOT kill it after launch. The shell tool can move on while this shell keeps the server alive.
+
+Once the URL line prints, open the browser:
+
+```bash
+open "http://localhost:7980"
+```
+
+Quote the URL verbatim so the user can click it directly. If `open` fails in a sandbox (`kLSExecutableIncorrectFormat`), tell the user to paste the URL into their browser.
+
+## What the user sees
+
+- **Dashboard** — every workspace under `~/.kimi-code/sessions/` sorted by last activity.
+- **Workspace** — one project's sessions as tiles on a canvas; pin, reorder, resize, and continue any turn.
+- **Session** — full transcript with tool calls and live GenUI TSX previews.
+- **Settings** — pick the active model/provider (ambient Kimi login, Macaron, or any Kimi / Anthropic / OpenAI-compatible endpoint).
+
+## Notes for the model
+
+- Do NOT run `mkx` / `mcx` / `mcc` directly — always go through `start.sh` so the port-collision handler and env plumbing (especially `MACARON_ENGINE=kimi`) both apply.
+- The Codex and Claude Code flavors of this launcher are separate skills (`macaron-webui` and the Claude plugin's launcher) — this skill is only for Kimi Code sessions.
+- If the port is busy AND the script fails to reclaim it: report the failure verbatim and ask the user for a free port (`MACARON_PORT=<n>`).
+- If `start.sh` errors on install or build: it prints one or more `[macaron] fix: <command>` lines on stderr. Run each printed fix in order, then rerun `start.sh`. Report what happened.
+- The WebUI binds to `127.0.0.1:${port}` — nothing leaves the user's machine.
+- Stop the server with Ctrl-C in the shell that spawned it, or `lsof -ti tcp:${port} | xargs kill`.

--- a/start.sh
+++ b/start.sh
@@ -24,13 +24,14 @@ SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Codex plugin cache (~/.codex/plugins/cache/…) is NOT a stable working dir:
 # Codex prunes/regenerates it on version sync, killing our node_modules +
 # web/dist + server/dist and leaving a listening server pointing at
-# nothing. Claude Code plugin cache (~/.claude/plugins/cache/…) has the
-# same class of behavior. Detect either and rsync source into a stable
+# nothing. Claude Code (~/.claude/plugins/cache/…) and Kimi Code
+# (~/.kimi-code/plugins/cache/…) caches have the same class of behavior.
+# Detect any of them and rsync source into a stable
 # runtime dir under $HOME, then run install/build/launch from there.
 DIR="$SRC_DIR"
 _needs_mirror=0
 case "$SRC_DIR" in
-  *"/.codex/plugins/cache/"*|*"/.claude/plugins/cache/"*) _needs_mirror=1 ;;
+  *"/.codex/plugins/cache/"*|*"/.claude/plugins/cache/"*|*"/.kimi-code/plugins/cache/"*) _needs_mirror=1 ;;
 esac
 if [ "$_needs_mirror" = 1 ]; then
   # Version key: pull from package.json so parallel major bumps get
@@ -88,11 +89,11 @@ fi
 [ -n "$_CALLER_FOREGROUND" ] && MACARON_FOREGROUND="$_CALLER_FOREGROUND"
 
 ENGINE="${MACARON_ENGINE:-claude}"
-if [ "$ENGINE" = "codex" ]; then
-  PORT="${MACARON_PORT:-7979}"
-else
-  PORT="${MACARON_PORT:-7878}"
-fi
+case "$ENGINE" in
+  codex) PORT="${MACARON_PORT:-7979}" ;;
+  kimi)  PORT="${MACARON_PORT:-7980}" ;;
+  *)     PORT="${MACARON_PORT:-7878}" ;;
+esac
 FOREGROUND="${MACARON_FOREGROUND:-0}"
 
 WEB_DIST="$DIR/web/dist"

--- a/start.sh
+++ b/start.sh
@@ -174,6 +174,16 @@ elif [ -n "$(find "$DIR/web/src" "$DIR/server/src" "$DIR/shared/src" \
   needs_build=1
 fi
 
+# A `pnpm bundle` / prepack run leaves dist/index.js as a self-contained bun
+# bundle that inlines server sources. tsc's incremental build only re-emits
+# changed files and never overwrites that entry, so a stale bundle would be
+# served forever ("build succeeded" but nothing changed). Detect the bundle
+# marker (__require shim) and force a full tsc re-emit.
+if grep -q '__require' "$SERVER_DIST" 2>/dev/null; then
+  rm -f "$DIR/server/tsconfig.tsbuildinfo"
+  needs_build=1
+fi
+
 if [ "$needs_build" = 1 ]; then
   echo "[macaron] building (~30s)…" >&2
   if ! (cd "$DIR" && "$_PNPM" run build 2>&1); then

--- a/start.sh
+++ b/start.sh
@@ -25,13 +25,14 @@ SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Codex prunes/regenerates it on version sync, killing our node_modules +
 # web/dist + server/dist and leaving a listening server pointing at
 # nothing. Claude Code (~/.claude/plugins/cache/…) and Kimi Code
-# (~/.kimi-code/plugins/cache/…) caches have the same class of behavior.
+# (~/.kimi-code/plugins/… — installs run from a managed copy that gets
+# replaced on plugin update) have the same class of behavior.
 # Detect any of them and rsync source into a stable
 # runtime dir under $HOME, then run install/build/launch from there.
 DIR="$SRC_DIR"
 _needs_mirror=0
 case "$SRC_DIR" in
-  *"/.codex/plugins/cache/"*|*"/.claude/plugins/cache/"*|*"/.kimi-code/plugins/cache/"*) _needs_mirror=1 ;;
+  *"/.codex/plugins/cache/"*|*"/.claude/plugins/cache/"*|*"/.kimi-code/plugins/"*) _needs_mirror=1 ;;
 esac
 if [ "$_needs_mirror" = 1 ]; then
   # Version key: pull from package.json so parallel major bumps get

--- a/web/kimi.html
+++ b/web/kimi.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Macaron Artifacts · Kimi</title>
+    <link rel="icon" type="image/svg+xml" href="/mindlab-symbol.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#C96442" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Macaron" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Space+Grotesk:wght@400;500;600;700&display=swap" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/kimi/main.tsx"></script>
+  </body>
+</html>

--- a/web/src/kimi/KimiApp.tsx
+++ b/web/src/kimi/KimiApp.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import { KimiSidebar } from './KimiSidebar';
+import { NotifyStack } from '../components/NotifyStack';
+
+export function KimiApp() {
+  return (
+    <div className="kx-app">
+      <KimiSidebar />
+      <main className="kx-view"><Outlet /></main>
+      <NotifyStack />
+    </div>
+  );
+}

--- a/web/src/kimi/KimiChat.tsx
+++ b/web/src/kimi/KimiChat.tsx
@@ -1,0 +1,557 @@
+// Kimi thread view. Layout is the same left→right rail we had in the
+// ChatGPT-style pass, but the paper-theme CSS pulls it into the Macaron
+// look. Every visual detail — background, borders, tool cards, code
+// blocks — is tuned to match the claude WebUI's palette (see styles.css).
+
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Terminal, Pencil, Search, Hexagon, ListTodo, Settings, ChevronDown, ChevronRight, Sparkles, GitBranch, AlertTriangle } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
+import type { SessionDetail, Message, Block } from '@macaron/shared';
+import { kimiApi } from './api';
+import { sendKimiMessage, startKimiThread, subscribeKimiLive } from './stream';
+import { KimiComposer } from './KimiComposer';
+import { notify } from '../lib/notify';
+
+// GenuiPreview + its vendored runtime (~500KB gzip) is behind a lazy
+// import so the default kimi bundle stays small. First render_ui in a
+// thread triggers the load; subsequent ones use the cached chunk.
+const GenuiPreview = lazy(() =>
+  import('../genui-runtime').then((m) => ({ default: m.GenuiPreview })),
+);
+
+const RENDER_UI_TOOL_NAME = 'mcp:macaron/render_ui';
+const isRenderUiTool = (name: string): boolean =>
+  name === RENDER_UI_TOOL_NAME || name === 'mcp__macaron__render_ui';
+
+type Item =
+  | { id: string; kind: 'user'; text: string }
+  | { id: string; kind: 'assistant'; text: string }
+  | { id: string; kind: 'reasoning'; text: string }
+  | { id: string; kind: 'tool'; name: string; input: unknown; result?: string; isError?: boolean }
+  // GenUI render_ui tool call. Kimi hands us the full `code` at
+  // tool_use time (arguments are already aggregated by the CLI), so we
+  // render immediately — no pending phase in practice. The tool_result
+  // (checkGenUI diagnostics) may flip `status` to 'error' with details.
+  | { id: string; kind: 'genui'; toolUseId: string; code: string; status: 'ready' | 'error'; error?: string };
+
+function toolInputToCmd(name: string, input: unknown): string {
+  if (name === 'Bash') {
+    const cmd = (input as { command?: string } | null)?.command;
+    return cmd || JSON.stringify(input);
+  }
+  if (name === 'Edit') {
+    const changes = (input as { changes?: Array<{ path: string; kind: string }> } | null)?.changes;
+    if (Array.isArray(changes)) {
+      return changes
+        .map((c) => `${c.kind === 'add' ? '＋' : c.kind === 'delete' ? '－' : '△'} ${c.path}`)
+        .join('\n');
+    }
+  }
+  if (name === 'WebSearch') {
+    const q = (input as { query?: string } | null)?.query;
+    return q ? q : JSON.stringify(input);
+  }
+  return typeof input === 'string' ? input : JSON.stringify(input, null, 2);
+}
+
+function historyToItems(detail: SessionDetail): Item[] {
+  const out: Item[] = [];
+  let seq = 0;
+  const next = () => `h-${seq++}`;
+  const walk = (blocks: Block[], role: Message['role']) => {
+    for (const b of blocks) {
+      if (b.kind === 'text' && b.text.trim()) {
+        if (role === 'user') out.push({ id: next(), kind: 'user', text: b.text });
+        else out.push({ id: next(), kind: 'assistant', text: b.text });
+      } else if (b.kind === 'thinking' && b.text.trim()) {
+        out.push({ id: next(), kind: 'reasoning', text: b.text });
+      } else if (b.kind === 'tool_use') {
+        if (isRenderUiTool(b.name)) {
+          const code = String((b.input as { code?: unknown } | null)?.code || '');
+          out.push({
+            id: `genui-${b.id}`,
+            kind: 'genui',
+            toolUseId: b.id,
+            code,
+            status: 'ready',
+          });
+        } else {
+          out.push({ id: b.id, kind: 'tool', name: b.name, input: b.input });
+        }
+      } else if (b.kind === 'tool_result') {
+        const target = [...out].reverse().find(
+          (it) =>
+            (it.kind === 'tool' && it.result === undefined && (b.toolUseId ? it.id === b.toolUseId : true))
+            || (it.kind === 'genui' && it.toolUseId === b.toolUseId),
+        );
+        if (target?.kind === 'tool') target.result = b.text;
+        else if (target?.kind === 'genui') {
+          const flagged = b.text.startsWith('Rendered inline, but the TSX has issues');
+          if (flagged) { target.status = 'error'; target.error = b.text; }
+        }
+      }
+    }
+  };
+  for (const m of detail.messages) walk(m.blocks, m.role);
+  return out;
+}
+
+function reconcileHistoryWithLive(history: Item[], live: Item[]): Item[] {
+  const liveUser = live.find((it): it is Extract<Item, { kind: 'user' }> => it.kind === 'user');
+  const liveText = liveUser?.text.trim();
+  if (!liveText) return history;
+
+  // Kimi may have already appended part of the in-flight turn to its wire
+  // log. When that latest user bubble matches the live snapshot, let the
+  // snapshot own the whole turn so partial disk blocks are not rendered a
+  // second time.
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i]!;
+    if (item.kind !== 'user') continue;
+    return item.text.trim() === liveText ? history.slice(0, i) : history;
+  }
+  return history;
+}
+
+function withUser(cur: Item[], text: string): Item[] {
+  return [
+    ...cur,
+    { id: `u-${Date.now()}-${cur.length}`, kind: 'user', text },
+  ];
+}
+
+function withAssistantDelta(cur: Item[], text: string): Item[] {
+  const last = cur[cur.length - 1];
+  if (last?.kind === 'assistant') {
+    return [...cur.slice(0, -1), { ...last, text: last.text + text }];
+  }
+  return [...cur, { id: `a-${Date.now()}-${cur.length}`, kind: 'assistant', text }];
+}
+
+function withTool(cur: Item[], id: string, name: string, input: unknown): Item[] {
+  if (isRenderUiTool(name)) {
+    const code = String((input as { code?: unknown } | null)?.code || '');
+    return [
+      ...cur,
+      {
+        id: `genui-${id}`,
+        kind: 'genui',
+        toolUseId: id,
+        code,
+        status: 'ready',
+      },
+    ];
+  }
+  return [...cur, { id, kind: 'tool', name, input }];
+}
+
+function withToolResult(cur: Item[], toolUseId: string, text: string, isError: boolean): Item[] {
+  return cur.map((it) => {
+    if (it.kind === 'tool' && it.id === toolUseId) return { ...it, result: text, isError };
+    if (it.kind === 'genui' && it.toolUseId === toolUseId) {
+      const flagged = isError || text.startsWith('Rendered inline, but the TSX has issues');
+      return flagged
+        ? { ...it, status: 'error' as const, error: text }
+        : it;
+    }
+    return it;
+  });
+}
+
+function Reasoning({ text }: { text: string }) {  const [open, setOpen] = useState(false);
+  return (
+    <div className="kx-reasoning">
+      <div className="kx-reasoning-head" onClick={() => setOpen((v) => !v)}>
+        <span className="kx-reasoning-caret">{open ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
+        <span>Reasoning</span>
+      </div>
+      {open && <div className="kx-reasoning-body">{text}</div>}
+    </div>
+  );
+}
+
+function toolGlyph(name: string): ReactNode {
+  if (name === 'Bash') return <Terminal size={14} aria-hidden="true" />;
+  if (name === 'Edit') return <Pencil size={14} aria-hidden="true" />;
+  if (name === 'WebSearch') return <Search size={14} aria-hidden="true" />;
+  if (name.startsWith('mcp:')) return <Hexagon size={14} aria-hidden="true" />;
+  if (name === 'TodoWrite') return <ListTodo size={14} aria-hidden="true" />;
+  return <Settings size={14} aria-hidden="true" />;
+}
+
+function ToolCard({ it }: { it: Extract<Item, { kind: 'tool' }> }) {
+  const [expanded, setExpanded] = useState(false);
+  const cmd = toolInputToCmd(it.name, it.input);
+  const out = it.result ?? '';
+  const running = it.result === undefined;
+  const long = out.split('\n').length > 8 || out.length > 600;
+  const shown = expanded || !long ? out : out.split('\n').slice(0, 8).join('\n') + '\n…';
+  return (
+    <div className={'kx-tool' + (it.isError ? ' err' : '')}>
+      <div className="kx-tool-head">
+        <span className="kx-tool-glyph">{toolGlyph(it.name)}</span>
+        <span className="kx-tool-name">{it.name}</span>
+        <span className={'kx-tool-status' + (it.isError ? ' err' : '')}>
+          {running ? 'running…' : it.isError ? 'failed' : 'done'}
+        </span>
+      </div>
+      <div className="kx-tool-cmd">{cmd}</div>
+      {out && (
+        <>
+          <div className={'kx-tool-out' + (it.isError ? ' err' : '')}>{shown}</div>
+          {long && (
+            <button className="kx-tool-more" onClick={() => setExpanded((v) => !v)}>
+              {expanded ? 'collapse' : `expand (${out.split('\n').length} lines)`}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function GenuiCard({ it }: { it: Extract<Item, { kind: 'genui' }> }) {
+  return (
+    <div className="kx-genui">
+      <div className="kx-genui-head">
+        <span className="kx-genui-glyph"><Sparkles size={14} aria-hidden="true" /></span>
+        <span className="kx-genui-name">Rendered UI</span>
+        {it.status === 'error' && <span className="kx-genui-status err">diagnostics failed</span>}
+      </div>
+      <Suspense fallback={<div className="kx-genui-loading">Loading GenUI runtime…</div>}>
+        <GenuiPreview code={it.code} done />
+      </Suspense>
+      {it.status === 'error' && it.error && (
+        <details className="kx-genui-details">
+          <summary>Show diagnostics</summary>
+          <pre>{it.error}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+const KIMI_MARKDOWN_COMPONENTS = { code: MarkdownCode, pre: MarkdownPre } as const;
+
+function MessageRow({ it, streaming = false }: { it: Item; streaming?: boolean }) {
+  if (it.kind === 'reasoning') return <Reasoning text={it.text} />;
+  if (it.kind === 'tool') return <ToolCard it={it} />;
+  if (it.kind === 'genui') return <GenuiCard it={it} />;
+  const isUser = it.kind === 'user';
+  return (
+    <div className={'kx-msg ' + (isUser ? 'user' : 'assistant')}>
+      <div className="kx-msg-body">
+        <div className="kx-msg-role">{isUser ? 'You' : 'Kimi'}</div>
+        {/* User text stays as pre-wrap plain text (WYSIWYG for what they typed);
+            assistant text renders as GitHub-flavored Markdown so headings,
+            lists, tables, inline code, and links come through. */}
+        {isUser ? (
+          <div className="kx-msg-text">{it.text}</div>
+        ) : (
+          <div className="kx-msg-text md">
+            <MarkdownCodeStreamingProvider content={it.text} streaming={streaming}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={KIMI_MARKDOWN_COMPONENTS}>{it.text}</ReactMarkdown>
+            </MarkdownCodeStreamingProvider>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Kimi-side "thinking…" indicator — three black-and-white dots pulsing in
+// sequence. Minimal, quiet, no verb chatter; visible at the tail of the
+// thread while a turn is in flight and no streaming text has landed yet.
+function KxThinkingLine() {
+  return (
+    <div className="kx-thinking" aria-label="Kimi is thinking">
+      <span className="kx-dot" />
+      <span className="kx-dot" />
+      <span className="kx-dot" />
+    </div>
+  );
+}
+
+export type KimiChatProps = {
+  /** Override sid from URL when rendered inside a canvas tile. */
+  sid?: string;
+  /** Suppress the top breadcrumb bar (tile grip carries the header). */
+  hideBar?: boolean;
+  /** Only render composer + reduce padding when this tile is the focused one. */
+  focused?: boolean;
+  /** Notify parent tile whenever the in-flight run flips (for running-bar animation). */
+  onSendingChange?: (sending: boolean) => void;
+  /** Bump this number from the parent to force a fresh transcript reload. */
+  refreshKey?: number;
+};
+
+export function KimiChat(props: KimiChatProps = {}) {
+  const params = useParams();
+  const navigate = useNavigate();
+  const sid = props.sid ?? params.sid ?? '';
+  const isNew = !sid;
+  const focused = props.focused ?? true;
+  const hideBar = props.hideBar ?? false;
+  const onSendingChange = props.onSendingChange;
+  const refreshKey = props.refreshKey ?? 0;
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [live, setLive] = useState<Item[]>([]);
+  const [pending, setPending] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // On a brand-new thread the route `sid` stays empty until `onDone` navigates,
+  // but the turn is already in flight — so stop must target the sid the server
+  // reveals via `meta`. Captured here the instant it streams in.
+  const liveSidRef = useRef('');
+  // True only after the user kicks off a turn on THIS mount. A server-side
+  // reattach also flips `sending`, but must not create a completion notification.
+  const streamedRef = useRef(false);
+
+  useEffect(() => { onSendingChange?.(sending); }, [sending, onSendingChange]);
+
+  // In-app notification when a turn finishes — matches the Claude side
+  // (NotifyStack is mounted in KimiApp). Click routes to the thread's
+  // canvas view so the user lands on the right tile.
+  useEffect(() => {
+    if (sending) return;
+    if (!streamedRef.current) return;
+    streamedRef.current = false;
+    if (!sid) return;
+    const project = detail?.project;
+    notify({
+      title: 'Macaron · thread ready',
+      body: `${sid.slice(0, 8)} finished a turn`,
+      tag: `kimi-done-${sid}`,
+      href: project
+        ? `/w/${encodeURIComponent(project)}/t/${encodeURIComponent(sid)}`
+        : `/t/${encodeURIComponent(sid)}`,
+    });
+  }, [sending, sid, detail?.project]);
+
+  useEffect(() => {
+    if (isNew) {
+      setDetail(null);
+      setLive([]);
+      setSending(false);
+      setError('');
+      return;
+    }
+    let active = true;
+    let hasLiveSnapshot = false;
+    setLive([]);
+    setSending(false);
+    setError('');
+    void kimiApi.thread(sid)
+      .then((next) => { if (active) setDetail(next); })
+      .catch((e) => { if (active && !hasLiveSnapshot) setError((e as Error).message); });
+
+    const unsubscribe = subscribeKimiLive(sid, {
+      // `meta` is present only when the registry has a snapshot. Reset first so
+      // a fresh subscription is idempotent if this effect reruns.
+      onMeta: () => {
+        if (!active) return;
+        hasLiveSnapshot = true;
+        setLive([]);
+        setSending(true);
+        setError('');
+      },
+      onUserText: (text) => { if (active) setLive((cur) => withUser(cur, text)); },
+      onDelta: (text) => { if (active) setLive((cur) => withAssistantDelta(cur, text)); },
+      onToolUse: (ev) => { if (active) setLive((cur) => withTool(cur, ev.id, ev.name, ev.input)); },
+      onToolResult: (ev) => {
+        if (active) setLive((cur) => withToolResult(cur, ev.tool_use_id, ev.text, ev.isError));
+      },
+      onError: (message) => { if (active) setError(message); },
+      onDone: () => {
+        if (!active) return;
+        setSending(false);
+        // Keep the complete live buffer visible while the Kimi wire log catches
+        // up asynchronously; refresh metadata without clearing that buffer.
+        void kimiApi.thread(sid).then((next) => { if (active) setDetail(next); }).catch(() => {});
+      },
+      onLiveEnd: () => { if (active) setSending(false); },
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [sid, isNew, refreshKey]);
+
+  const diskHistory = useMemo(() => (detail ? historyToItems(detail) : []), [detail]);
+  const history = useMemo(
+    () => reconcileHistoryWithLive(diskHistory, live),
+    [diskHistory, live],
+  );
+  const items = useMemo(() => [...history, ...live], [history, live]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [items.length, live[live.length - 1]]);
+
+  const appendUser = (text: string) => setLive((cur) => withUser(cur, text));
+  const appendAssistantDelta = (text: string) => setLive((cur) => withAssistantDelta(cur, text));
+  const appendTool = (id: string, name: string, input: unknown) =>
+    setLive((cur) => withTool(cur, id, name, input));
+  const applyToolResult = (toolUseId: string, text: string, isError: boolean) => {
+    setLive((cur) => withToolResult(cur, toolUseId, text, isError));
+  };
+
+  const stop = useCallback(async () => {
+    const target = sid || liveSidRef.current;
+    if (!target) return;
+    try { await kimiApi.stopThread(target); } catch { /* nop */ }
+  }, [sid]);
+
+  const submit = useCallback(async (opts?: { text?: string }) => {
+    // `opts.text` present ⇒ programmatic send (from the $macaron/chat bridge
+    // or auto-continue). We don't consume composer state in that case, so a
+    // user still typing something doesn't get their draft cleared.
+    const programmatic = typeof opts?.text === 'string';
+    const text = (programmatic ? opts!.text! : pending).trim();
+    if (!text || sending) return;
+    if (!programmatic) {
+      setPending('');
+    }
+    streamedRef.current = true;
+    setSending(true);
+    setError('');
+    appendUser(text);
+    try {
+      if (isNew) {
+        let newSid = '';
+        await startKimiThread({ text }, {
+          onMeta: (s) => { newSid = s; liveSidRef.current = s; },
+          onDelta: appendAssistantDelta,
+          onToolUse: (ev) => appendTool(ev.id, ev.name, ev.input),
+          onToolResult: (ev) => applyToolResult(ev.tool_use_id, ev.text, ev.isError),
+          onError: (m) => setError(m),
+          onDone: () => {
+            setSending(false);
+            if (newSid) navigate(`/t/${encodeURIComponent(newSid)}`, { replace: true });
+          },
+        });
+      } else {
+        await sendKimiMessage(sid, { text }, {
+          onDelta: appendAssistantDelta,
+          onToolUse: (ev) => appendTool(ev.id, ev.name, ev.input),
+          onToolResult: (ev) => applyToolResult(ev.tool_use_id, ev.text, ev.isError),
+          onError: (m) => setError(m),
+          onDone: () => {
+            setSending(false);
+            kimiApi.thread(sid).then(setDetail).catch(() => {}).finally(() => setLive([]));
+          },
+        });
+      }
+    } catch (e) {
+      setError((e as Error).message);
+      setSending(false);
+    }
+  }, [pending, sending, isNew, sid, navigate]);
+
+  // Chat bridge for render_ui widgets. Mirrors Claude side (Session.tsx):
+  // a sandboxed widget imports `sendUserMessage` from '$macaron/chat',
+  // the shim dispatches to globalThis['$app/chat'], and we relay into
+  // submit() as a programmatic user turn. `sendUserMessage` is also bound
+  // on globalThis so widgets that forget the import still work.
+  useEffect(() => {
+    if (!focused) return;
+    const g = globalThis as unknown as {
+      '$app/chat'?: (prompt: string) => void;
+      sendUserMessage?: (prompt: string) => void;
+    };
+    const bridge = (prompt: string) => { void submit({ text: prompt }); };
+    g['$app/chat'] = bridge;
+    g.sendUserMessage = bridge;
+    return () => {
+      if (g['$app/chat'] === bridge) delete g['$app/chat'];
+      if (g.sendUserMessage === bridge) delete g.sendUserMessage;
+    };
+  }, [focused, submit]);
+
+  const title = isNew
+    ? 'New thread'
+    : detail?.cwd?.split('/').filter(Boolean).pop() || 'Thread';
+
+  return (
+    <div className={'kx-main' + (hideBar ? ' tile' : '')}>
+      {!hideBar && (
+        <div className="kx-main-head">
+          <div className="kx-main-head-title">{title}</div>
+          {!isNew && (
+            <>
+              <span className="kx-main-head-dot">·</span>
+              <span className="kx-main-head-sub">{sid.slice(0, 8)}</span>
+              {detail?.gitBranch && (
+                <>
+                  <span className="kx-main-head-dot">·</span>
+                  <span className="kx-main-head-branch"><GitBranch size={13} aria-hidden="true" /> {detail.gitBranch}</span>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      )}
+      <div className="kx-main-scroll" ref={scrollRef}>
+        {isNew && items.length === 0 ? (
+          <div className="kx-home">
+            <div className="kx-home-inner">
+              <h1 className="kx-home-title">What can I help with?</h1>
+              <p className="kx-home-sub">
+                Kimi Code will run in your working directory with the provider
+                set on the composer below. Permissions are auto-approved.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="kx-thread-body">
+            {items.map((it, i) => (
+              <MessageRow
+                key={it.id}
+                it={it}
+                streaming={sending && i === items.length - 1 && it.kind === 'assistant'}
+              />
+            ))}
+            {/* Show the thinking spinner at the tail of the thread while a
+                turn is in flight. Hide it once the last item is a live
+                assistant message that has actually started emitting text —
+                at that point the streaming text itself is the progress
+                signal, so a second one is noise. */}
+            {sending && (() => {
+              const last = items[items.length - 1];
+              const streamingText = last?.kind === 'assistant' && last.text.length > 0;
+              return streamingText ? null : <KxThinkingLine />;
+            })()}
+            {error && (
+              <div className="kx-tool err">
+                <div className="kx-tool-head">
+                  <span className="kx-tool-glyph"><AlertTriangle size={14} aria-hidden="true" /></span>
+                  <span className="kx-tool-name">Error</span>
+                </div>
+                <div className="kx-tool-out err">{error}</div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className={'kx-composer-grid' + (focused ? ' open' : '')}>
+        <div className="kx-composer-inner">
+          <KimiComposer
+            value={pending}
+            onChange={setPending}
+            onSubmit={submit}
+            onStop={stop}
+            disabled={sending}
+            running={sending && !isNew}
+            placeholder={sending ? 'Draft next message…' : undefined}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/kimi/KimiComposer.tsx
+++ b/web/src/kimi/KimiComposer.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import { Square, ArrowUp } from 'lucide-react';
+import { KimiProviderPicker } from './KimiProviderPicker';
+
+// No image attach here (unlike the codex composer): `kimi -p` has no verified
+// headless image input, so the server accepts but drops images — offering the
+// button would silently discard user content.
+export function KimiComposer({
+  value,
+  onChange,
+  onSubmit,
+  onStop,
+  disabled,
+  running,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onStop?: () => void;
+  disabled?: boolean;
+  running?: boolean;
+  placeholder?: string;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 220) + 'px';
+  }, [value]);
+
+  const key = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      if (!disabled && value.trim()) onSubmit();
+    }
+  };
+
+  return (
+    <div className="kx-composer-wrap">
+      <div className="kx-composer">
+        <div className="kx-composer-row">
+          <textarea
+            ref={ref}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={key}
+            placeholder={placeholder ?? 'Message Kimi…'}
+            rows={1}
+          />
+          {running && onStop ? (
+            <button className="kx-send stop" onClick={onStop} title="Stop"><Square size={14} fill="currentColor" aria-hidden="true" /></button>
+          ) : (
+            <button
+              className="kx-send"
+              disabled={disabled || !value.trim()}
+              onClick={onSubmit}
+              title="Send (Enter)"
+              aria-label="Send"
+            ><ArrowUp size={16} aria-hidden="true" /></button>
+          )}
+        </div>
+      </div>
+      <div className="kx-composer-foot">
+        <div className="kx-composer-pickers">
+          <KimiProviderPicker />
+        </div>
+        <span className="kx-composer-hint">Enter to send · Shift+Enter for newline</span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/kimi/KimiProviderPicker.tsx
+++ b/web/src/kimi/KimiProviderPicker.tsx
@@ -1,0 +1,73 @@
+// Inline provider chip for the Kimi composer. Reads /api/kimi/config and
+// lets the user switch active provider without navigating to Settings.
+// Adding / editing providers still lives on the Settings page — this chip
+// only exposes the "which one runs the next turn" switch.
+
+import { ChevronDown, Monitor } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { kimiApi, type PublicKimiSettings } from './api';
+
+const SYSTEM_ID = 'system';
+
+export function KimiProviderPicker() {
+  const [settings, setSettings] = useState<PublicKimiSettings | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    kimiApi.config().then(setSettings).catch(() => { /* chip stays hidden */ });
+  }, []);
+
+  if (!settings) return null;
+
+  const options: Array<{ id: string; label: string; usable: boolean }> = [];
+  for (const b of settings.builtins) {
+    options.push({ id: b.id, label: b.name, usable: true });
+  }
+  for (const p of settings.customProviders) {
+    // Only surface custom providers with a key set — a keyless entry would
+    // 401 on send and confuse the user.
+    if (p.configured) options.push({ id: p.id, label: p.name, usable: true });
+  }
+
+  const activeId = settings.activeProviderId;
+  const activeLabel =
+    options.find((o) => o.id === activeId)?.label
+    ?? (activeId === SYSTEM_ID ? 'System default' : '(unconfigured)');
+
+  const onChange = async (id: string) => {
+    if (busy || id === activeId) return;
+    setBusy(true);
+    setErr('');
+    const prev = settings;
+    setSettings({ ...settings, activeProviderId: id });
+    try {
+      setSettings(await kimiApi.setActive(id));
+    } catch (e) {
+      setSettings(prev);
+      setErr((e as Error).message);
+      window.setTimeout(() => setErr(''), 2200);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={'kx-provider-chip' + (busy ? ' busy' : '')} title={err ? `Switch failed: ${err}` : `Provider · ${activeLabel}`}>
+      <Monitor size={13} strokeWidth={2} aria-hidden="true" />
+      <span className="kx-provider-chip-label">{activeLabel}</span>
+      <ChevronDown className="kx-provider-chip-caret" size={9} strokeWidth={2.5} aria-hidden="true" />
+      <select
+        className="kx-provider-chip-select"
+        value={activeId}
+        disabled={busy}
+        onChange={(e) => void onChange(e.target.value)}
+        aria-label="Provider"
+      >
+        {options.map((o) => (
+          <option key={o.id} value={o.id}>{o.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/src/kimi/KimiSettings.tsx
+++ b/web/src/kimi/KimiSettings.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useConfirm } from '../components/Confirm';
+import {
+  kimiApi,
+  type KimiProviderType,
+  type PublicKimiBuiltin,
+  type PublicKimiProvider,
+  type PublicKimiSettings,
+} from './api';
+
+const PROVIDER_TYPES = ['kimi', 'anthropic', 'openai'] as const;
+
+const SYSTEM_ID = 'system';
+
+export function KimiSettings() {
+  const [settings, setSettings] = useState<PublicKimiSettings | null>(null);
+  const [selectedId, setSelectedId] = useState<string>('');
+  const [msg, setMsg] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await kimiApi.config();
+      setSettings(s);
+      // Keep whatever the user was inspecting; fall back to active on first
+      // load or when the previous selection got deleted.
+      setSelectedId((cur) => {
+        if (cur && (cur === SYSTEM_ID || s.customProviders.some((p) => p.id === cur))) return cur;
+        return s.activeProviderId;
+      });
+    } catch { /* nop */ }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const flash = useCallback((text: string) => {
+    setMsg(text);
+    window.setTimeout(() => setMsg((cur) => (cur === text ? '' : cur)), 2200);
+  }, []);
+
+  if (!settings) return <div className="kx-settings"><div className="kx-settings-loading">Loading…</div></div>;
+
+  const builtin = settings.builtins[0];
+  const selected = selectedId === SYSTEM_ID
+    ? null
+    : settings.customProviders.find((p) => p.id === selectedId) ?? null;
+
+  const setActive = async (id: string) => {
+    try {
+      const s = await kimiApi.setActive(id);
+      setSettings(s);
+      flash(id === SYSTEM_ID ? 'Switched to System default' : `Switched to ${s.customProviders.find((p) => p.id === id)?.name ?? id}`);
+    } catch (e) {
+      flash(`Switch failed: ${(e as Error).message}`);
+    }
+  };
+
+  const addProvider = async () => {
+    try {
+      const { id, settings: s } = await kimiApi.createProvider({ name: 'New provider' });
+      setSettings(s);
+      setSelectedId(id);
+      flash('Provider added');
+    } catch (e) {
+      flash(`Add failed: ${(e as Error).message}`);
+    }
+  };
+
+  return (
+    <div className="kx-settings">
+      <header className="kx-settings-head">
+        <h1>Kimi Settings</h1>
+        <div className="kx-settings-sub">
+          Pick which provider new threads use, or fall back to System default (your ambient Kimi Code CLI login).
+        </div>
+      </header>
+
+      <div className="kx-settings-grid">
+        <ProviderList
+          builtin={builtin!}
+          providers={settings.customProviders}
+          activeId={settings.activeProviderId}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onSetActive={setActive}
+          onAdd={addProvider}
+        />
+        <div className="kx-settings-pane">
+          {selectedId === SYSTEM_ID
+            ? <SystemPane builtin={builtin!} isActive={settings.activeProviderId === SYSTEM_ID} onSetActive={() => setActive(SYSTEM_ID)} />
+            : selected
+              ? <ProviderPane
+                  key={selected.id}
+                  provider={selected}
+                  isActive={settings.activeProviderId === selected.id}
+                  onSetActive={() => setActive(selected.id)}
+                  onAfterMutate={(next) => setSettings(next)}
+                  onDeleted={async () => {
+                    await refresh();
+                    setSelectedId(settings.activeProviderId);
+                  }}
+                  flash={flash}
+                />
+              : <div className="kx-settings-empty">Select a provider on the left.</div>}
+        </div>
+      </div>
+
+      {msg && <div className="kx-settings-flash">{msg}</div>}
+    </div>
+  );
+}
+
+// -------- Left pane: the provider list --------
+
+function ProviderList({
+  builtin,
+  providers,
+  activeId,
+  selectedId,
+  onSelect,
+  onSetActive,
+  onAdd,
+}: {
+  builtin: PublicKimiBuiltin;
+  providers: PublicKimiProvider[];
+  activeId: string;
+  selectedId: string;
+  onSelect: (id: string) => void;
+  onSetActive: (id: string) => void;
+  onAdd: () => void;
+}) {
+  const isSel = (id: string) => selectedId === id;
+  const isAct = (id: string) => activeId === id;
+  return (
+    <aside className="kx-settings-list">
+      <div className="kx-settings-list-label">BUILT-IN</div>
+      <button
+        type="button"
+        className={'kx-plist-row' + (isSel(SYSTEM_ID) ? ' selected' : '') + (isAct(SYSTEM_ID) ? ' active' : '')}
+        onClick={() => onSelect(SYSTEM_ID)}
+        onDoubleClick={() => onSetActive(SYSTEM_ID)}
+      >
+        <div className="kx-plist-row-main">
+          <span className="kx-plist-row-name">{builtin.name}</span>
+          {isAct(SYSTEM_ID) && <span className="kx-plist-active-badge">active</span>}
+        </div>
+        <div className="kx-plist-row-sub">
+          {builtin.detectedEndpoint || 'ambient OAuth login'}
+        </div>
+      </button>
+
+      <div className="kx-settings-list-label">CUSTOM</div>
+      {providers.length === 0 && <div className="kx-plist-empty">No custom providers yet.</div>}
+      {providers.map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          className={'kx-plist-row' + (isSel(p.id) ? ' selected' : '') + (isAct(p.id) ? ' active' : '')}
+          onClick={() => onSelect(p.id)}
+          onDoubleClick={() => onSetActive(p.id)}
+        >
+          <div className="kx-plist-row-main">
+            <span className="kx-plist-row-name">{p.name}</span>
+            {isAct(p.id) && <span className="kx-plist-active-badge">active</span>}
+            {!p.configured && <span className="kx-plist-warn">no key</span>}
+          </div>
+          <div className="kx-plist-row-sub">{p.model} · {p.baseUrl || '(no url)'}</div>
+        </button>
+      ))}
+
+      <button type="button" className="kx-plist-add" onClick={onAdd}>+ Add provider</button>
+    </aside>
+  );
+}
+
+// -------- Right pane: system provider (read-only) --------
+
+function SystemPane({
+  builtin,
+  isActive,
+  onSetActive,
+}: {
+  builtin: PublicKimiBuiltin;
+  isActive: boolean;
+  onSetActive: () => void;
+}) {
+  return (
+    <section className="kx-settings-section">
+      <div className="kx-section-head">
+        <h2>System default</h2>
+        {isActive
+          ? <span className="kx-active-pill">Active</span>
+          : <button className="kx-btn primary" onClick={onSetActive}>Use this</button>}
+      </div>
+      <p className="kx-section-body">{builtin.description}</p>
+      <dl className="kx-kv">
+        <dt>Detected endpoint</dt>
+        <dd>{builtin.detectedEndpoint || <em>none</em>}</dd>
+        <dt>Detected model</dt>
+        <dd>{builtin.detectedModel || <em>none</em>}</dd>
+      </dl>
+      <p className="kx-section-note">
+        Nothing to edit here — the pass-through provider inherits everything from your existing Kimi Code CLI login.
+        Add a Custom provider on the left if you want to override.
+      </p>
+    </section>
+  );
+}
+
+// -------- Right pane: custom provider edit --------
+
+function ProviderPane({
+  provider,
+  isActive,
+  onSetActive,
+  onAfterMutate,
+  onDeleted,
+  flash,
+}: {
+  provider: PublicKimiProvider;
+  isActive: boolean;
+  onSetActive: () => void;
+  onAfterMutate: (next: PublicKimiSettings) => void;
+  onDeleted: () => void;
+  flash: (msg: string) => void;
+}) {
+  const [draft, setDraft] = useState<PublicKimiProvider>(provider);
+  const [apiKey, setApiKey] = useState('');
+  const [saving, setSaving] = useState(false);
+  const confirm = useConfirm();
+  useEffect(() => { setDraft(provider); setApiKey(''); }, [provider]);
+
+  const set = <K extends keyof PublicKimiProvider>(k: K, v: PublicKimiProvider[K]) => {
+    setDraft((d) => ({ ...d, [k]: v }));
+  };
+  const dirty = useMemo(() => {
+    const keys: (keyof PublicKimiProvider)[] = ['name', 'model', 'baseUrl', 'providerType'];
+    return apiKey.length > 0 || keys.some((k) => draft[k] !== provider[k]);
+  }, [draft, provider, apiKey]);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const patch: Partial<PublicKimiProvider> & { apiKey?: string } = {
+        name: draft.name,
+        model: draft.model,
+        baseUrl: draft.baseUrl,
+        providerType: draft.providerType,
+      };
+      if (apiKey) patch.apiKey = apiKey;
+      const s = await kimiApi.updateProvider(provider.id, patch);
+      onAfterMutate(s);
+      setApiKey('');
+      flash('Saved');
+    } catch (e) {
+      flash(`Save failed: ${(e as Error).message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const del = async () => {
+    const ok = await confirm({
+      title: 'Delete provider?',
+      body: <>Provider <code>{provider.name}</code> will be removed. This can't be undone.</>,
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await kimiApi.deleteProvider(provider.id);
+      onDeleted();
+      flash('Deleted');
+    } catch (e) {
+      flash(`Delete failed: ${(e as Error).message}`);
+    }
+  };
+
+  return (
+    <section className="kx-settings-section">
+      <div className="kx-section-head">
+        <h2>{draft.name || 'Custom provider'}</h2>
+        {isActive
+          ? <span className="kx-active-pill">Active</span>
+          : <button className="kx-btn primary" onClick={onSetActive}>Use this</button>}
+      </div>
+
+      <div className="kx-field-row">
+        <div className="kx-field">
+          <label>Name</label>
+          <input value={draft.name} onChange={(e) => set('name', e.target.value)} />
+        </div>
+        <div className="kx-field">
+          <label>Provider type</label>
+          <select value={draft.providerType} onChange={(e) => set('providerType', e.target.value as KimiProviderType)}>
+            {PROVIDER_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <small>The API dialect Kimi Code speaks to this endpoint.</small>
+        </div>
+      </div>
+
+      <div className="kx-field">
+        <label>Base URL</label>
+        <input
+          value={draft.baseUrl}
+          onChange={(e) => set('baseUrl', e.target.value)}
+          placeholder="https://api.example.com/v1"
+        />
+        <small>Most OpenAI-compatible proxies require the trailing <code>/v1</code>.</small>
+      </div>
+
+      <div className="kx-field">
+        <label>API key</label>
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={provider.configured ? '••••••• (leave blank to keep current)' : 'Paste your bearer token'}
+        />
+      </div>
+
+      <div className="kx-field">
+        <label>Model</label>
+        <input value={draft.model} onChange={(e) => set('model', e.target.value)} />
+      </div>
+
+      <div className="kx-section-actions">
+        <button className="kx-btn primary" onClick={save} disabled={saving || !dirty}>
+          {saving ? 'Saving…' : dirty ? 'Save changes' : 'Saved'}
+        </button>
+        <button className="kx-btn danger" onClick={del}>Delete</button>
+      </div>
+    </section>
+  );
+}

--- a/web/src/kimi/KimiSidebar.tsx
+++ b/web/src/kimi/KimiSidebar.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, Check, Circle, Plus, X, Settings } from 'lucide-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { assetUrl } from '../lib/assetBase';
+import { kimiApi, type KimiThread, type KimiWorkspace } from './api';
+import {
+  getCanvasSids,
+  toggleCanvasSid,
+  focusCanvasSid,
+  subscribeCanvas,
+} from '../lib/canvas';
+import { subscribeSystemEvents } from '../lib/systemEvents';
+import { useConfirm } from '../components/Confirm';
+import { useToast } from '../components/Toast';
+
+type WsData = KimiWorkspace & { sessions: KimiThread[] };
+
+function basename(p: string): string {
+  if (!p) return '';
+  const parts = p.split('/').filter(Boolean);
+  return parts[parts.length - 1] || p;
+}
+
+export function KimiSidebar() {
+  const [workspaces, setWorkspaces] = useState<WsData[]>([]);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [status, setStatus] = useState<'connecting' | 'ok' | 'bad'>('connecting');
+  const [providerLabel, setProviderLabel] = useState('');
+  const [canvasBy, setCanvasBy] = useState<Record<string, string[]>>({});
+  const confirm = useConfirm();
+  const toast = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const activeProject = /^\/w\/([^/]+)/.exec(location.pathname)?.[1] ? decodeURIComponent(/^\/w\/([^/]+)/.exec(location.pathname)![1]!) : '';
+
+  const load = useCallback(async () => {
+    try {
+      const d = await kimiApi.workspaces();
+      const results = await Promise.all(
+        d.workspaces.map(async (w) => {
+          try {
+            const detail = await kimiApi.workspace(w.project);
+            return { ...w, sessions: detail.sessions } as WsData;
+          } catch {
+            return { ...w, sessions: [] } as WsData;
+          }
+        }),
+      );
+      setWorkspaces(results);
+    } catch { /* nop */ }
+  }, []);
+
+  useEffect(() => {
+    load();
+    kimiApi.config()
+      .then((c) => {
+        setStatus('ok');
+        if (c.activeProviderId === 'system') {
+          const b = c.builtins[0];
+          setProviderLabel(`system · ${b?.detectedModel || '(kimi default)'}`);
+        } else {
+          const p = c.customProviders.find((x) => x.id === c.activeProviderId);
+          setProviderLabel(p ? `${p.name} · ${p.model}` : 'unknown provider');
+        }
+      })
+      .catch(() => setStatus('bad'));
+    const t = setInterval(load, 10_000);
+    // Refresh immediately when a kimi session changes on disk (e.g. a
+    // terminal-started `kimi` run); interval stays as a fallback.
+    const unsub = subscribeSystemEvents((ev) => {
+      if (ev.engine === 'kimi') void load();
+    });
+    return () => {
+      clearInterval(t);
+      unsub();
+    };
+  }, [load]);
+
+  // Auto-expand the workspace that owns the active thread OR is the current
+  // canvas route.
+  const activeSid = /\/t\/([^/]+)/.exec(location.pathname)?.[1];
+  useEffect(() => {
+    if (activeProject) {
+      setExpanded((s) => (s.has(activeProject) ? s : new Set(s).add(activeProject)));
+    }
+    if (!activeSid) return;
+    for (const w of workspaces) {
+      if (w.sessions.some((s) => s.sessionId === activeSid)) {
+        setExpanded((s) => (s.has(w.project) ? s : new Set(s).add(w.project)));
+        break;
+      }
+    }
+  }, [activeSid, activeProject, workspaces]);
+
+  // Re-read per-workspace canvas sids so the +/✓ toggles stay accurate.
+  useEffect(() => {
+    const refresh = () => {
+      const next: Record<string, string[]> = {};
+      for (const w of workspaces) next[w.project] = getCanvasSids(w.project);
+      setCanvasBy(next);
+    };
+    refresh();
+    const unsubs = workspaces.map((w) => subscribeCanvas(w.project, refresh));
+    return () => { for (const u of unsubs) u(); };
+  }, [workspaces]);
+
+  const toggle = (p: string) => setExpanded((s) => {
+    const n = new Set(s);
+    if (n.has(p)) n.delete(p); else n.add(p);
+    return n;
+  });
+
+  const del = async (e: React.MouseEvent, sid: string) => {
+    e.stopPropagation();
+    const ok = await confirm({
+      title: 'Delete thread?',
+      body: (
+        <>
+          The session directory under <code>~/.kimi-code/sessions</code> will be
+          removed. This can't be undone.
+        </>
+      ),
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await kimiApi.deleteThread(sid);
+      await load();
+      if (activeSid === sid) navigate('/');
+    } catch (err) {
+      toast(`Delete failed: ${(err as Error).message}`);
+    }
+  };
+
+  return (
+    <aside className="kx-sidebar">
+      <Link className="kx-sb-brand" to="/">
+        <img className="kx-sb-logo" src={assetUrl('/mindlab-symbol.svg')} alt="" />
+        <div>
+          <div className="kx-sb-brand-name">Macaron Artifacts</div>
+          <div className="kx-sb-brand-sub">Presented by Mind Lab</div>
+        </div>
+      </Link>
+
+      <button className="kx-sb-new" onClick={() => navigate('/')}>
+        <Plus size={14} aria-hidden="true" />
+        <span>New thread</span>
+      </button>
+
+      <div className="kx-sb-label"><span>WORKSPACES</span></div>
+
+      <div className="kx-sb-list">
+        {workspaces.length === 0 && (
+          <div className="kx-sb-empty">No workspaces yet.</div>
+        )}
+        {workspaces.map((w) => {
+          const isExpanded = expanded.has(w.project);
+          const name = w.name || basename(w.cwd) || w.project;
+          return (
+            <div key={w.project} className={'kx-sb-ws' + (isExpanded ? ' open' : '')}>
+              <div
+                className={'kx-sb-ws-head' + (w.project === activeProject ? ' active' : '')}
+                onClick={() => {
+                  toggle(w.project);
+                  navigate(`/w/${encodeURIComponent(w.project)}`);
+                }}
+              >
+                <span className="kx-sb-ws-arrow">{isExpanded ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}</span>
+                <span className="kx-sb-ws-name">{name}</span>
+                <span className="kx-sb-ws-count">{w.sessionCount}</span>
+              </div>
+              {isExpanded && (
+                <div className="kx-sb-ws-sessions">
+                  {w.sessions.map((s) => {
+                    const pinned = (canvasBy[w.project] || []).includes(s.sessionId);
+                    return (
+                      <div
+                        key={s.sessionId}
+                        className={'kx-sb-thread' + (pinned ? ' pinned' : '')}
+                        onClick={() => {
+                          // Click to add to canvas; re-click on pinned focuses it.
+                          if (!pinned) toggleCanvasSid(w.project, s.sessionId);
+                          else focusCanvasSid(w.project, s.sessionId);
+                          if (activeProject !== w.project) {
+                            navigate(`/w/${encodeURIComponent(w.project)}`);
+                          }
+                        }}
+                        title={s.cwd}
+                      >
+                        <span className="kx-sb-thread-title">
+                          {s.title || s.preview || s.sessionId.slice(0, 8)}
+                        </span>
+                        <button
+                          type="button"
+                          className={'kx-sb-thread-pin' + (pinned ? ' pinned' : '')}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleCanvasSid(w.project, s.sessionId);
+                            if (activeProject !== w.project) {
+                              navigate(`/w/${encodeURIComponent(w.project)}`);
+                            }
+                          }}
+                          title={pinned ? 'Remove from canvas' : 'Add to canvas'}
+                        >{pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}</button>
+                        <button
+                          className="kx-sb-thread-del"
+                          onClick={(e) => del(e, s.sessionId)}
+                          title="Delete"
+                        ><X size={14} aria-hidden="true" /></button>
+                      </div>
+                    );
+                  })}
+                  {w.sessions.length === 0 && (
+                    <div className="kx-sb-thread empty">No threads</div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="kx-sb-grow" />
+
+      <Link className="kx-sb-settings" to="/settings">
+        <span><Settings size={16} aria-hidden="true" /></span>
+        <span>Settings</span>
+      </Link>
+
+      <footer className="kx-sb-foot">
+        <div className={'kx-sb-status kx-sb-status-' + status}>
+          <Circle className="kx-sb-status-dot" size={8} fill="currentColor" strokeWidth={0} aria-hidden="true" />
+          {status === 'ok' ? providerLabel || 'online' : status === 'bad' ? 'config missing' : 'connecting…'}
+        </div>
+      </footer>
+    </aside>
+  );
+}

--- a/web/src/kimi/KimiWorkspace.tsx
+++ b/web/src/kimi/KimiWorkspace.tsx
@@ -1,0 +1,304 @@
+// Kimi workspace canvas — port of Workspace.tsx into the kimi namespace.
+// Same dnd-kit sortable grid, same pointer-driven SE resize, same tile
+// grip / running progress bar / focus-only composer animation. Backed by
+// kimiApi (workspaces/threads) instead of the claude namespace.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Copy, RefreshCw, X } from 'lucide-react';
+import { kimiApi, type KimiThread, type KimiWorkspace as Wk } from './api';
+import { KimiChat } from './KimiChat';
+import {
+  useCanvas,
+  CANVAS_COLS,
+  MIN_COL_SPAN,
+  MAX_COL_SPAN,
+  MIN_ROW_SPAN,
+  MAX_ROW_SPAN,
+  type TileGeom,
+} from '../lib/canvas';
+import { subscribeSystemEvents } from '../lib/systemEvents';
+
+const ROW_UNIT_PX = 48;
+
+type ResizeState = {
+  sid: string;
+  startX: number;
+  startY: number;
+  startColSpan: number;
+  startRowSpan: number;
+  colPx: number;
+};
+
+function basename(p: string): string {
+  if (!p) return '';
+  const parts = p.split('/').filter(Boolean);
+  return parts[parts.length - 1] || p;
+}
+
+export function KimiWorkspace() {
+  const { project = '', sid: sidFromUrl = '' } = useParams();
+  const navigate = useNavigate();
+  const [workspace, setWorkspace] = useState<Wk | null>(null);
+  const [sessions, setSessions] = useState<KimiThread[] | null>(null);
+  const [error, setError] = useState('');
+  const canvas = useCanvas(project);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const resizeRef = useRef<ResizeState | null>(null);
+
+  const load = useCallback(() => {
+    kimiApi
+      .workspace(project)
+      .then((d) => {
+        setWorkspace(d.workspace);
+        setSessions(d.sessions);
+      })
+      .catch((e) => setError((e as Error).message));
+  }, [project]);
+
+  useEffect(() => {
+    setWorkspace(null);
+    setSessions(null);
+    load();
+    const t = setInterval(load, 15_000);
+    // Live-refresh on a kimi disk change (e.g. a terminal-started session in
+    // this workspace) so the list picks up external sessions without a manual
+    // refresh — mirrors the claude Workspace. Interval stays as a fallback.
+    const unsub = subscribeSystemEvents((ev) => {
+      if (ev.engine === 'kimi') load();
+    });
+    return () => {
+      clearInterval(t);
+      unsub();
+    };
+  }, [project, load]);
+
+  // Deep-link support: /w/:project/t/:sid pins + focuses, then rewrites URL.
+  useEffect(() => {
+    if (!sidFromUrl) return;
+    if (!canvas.isOnCanvas(sidFromUrl)) canvas.add(sidFromUrl);
+    canvas.focus(sidFromUrl);
+    navigate(`/w/${encodeURIComponent(project)}`, { replace: true });
+  }, [sidFromUrl, project, canvas, navigate]);
+
+  const name = workspace?.name || basename(workspace?.cwd || '') || project;
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const sids = useMemo(() => canvas.tiles.map((t) => t.sid), [canvas.tiles]);
+
+  const onDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const from = sids.indexOf(String(active.id));
+    const to = sids.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+    canvas.reorder(from, to);
+  };
+
+  const onResizeMove = useCallback((e: PointerEvent) => {
+    const r = resizeRef.current;
+    if (!r) return;
+    const dxCols = Math.round((e.clientX - r.startX) / (r.colPx + 12));
+    const dyRows = Math.round((e.clientY - r.startY) / (ROW_UNIT_PX + 12));
+    const nextCol = Math.max(MIN_COL_SPAN, Math.min(MAX_COL_SPAN, r.startColSpan + dxCols));
+    const nextRow = Math.max(MIN_ROW_SPAN, Math.min(MAX_ROW_SPAN, r.startRowSpan + dyRows));
+    canvas.resize(r.sid, { colSpan: nextCol, rowSpan: nextRow });
+  }, [canvas]);
+
+  const onResizeEnd = useCallback(() => {
+    resizeRef.current = null;
+    window.removeEventListener('pointermove', onResizeMove);
+  }, [onResizeMove]);
+
+  const startResize = (sid: string, e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const tile = canvas.tiles.find((t) => t.sid === sid);
+    if (!tile) return;
+    const grid = gridRef.current;
+    if (!grid) return;
+    const gridRect = grid.getBoundingClientRect();
+    const gapPx = 12;
+    const colPx = (gridRect.width - gapPx * (CANVAS_COLS - 1)) / CANVAS_COLS;
+    resizeRef.current = {
+      sid,
+      startX: e.clientX,
+      startY: e.clientY,
+      startColSpan: tile.colSpan,
+      startRowSpan: tile.rowSpan,
+      colPx,
+    };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    window.addEventListener('pointermove', onResizeMove);
+    window.addEventListener('pointerup', onResizeEnd, { once: true });
+  };
+
+  if (error) return <div className="kx-canvas-error">Error: {error}</div>;
+  if (!sessions) return <div className="kx-canvas-loading">Loading…</div>;
+
+  return (
+    <section className="kx-canvas">
+      <header className="kx-canvas-head">
+        <div className="kx-canvas-title">
+          <span className="kx-canvas-name">{name}</span>
+          <span className="kx-canvas-meta">
+            {canvas.tiles.length} pinned · {sessions.length} in workspace
+          </span>
+        </div>
+      </header>
+
+      {canvas.tiles.length === 0 ? (
+        <div className="kx-canvas-empty">
+          <p>Canvas is empty.</p>
+          <p className="muted">
+            Pick threads from the sidebar (click one to pin it) or start a
+            new one.
+          </p>
+        </div>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+          <SortableContext items={sids} strategy={rectSortingStrategy}>
+            <div
+              className="kx-canvas-grid"
+              ref={gridRef}
+              style={{
+                gridTemplateColumns: `repeat(${CANVAS_COLS}, 1fr)`,
+                gridAutoRows: `${ROW_UNIT_PX}px`,
+              }}
+            >
+              {canvas.tiles.map((tile) => {
+                const meta = sessions.find((x) => x.sessionId === tile.sid);
+                const isFocused = canvas.focusedSid === tile.sid;
+                return (
+                  <SortableTile
+                    key={tile.sid}
+                    tile={tile}
+                    label={meta?.preview?.slice(0, 60) || tile.sid.slice(0, 8)}
+                    isFocused={isFocused}
+                    onFocus={() => canvas.focus(tile.sid)}
+                    onRemove={() => canvas.remove(tile.sid)}
+                    onResizeStart={(e) => startResize(tile.sid, e)}
+                  />
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+    </section>
+  );
+}
+
+function SortableTile({
+  tile,
+  label,
+  isFocused,
+  onFocus,
+  onRemove,
+  onResizeStart,
+}: {
+  tile: TileGeom;
+  label: string;
+  isFocused: boolean;
+  onFocus: () => void;
+  onRemove: () => void;
+  onResizeStart: (e: React.PointerEvent) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: tile.sid });
+  const [isRunning, setIsRunning] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const style: React.CSSProperties = {
+    gridColumn: `span ${tile.colSpan}`,
+    gridRow: `span ${tile.rowSpan}`,
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 5 : undefined,
+    opacity: isDragging ? 0.85 : 1,
+  };
+
+  const copyResume = () => {
+    void navigator.clipboard.writeText(`kimi -r ${tile.sid}`);
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`kx-tile${isFocused ? ' focused' : ''}${isDragging ? ' dragging' : ''}${isRunning ? ' running' : ''}`}
+      style={style}
+      onClick={() => { if (!isFocused) onFocus(); }}
+    >
+      {isRunning && <div className="kx-tile-runbar" aria-hidden />}
+      <div className="kx-tile-grip" {...attributes} {...listeners} title="Drag to reorder">
+        <span className="kx-tile-grip-dots">⋮⋮</span>
+        <span className="kx-tile-grip-label">{label}</span>
+        <button
+          type="button"
+          className="kx-tile-action"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => { e.stopPropagation(); copyResume(); }}
+          title="Copy `kimi -r` command"
+          aria-label="Copy resume command"
+        >
+          <Copy size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className="kx-tile-action"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => { e.stopPropagation(); setRefreshKey((k) => k + 1); }}
+          title="Refresh"
+          aria-label="Refresh"
+        >
+          <RefreshCw size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className="kx-tile-action kx-tile-action-danger"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
+          title="Remove from canvas"
+          aria-label="Remove from canvas"
+        >
+          <X size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+      </div>
+      <div className="kx-tile-body">
+        <KimiChat
+          sid={tile.sid}
+          focused={isFocused}
+          hideBar
+          refreshKey={refreshKey}
+          onSendingChange={setIsRunning}
+        />
+      </div>
+      <div
+        className="kx-tile-resize"
+        onPointerDown={onResizeStart}
+        title="Drag to resize"
+        aria-label="Resize"
+      />
+    </div>
+  );
+}

--- a/web/src/kimi/api.ts
+++ b/web/src/kimi/api.ts
@@ -1,0 +1,92 @@
+// Kimi WebUI ↔ server API. Namespaced under /api/kimi/*.
+
+import type {
+  SessionListItem,
+  SessionDetail,
+  Workspace,
+} from '@macaron/shared';
+import { authedFetch } from '../lib/auth';
+
+export type KimiThread = SessionListItem;
+export type KimiWorkspace = Workspace;
+
+export type KimiProviderType = 'kimi' | 'anthropic' | 'openai';
+
+export type PublicKimiProvider = {
+  id: string;
+  name: string;
+  model: string;
+  baseUrl: string;
+  providerType: KimiProviderType;
+  configured: boolean;
+};
+
+export type PublicKimiBuiltin = {
+  id: 'system';
+  name: string;
+  description: string;
+  detectedEndpoint: string | null;
+  detectedModel: string | null;
+};
+
+export type PublicKimiSettings = {
+  activeProviderId: string;
+  builtins: PublicKimiBuiltin[];
+  customProviders: PublicKimiProvider[];
+};
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await authedFetch(url);
+  if (!r.ok) throw new Error(`http ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
+async function reqJSON<T>(url: string, init: RequestInit): Promise<T> {
+  const r = await authedFetch(url, init);
+  if (!r.ok) throw new Error(`http ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return r.json() as Promise<T>;
+}
+
+export const kimiApi = {
+  threads: () => getJSON<{ threads: KimiThread[] }>('/api/kimi/threads'),
+  workspaces: () => getJSON<{ workspaces: KimiWorkspace[] }>('/api/kimi/workspaces'),
+  workspace: (project: string) =>
+    getJSON<{ workspace: KimiWorkspace; sessions: KimiThread[] }>(
+      `/api/kimi/workspaces/${encodeURIComponent(project)}`,
+    ),
+  thread: (sid: string) => getJSON<SessionDetail>(`/api/kimi/threads/${encodeURIComponent(sid)}`),
+  deleteThread: async (sid: string): Promise<void> => {
+    const r = await authedFetch(`/api/kimi/threads/${encodeURIComponent(sid)}`, { method: 'DELETE' });
+    if (!r.ok) throw new Error(`http ${r.status}`);
+  },
+  stopThread: (sid: string) =>
+    reqJSON<{ ok: boolean; running: boolean }>(
+      `/api/kimi/threads/${encodeURIComponent(sid)}/stop`,
+      { method: 'POST' },
+    ),
+  config: () => getJSON<PublicKimiSettings>('/api/kimi/config'),
+  setActive: (providerId: string) =>
+    reqJSON<PublicKimiSettings>('/api/kimi/config/active', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ providerId }),
+    }),
+  createProvider: (patch: Partial<PublicKimiProvider> & { apiKey?: string }) =>
+    reqJSON<{ id: string; settings: PublicKimiSettings }>('/api/kimi/config/providers', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(patch),
+    }),
+  updateProvider: (id: string, patch: Partial<PublicKimiProvider> & { apiKey?: string }) =>
+    reqJSON<PublicKimiSettings>(`/api/kimi/config/providers/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(patch),
+    }),
+  deleteProvider: async (id: string): Promise<PublicKimiSettings> => {
+    const r = await authedFetch(`/api/kimi/config/providers/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (!r.ok) throw new Error(`http ${r.status}`);
+    return r.json();
+  },
+  engine: () => getJSON<{ engine: 'claude' | 'codex' | 'kimi' }>('/api/engine'),
+};

--- a/web/src/kimi/main.tsx
+++ b/web/src/kimi/main.tsx
@@ -1,0 +1,51 @@
+// Kimi WebUI entry. Separate from the claude entry so it doesn't pull in
+// the GenUI runtime, macaron-vendor, UnoCSS, etc. This bundle stays small
+// and focused on chat.
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { createHashRouter, RouterProvider } from 'react-router-dom';
+import { KimiApp } from './KimiApp';
+import { KimiChat } from './KimiChat';
+import { KimiSettings } from './KimiSettings';
+import { KimiWorkspace } from './KimiWorkspace';
+import { AuthGate } from '../components/AuthGate';
+import { ToastProvider } from '../components/Toast';
+import { ConfirmProvider } from '../components/Confirm';
+import { consumeHandoff } from '../lib/auth';
+import { registerServiceWorker } from '../lib/pwa';
+import './styles.css';
+import '../chat-code.css';
+
+// Pick up the hosted-mode handoff (docs connect page stashed {server, token}
+// same-tab in sessionStorage). The handoff binds the token to its server origin;
+// nothing secret rides the URL.
+consumeHandoff();
+
+const router = createHashRouter([
+  {
+    path: '/',
+    element: <KimiApp />,
+    children: [
+      { index: true, element: <KimiChat /> },
+      { path: 't/:sid', element: <KimiChat /> },
+      { path: 'w/:project', element: <KimiWorkspace /> },
+      { path: 'w/:project/t/:sid', element: <KimiWorkspace /> },
+      { path: 'settings', element: <KimiSettings /> },
+    ],
+  },
+]);
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <AuthGate>
+      <ToastProvider>
+        <ConfirmProvider>
+          <RouterProvider router={router} />
+        </ConfirmProvider>
+      </ToastProvider>
+    </AuthGate>
+  </React.StrictMode>,
+);
+
+registerServiceWorker();

--- a/web/src/kimi/stream.ts
+++ b/web/src/kimi/stream.ts
@@ -1,0 +1,104 @@
+// SSE consumers for the /api/kimi/threads endpoints. Parses `data:` frames
+// into typed events the chat view can consume with simple callbacks.
+
+import { authedFetch } from '../lib/auth';
+
+export type KimiStreamEvent =
+  | { type: 'starting'; cwd?: string }
+  | { type: 'meta'; sessionId: string; cwd?: string }
+  | { type: 'user-text'; text: string }
+  | { type: 'delta'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; text: string; isError: boolean }
+  | { type: 'usage'; outputTokens: number; thinkingTokens?: number }
+  | { type: 'event'; subtype: string }
+  | { type: 'error'; error: string }
+  | { type: 'done'; exitCode: number }
+  | { type: 'live-end'; reason?: string };
+
+export type KimiStreamHandlers = {
+  onMeta?: (sessionId: string, cwd?: string) => void;
+  onUserText?: (text: string) => void;
+  onDelta?: (text: string) => void;
+  onToolUse?: (ev: Extract<KimiStreamEvent, { type: 'tool_use' }>) => void;
+  onToolResult?: (ev: Extract<KimiStreamEvent, { type: 'tool_result' }>) => void;
+  onEvent?: (subtype: string) => void;
+  onUsage?: (out: number, thinking?: number) => void;
+  onError?: (msg: string) => void;
+  onDone?: (exitCode: number) => void;
+  onLiveEnd?: (reason?: string) => void;
+};
+
+// Text-only on purpose: `kimi -p` has no verified headless image input (see
+// KimiComposer), so the client never sends `images`.
+type Body = { text: string; cwd?: string };
+
+async function pump(resp: Response, h: KimiStreamHandlers): Promise<void> {
+  if (!resp.ok || !resp.body) {
+    const txt = await resp.text().catch(() => '');
+    h.onError?.(`http ${resp.status}: ${txt.slice(0, 200)}`);
+    return;
+  }
+  const reader = resp.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    const events = buf.split(/\r?\n\r?\n/);
+    buf = events.pop() || '';
+    for (const ev of events) {
+      const data = ev
+        .split(/\r?\n/)
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.slice(5).trimStart())
+        .join('\n')
+        .trim();
+      if (!data || data === '[DONE]') continue;
+      let p: KimiStreamEvent;
+      try { p = JSON.parse(data) as KimiStreamEvent; } catch { continue; }
+      switch (p.type) {
+        case 'meta': h.onMeta?.(p.sessionId, p.cwd); break;
+        case 'user-text': h.onUserText?.(p.text); break;
+        case 'delta': h.onDelta?.(p.text); break;
+        case 'tool_use': h.onToolUse?.(p); break;
+        case 'tool_result': h.onToolResult?.(p); break;
+        case 'event': h.onEvent?.(p.subtype); break;
+        case 'usage': h.onUsage?.(p.outputTokens, p.thinkingTokens); break;
+        case 'error': h.onError?.(p.error); break;
+        case 'done': h.onDone?.(p.exitCode); break;
+        case 'live-end': h.onLiveEnd?.(p.reason); break;
+      }
+    }
+  }
+}
+
+export async function startKimiThread(body: Body, h: KimiStreamHandlers): Promise<void> {
+  const resp = await authedFetch('/api/kimi/threads', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  await pump(resp, h);
+}
+
+export async function sendKimiMessage(sid: string, body: Body, h: KimiStreamHandlers): Promise<void> {
+  const resp = await authedFetch(`/api/kimi/threads/${encodeURIComponent(sid)}/message`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  await pump(resp, h);
+}
+
+// Passive viewer for the server-authoritative in-flight turn. The endpoint
+// replays its buffered snapshot before forwarding new events, so remounting a
+// thread after a refresh reconstructs the same live UI as the original POST.
+export function subscribeKimiLive(sid: string, h: KimiStreamHandlers): () => void {
+  const ac = new AbortController();
+  authedFetch(`/api/kimi/threads/${encodeURIComponent(sid)}/live`, { signal: ac.signal })
+    .then((resp) => pump(resp, h))
+    .catch(() => { /* aborted or disconnected; a remount replays the snapshot */ });
+  return () => ac.abort();
+}

--- a/web/src/kimi/styles.css
+++ b/web/src/kimi/styles.css
@@ -1,0 +1,1386 @@
+/* Kimi WebUI — ChatGPT-style monochrome palette. Grayscale only:
+   white/off-white surfaces, near-black text, thin gray borders. Layout is
+   the sidebar-workspaces + chat + composer rail; look is the OpenAI
+   product family (no warm cream, no accent color beyond text). */
+
+:root {
+  color-scheme: light;
+  --kx-bg: #fafafa;
+  --kx-surface: #ffffff;
+  --kx-sidebar: #f4f4f5;
+  --kx-hover: #ececec;
+  --kx-active: #e4e4e7;
+  --kx-code: #f4f4f5;
+  --kx-code-strong: #1a1a1d;
+  --kx-border: #ebebee;
+  --kx-border-strong: #d4d4d8;
+  --kx-text: #18181b;
+  --kx-text-2: #3f3f46;
+  --kx-muted: #71717a;
+  --kx-muted-2: #a1a1aa;
+  --kx-good: #4d8f5b;
+  --kx-warn: #b48a2f;
+  --kx-bad: #c53a3a;
+
+  --kx-radius-sm: 6px;
+  --kx-radius: 10px;
+  --kx-radius-lg: 14px;
+  --kx-radius-xl: 20px;
+  --kx-shadow-1: 0 1px 2px rgba(24, 24, 27, 0.04);
+  --kx-shadow-2: 0 2px 6px rgba(24, 24, 27, 0.06);
+  --kx-shadow-3: 0 8px 24px rgba(24, 24, 27, 0.08);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; margin: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+    Roboto, Arial, sans-serif;
+  background: var(--kx-bg);
+  color: var(--kx-text);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.kx-app {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  grid-template-rows: 100%;
+  background: var(--kx-bg);
+  color: var(--kx-text);
+  overflow: hidden;
+}
+
+/* ---------- Sidebar ---------- */
+
+.kx-sidebar {
+  background: var(--kx-sidebar);
+  border-right: 1px solid var(--kx-border);
+  padding: 18px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  overflow: hidden;
+}
+.kx-sb-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+  padding: 10px 12px;
+  background: #F2F2F0;
+  border-radius: 10px;
+}
+:root[data-theme="dark"] .kx-sb-brand { background: #35332C; }
+:root[data-theme="dark"] .kx-sb-brand-name { color: #7C97FF; }
+.kx-sb-logo {
+  width: 26px;
+  height: 26px;
+  opacity: 1;
+  flex-shrink: 0;
+}
+.kx-sb-brand-name {
+  font-weight: 500;
+  font-size: 14.5px;
+  line-height: 1.15;
+  letter-spacing: -0.1px;
+  color: #002BFF;
+}
+.kx-sb-brand-sub {
+  font-size: 11px;
+  color: #6B7280;
+  margin-top: -2px;
+  letter-spacing: 0.1px;
+}
+
+.kx-sb-new {
+  padding: 9px 12px;
+  background: var(--kx-surface);
+  color: var(--kx-text);
+  border: 1px solid var(--kx-border-strong);
+  border-radius: var(--kx-radius-sm);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: var(--kx-shadow-1);
+  transition: background 120ms, border-color 120ms, box-shadow 120ms;
+}
+.kx-sb-new:hover {
+  background: var(--kx-hover);
+  border-color: var(--kx-muted-2);
+  box-shadow: var(--kx-shadow-2);
+}
+.kx-sb-new > span:first-child {
+  font-size: 14px;
+  color: var(--kx-text-2);
+  line-height: 1;
+}
+
+.kx-sb-label {
+  padding: 10px 6px 2px;
+  font-size: 10.5px;
+  letter-spacing: 1.4px;
+  color: var(--kx-muted);
+  font-weight: 500;
+}
+
+.kx-sb-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 2px;
+  padding-bottom: 4px;
+}
+
+/* Workspace group */
+.kx-sb-ws { margin-bottom: 2px; }
+.kx-sb-ws-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: var(--kx-radius-sm);
+  cursor: pointer;
+  color: var(--kx-text);
+  font-size: 13px;
+  font-weight: 500;
+  transition: background 120ms;
+}
+.kx-sb-ws-head:hover { background: var(--kx-hover); }
+.kx-sb-ws-arrow {
+  width: 12px;
+  color: var(--kx-muted-2);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+.kx-sb-ws-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.kx-sb-ws-count {
+  font-size: 10.5px;
+  color: var(--kx-muted);
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--kx-border);
+  min-width: 22px;
+  text-align: center;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+}
+.kx-sb-ws-sessions {
+  padding: 2px 0 6px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.kx-sb-thread {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--kx-radius-sm);
+  cursor: pointer;
+  font-size: 12.5px;
+  color: var(--kx-text-2);
+  transition: background 100ms, color 100ms;
+}
+.kx-sb-thread:hover {
+  background: var(--kx-hover);
+  color: var(--kx-text);
+}
+.kx-sb-thread.active {
+  background: var(--kx-active);
+  color: var(--kx-text);
+}
+.kx-sb-thread.empty {
+  color: var(--kx-muted-2);
+  cursor: default;
+  font-style: italic;
+  font-size: 12px;
+  padding: 4px 10px;
+}
+.kx-sb-thread.empty:hover { background: transparent; }
+.kx-sb-thread-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.kx-sb-thread-del {
+  visibility: hidden;
+  background: transparent;
+  border: 0;
+  color: var(--kx-muted);
+  cursor: pointer;
+  padding: 0 5px;
+  font-size: 15px;
+  line-height: 1;
+  border-radius: 4px;
+}
+.kx-sb-thread:hover .kx-sb-thread-del { visibility: visible; }
+.kx-sb-thread-del:hover { color: var(--kx-bad); background: rgba(197, 58, 58, 0.10); }
+
+.kx-sb-empty {
+  padding: 24px 14px;
+  color: var(--kx-muted);
+  font-size: 12.5px;
+  text-align: center;
+}
+
+.kx-sb-grow { flex: 0.001; }
+.kx-sb-settings {
+  padding: 8px 10px;
+  color: var(--kx-text-2);
+  text-decoration: none;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.kx-sb-settings:hover { background: var(--kx-hover); color: var(--kx-text); }
+.kx-sb-foot {
+  border-top: 1px solid var(--kx-border);
+  padding: 10px 8px 2px;
+  color: var(--kx-muted);
+  font-size: 11.5px;
+}
+.kx-sb-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.kx-sb-status-dot { color: var(--kx-muted-2); flex-shrink: 0; }
+.kx-sb-status-ok .kx-sb-status-dot { color: var(--kx-good); }
+.kx-sb-status-bad .kx-sb-status-dot { color: var(--kx-bad); }
+
+/* ---------- Main ---------- */
+
+.kx-view {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--kx-bg);
+}
+.kx-main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.kx-main-head {
+  height: 56px;
+  padding: 0 26px;
+  border-bottom: 1px solid var(--kx-border);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  background: var(--kx-bg);
+}
+.kx-main-head-title {
+  font-weight: 600;
+  font-size: 14.5px;
+  color: var(--kx-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: -0.1px;
+}
+.kx-main-head-dot { color: var(--kx-muted-2); }
+.kx-main-head-sub {
+  color: var(--kx-muted);
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+.kx-main-head-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--kx-muted);
+  font-size: 12px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+.kx-main-scroll {
+  flex: 1;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}
+.kx-thread-body {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 24px 24px 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ---------- Messages ---------- */
+
+.kx-msg {
+  display: flex;
+  padding: 16px 0;
+  align-items: flex-start;
+}
+.kx-msg + .kx-msg { border-top: 1px solid transparent; }
+.kx-msg-body {
+  flex: 1;
+  min-width: 0;
+  padding-top: 2px;
+}
+.kx-msg-role {
+  font-size: 11px;
+  color: var(--kx-muted);
+  font-weight: 500;
+  margin-bottom: 5px;
+  letter-spacing: 0.2px;
+}
+.kx-msg-text {
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--kx-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.kx-msg-text code {
+  background: var(--kx-code);
+  padding: 1.5px 6px;
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  color: var(--kx-text);
+}
+
+/* Markdown mode: assistant messages render via react-markdown, so we
+   restore the block-level styles that white-space: pre-wrap swallowed. */
+.kx-msg-text.md { white-space: normal; }
+.kx-msg-text.md p { margin: 0 0 10px; }
+.kx-msg-text.md p:last-child { margin-bottom: 0; }
+.kx-msg-text.md h1,
+.kx-msg-text.md h2,
+.kx-msg-text.md h3,
+.kx-msg-text.md h4 { margin: 16px 0 8px; font-weight: 600; line-height: 1.35; }
+.kx-msg-text.md h1 { font-size: 20px; }
+.kx-msg-text.md h2 { font-size: 17px; }
+.kx-msg-text.md h3 { font-size: 15px; }
+.kx-msg-text.md h4 { font-size: 14px; }
+.kx-msg-text.md ul,
+.kx-msg-text.md ol { margin: 6px 0 10px; padding-left: 22px; }
+.kx-msg-text.md li { margin: 2px 0; }
+.kx-msg-text.md li > p { margin: 0; }
+.kx-msg-text.md pre {
+  background: var(--kx-code);
+  border: 0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 8px 0 12px;
+  overflow-x: auto;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.kx-msg-text.md pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+  color: inherit;
+}
+.kx-msg-text.md blockquote {
+  margin: 6px 0 10px;
+  padding: 2px 12px;
+  border-left: 3px solid var(--kx-border);
+  color: var(--kx-text-2, var(--kx-text));
+  opacity: 0.85;
+}
+.kx-msg-text.md table {
+  border-collapse: collapse;
+  margin: 8px 0 12px;
+  font-size: 13px;
+}
+.kx-msg-text.md th,
+.kx-msg-text.md td { border: 1px solid var(--kx-border); padding: 4px 10px; }
+.kx-msg-text.md th { background: var(--kx-sidebar); font-weight: 600; text-align: left; }
+.kx-msg-text.md a { color: var(--kx-accent, #C96442); text-decoration: underline; }
+.kx-msg-text.md hr { border: 0; border-top: 1px solid var(--kx-border); margin: 12px 0; }
+
+/* ---------- Thinking dots (tail of thread while a turn is in flight) --- */
+.kx-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 0 12px;
+}
+.kx-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--kx-text);
+  animation: kx-dot-pulse 1.2s ease-in-out infinite;
+}
+.kx-dot:nth-child(1) { animation-delay: 0s; }
+.kx-dot:nth-child(2) { animation-delay: 0.18s; }
+.kx-dot:nth-child(3) { animation-delay: 0.36s; }
+@keyframes kx-dot-pulse {
+  0%, 60%, 100% { background: var(--kx-text); opacity: 0.9; transform: scale(1); }
+  30%           { background: var(--kx-muted-2); opacity: 0.35; transform: scale(0.7); }
+}
+
+/* ---------- Reasoning ---------- */
+
+.kx-reasoning {
+  margin: 6px 0 10px 0;
+  padding: 8px 12px;
+  background: var(--kx-sidebar);
+  border: 1px solid var(--kx-border);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--kx-text-2);
+}
+.kx-reasoning-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--kx-muted);
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  font-size: 11.5px;
+  text-transform: uppercase;
+}
+.kx-reasoning-head:hover { color: var(--kx-text); }
+.kx-reasoning-caret { font-size: 11px; }
+.kx-reasoning-body {
+  margin-top: 8px;
+  padding-left: 10px;
+  border-left: 2px solid var(--kx-border-strong);
+  color: var(--kx-text-2);
+  font-style: italic;
+  white-space: pre-wrap;
+}
+
+/* ---------- GenUI (render_ui) cards ---------- */
+
+.kx-genui {
+  margin: 12px 0 12px 0;
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-lg);
+  background: var(--kx-surface);
+  overflow: hidden;
+  box-shadow: var(--kx-shadow-1);
+}
+.kx-genui-head {
+  padding: 9px 12px;
+  background: var(--kx-sidebar);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--kx-border);
+  font-size: 12.5px;
+}
+.kx-genui-glyph {
+  width: 20px; height: 20px;
+  display: grid; place-items: center;
+  background: linear-gradient(135deg, #C96442, #b45533);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.kx-genui-name {
+  font-weight: 500;
+  color: var(--kx-text);
+}
+.kx-genui-status {
+  margin-left: auto;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--kx-active);
+  color: var(--kx-muted);
+}
+.kx-genui-status.err { background: rgba(192, 82, 74, 0.14); color: #a04037; }
+.kx-genui-loading {
+  padding: 32px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--kx-muted);
+}
+.kx-genui-details {
+  padding: 8px 12px 10px;
+  font-size: 12px;
+  color: var(--kx-muted);
+  border-top: 1px solid var(--kx-border);
+}
+.kx-genui-details summary { cursor: pointer; padding: 4px 0; }
+.kx-genui-details pre {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  background: var(--kx-code);
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  color: var(--kx-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+/* Preview iframe styling — same restraint as Claude side's GenUI host. */
+.kx-genui .genui-host {
+  padding: 12px;
+  background: var(--kx-bg, var(--kx-surface));
+}
+.kx-genui .genui-status {
+  padding: 6px 12px 8px;
+  font-size: 10.5px;
+  color: var(--kx-muted);
+  letter-spacing: 0.3px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+.kx-genui .genui-status.ok { color: #4a8b4a; }
+.kx-genui .genui-status.err { color: #c0524a; }
+
+/* ---------- Tool cards ---------- */
+
+.kx-tool {
+  margin: 10px 0 10px 0;
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-lg);
+  background: var(--kx-surface);
+  overflow: hidden;
+  font-size: 13px;
+  box-shadow: var(--kx-shadow-1);
+}
+.kx-tool.err { border-color: rgba(197, 58, 58, 0.35); }
+.kx-tool-head {
+  padding: 9px 12px;
+  background: var(--kx-sidebar);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--kx-border);
+}
+.kx-tool-glyph {
+  width: 20px; height: 20px;
+  display: grid; place-items: center;
+  background: var(--kx-code-strong);
+  color: #fff;
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+}
+.kx-tool-name {
+  font-weight: 600;
+  color: var(--kx-text);
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+}
+.kx-tool-status {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--kx-muted);
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+.kx-tool-status.err { color: var(--kx-bad); }
+.kx-tool-cmd {
+  padding: 10px 12px;
+  background: var(--kx-code-strong);
+  color: #e8e8ea;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  line-height: 1.55;
+}
+.kx-tool-cmd::before {
+  content: '$ ';
+  color: #a0d0a5;
+  font-weight: 600;
+}
+.kx-tool-out {
+  padding: 10px 12px;
+  background: #17181c;
+  color: #cfcfd4;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  max-height: 260px;
+  overflow-y: auto;
+  line-height: 1.6;
+  border-top: 1px solid #2a2b30;
+}
+.kx-tool-out.err {
+  background: #2a1414;
+  color: #ffb6b6;
+}
+.kx-tool-more {
+  width: 100%;
+  padding: 6px 12px;
+  background: var(--kx-sidebar);
+  border: 0;
+  border-top: 1px solid var(--kx-border);
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--kx-muted);
+  cursor: pointer;
+  letter-spacing: 0.3px;
+}
+.kx-tool-more:hover { color: var(--kx-text); }
+
+/* ---------- Composer ---------- */
+
+.kx-composer-wrap {
+  position: sticky;
+  bottom: 0;
+  padding: 22px 28px 26px;
+  background: linear-gradient(180deg, rgba(250, 250, 250, 0), var(--kx-bg) 45%);
+  z-index: 10;
+}
+.kx-composer {
+  max-width: 820px;
+  margin: 0 auto;
+  background: var(--kx-surface);
+  border: 1px solid var(--kx-border-strong);
+  border-radius: var(--kx-radius-xl);
+  padding: 10px 14px 10px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: var(--kx-shadow-2);
+  transition: border-color 140ms, box-shadow 140ms;
+}
+.kx-composer:focus-within {
+  border-color: var(--kx-text);
+  box-shadow: var(--kx-shadow-3);
+}
+.kx-composer-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+.kx-composer textarea {
+  flex: 1;
+  border: 0;
+  outline: none;
+  background: transparent;
+  resize: none;
+  font: inherit;
+  font-size: 14.5px;
+  color: var(--kx-text);
+  padding: 7px 2px;
+  max-height: 220px;
+  min-height: 24px;
+  line-height: 1.55;
+}
+.kx-composer textarea::placeholder { color: var(--kx-muted-2); }
+.kx-send {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 0;
+  background: var(--kx-text);
+  color: #fff;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 15px;
+  transition: background 120ms, transform 120ms;
+  flex-shrink: 0;
+}
+.kx-send:hover:not(:disabled) { background: #000; transform: translateY(-0.5px); }
+.kx-send:disabled { background: var(--kx-border-strong); cursor: not-allowed; color: #fff; transform: none; }
+.kx-send.stop { background: var(--kx-bad); font-size: 10.5px; }
+.kx-send.stop:hover:not(:disabled) { background: #a12e2e; }
+.kx-composer-foot {
+  max-width: 820px;
+  margin: 10px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.kx-composer-hint {
+  font-size: 11px;
+  color: var(--kx-muted-2);
+  letter-spacing: 0.1px;
+  flex-shrink: 0;
+}
+
+/* --- Provider chip in the composer footer --- */
+.kx-provider-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 10px;
+  border: 1px solid var(--kx-border-strong);
+  border-radius: 999px;
+  background: var(--kx-surface);
+  color: var(--kx-text-2, var(--kx-muted));
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 100ms, border-color 100ms, color 100ms;
+  max-width: 260px;
+}
+.kx-provider-chip:hover { background: var(--kx-active); color: var(--kx-text); border-color: var(--kx-text); }
+.kx-provider-chip.busy { opacity: 0.6; cursor: progress; }
+.kx-provider-chip-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.kx-provider-chip-caret { opacity: 0.6; }
+.kx-provider-chip-select {
+  /* Invisible native <select> that owns the click + keyboard menu. */
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.kx-provider-chip.busy .kx-provider-chip-select { pointer-events: none; }
+
+.kx-composer-pickers {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+/* ---------- Home ---------- */
+
+.kx-home {
+  min-height: calc(100vh - 220px);
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+.kx-home-inner { text-align: center; max-width: 520px; }
+.kx-home-title {
+  font-weight: 600;
+  font-size: 30px;
+  color: var(--kx-text);
+  margin: 0 0 12px;
+  letter-spacing: -0.2px;
+}
+.kx-home-sub {
+  color: var(--kx-muted);
+  font-size: 14.5px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ---------- Settings ---------- */
+
+.kx-settings {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 28px 28px 80px;
+  overflow-y: auto;
+  height: 100%;
+  width: 100%;
+}
+.kx-settings-head { margin-bottom: 20px; }
+.kx-settings-loading {
+  padding: 60px 0;
+  text-align: center;
+  color: var(--kx-muted);
+  font-size: 13px;
+}
+.kx-settings-grid {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+.kx-settings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  background: var(--kx-surface);
+  border: 1px solid var(--kx-border);
+  border-radius: 12px;
+  position: sticky;
+  top: 20px;
+}
+.kx-settings-list-label {
+  padding: 10px 8px 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  color: var(--kx-muted);
+  text-transform: uppercase;
+}
+.kx-plist-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: var(--kx-text);
+  transition: background 100ms, border-color 100ms;
+}
+.kx-plist-row:hover { background: var(--kx-active); }
+.kx-plist-row.selected {
+  background: var(--kx-active);
+  border-color: var(--kx-border-strong);
+}
+.kx-plist-row.active { box-shadow: inset 3px 0 0 var(--kx-text); }
+.kx-plist-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.kx-plist-row-name {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--kx-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+.kx-plist-active-badge,
+.kx-plist-warn {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+.kx-plist-active-badge {
+  background: var(--kx-text);
+  color: var(--kx-surface);
+}
+.kx-plist-warn {
+  background: rgba(184, 138, 58, 0.15);
+  color: #8a6626;
+}
+.kx-plist-row-sub {
+  font-size: 11.5px;
+  color: var(--kx-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kx-plist-empty {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--kx-muted);
+  font-style: italic;
+}
+.kx-plist-add {
+  margin-top: 6px;
+  padding: 9px 12px;
+  background: transparent;
+  border: 1px dashed var(--kx-border-strong);
+  border-radius: 8px;
+  color: var(--kx-muted);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: color 100ms, border-color 100ms;
+}
+.kx-plist-add:hover { color: var(--kx-text); border-color: var(--kx-text); }
+.kx-settings-pane { display: flex; flex-direction: column; gap: 16px; }
+.kx-settings-empty {
+  padding: 32px;
+  border: 1px dashed var(--kx-border);
+  border-radius: 12px;
+  color: var(--kx-muted);
+  text-align: center;
+  font-size: 13px;
+}
+.kx-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.kx-section-head h2 { margin: 0; }
+.kx-section-body {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--kx-text-2, var(--kx-muted));
+  line-height: 1.55;
+}
+.kx-section-note {
+  margin: 12px 0 0;
+  font-size: 12.5px;
+  color: var(--kx-muted);
+  line-height: 1.5;
+}
+.kx-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+.kx-active-pill {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--kx-text);
+  color: var(--kx-surface);
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+.kx-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--kx-border-strong);
+  background: var(--kx-surface);
+  color: var(--kx-text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 100ms, border-color 100ms, color 100ms;
+}
+.kx-btn:hover:not(:disabled) { border-color: var(--kx-text); }
+.kx-btn:disabled { color: var(--kx-muted); cursor: not-allowed; }
+.kx-btn.primary {
+  background: var(--kx-text);
+  color: var(--kx-surface);
+  border-color: var(--kx-text);
+}
+.kx-btn.primary:hover:not(:disabled) { background: #000; border-color: #000; }
+.kx-btn.danger {
+  border-color: rgba(192, 82, 74, 0.4);
+  color: #a04037;
+}
+.kx-btn.danger:hover { background: rgba(192, 82, 74, 0.08); border-color: #a04037; }
+.kx-kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 16px;
+  row-gap: 6px;
+  margin: 8px 0 0;
+}
+.kx-kv dt {
+  font-size: 12px;
+  color: var(--kx-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.kx-kv dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--kx-text);
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  word-break: break-all;
+}
+.kx-kv dd em { color: var(--kx-muted); font-style: normal; }
+.kx-settings-flash {
+  position: fixed;
+  bottom: 22px;
+  right: 22px;
+  padding: 10px 16px;
+  background: var(--kx-text);
+  color: var(--kx-surface);
+  border-radius: 10px;
+  font-size: 13px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.16);
+  z-index: 90;
+}
+.kx-settings h1 {
+  font-weight: 600;
+  font-size: 26px;
+  margin: 0 0 6px;
+  color: var(--kx-text);
+  letter-spacing: -0.2px;
+}
+.kx-settings-sub {
+  color: var(--kx-muted);
+  margin: 0 0 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+.kx-settings-sub code {
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  background: var(--kx-code);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.kx-settings-section {
+  background: var(--kx-surface);
+  border: 1px solid var(--kx-border);
+  border-radius: 12px;
+  padding: 20px 22px;
+  margin-bottom: 16px;
+}
+.kx-settings-section h2 {
+  font-weight: 600;
+  font-size: 15px;
+  margin: 0 0 14px;
+  color: var(--kx-text);
+}
+.kx-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.kx-field label {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--kx-muted);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+.kx-field small { font-size: 12px; color: var(--kx-muted); }
+.kx-field input, .kx-field select {
+  padding: 9px 11px;
+  border: 1px solid var(--kx-border-strong);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13.5px;
+  color: var(--kx-text);
+  background: var(--kx-surface);
+  transition: border-color 100ms;
+}
+.kx-field input:focus, .kx-field select:focus {
+  outline: none;
+  border-color: var(--kx-text);
+}
+.kx-field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.kx-save {
+  padding: 9px 20px;
+  background: var(--kx-text);
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 500;
+  transition: background 100ms;
+}
+.kx-save:hover:not(:disabled) { background: #000; }
+.kx-save:disabled { background: var(--kx-border-strong); cursor: not-allowed; }
+
+/* ---------- Sidebar workspace-head active state ---------- */
+.kx-sb-ws-head.active {
+  background: var(--kx-active);
+  color: var(--kx-text);
+}
+.kx-sb-thread.pinned { color: var(--kx-text); }
+.kx-sb-thread-pin {
+  visibility: hidden;
+  width: 20px; height: 20px;
+  border-radius: 4px;
+  background: transparent;
+  border: 1px solid var(--kx-border-strong);
+  color: var(--kx-muted);
+  cursor: pointer;
+  font-size: 11.5px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  padding: 0;
+}
+.kx-sb-thread:hover .kx-sb-thread-pin,
+.kx-sb-thread-pin.pinned { visibility: visible; }
+.kx-sb-thread-pin.pinned {
+  border-color: var(--kx-text);
+  background: var(--kx-text);
+  color: #fff;
+}
+
+/* ---------- Canvas ---------- */
+
+.kx-canvas {
+  padding: 24px 28px 40px;
+  overflow-y: auto;
+  height: 100%;
+  min-height: 0;
+}
+.kx-canvas-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+/* Inner title wraps name + meta; without its own gap the two spans jam
+   together ("linfan1 pinned · 12 in workspace"). */
+.kx-canvas-title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.kx-canvas-name {
+  font-size: 19px;
+  font-weight: 600;
+  color: var(--kx-text);
+  letter-spacing: -0.3px;
+}
+.kx-canvas-meta {
+  color: var(--kx-muted);
+  font-size: 12px;
+  letter-spacing: 0.1px;
+}
+.kx-canvas-empty {
+  text-align: center;
+  padding: 80px 20px;
+  color: var(--kx-muted);
+}
+.kx-canvas-empty p:first-child {
+  color: var(--kx-text);
+  font-size: 15px;
+  font-weight: 500;
+  margin: 0 0 6px;
+}
+.kx-canvas-empty p code {
+  background: var(--kx-code);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+.kx-canvas-loading, .kx-canvas-error {
+  padding: 40px;
+  color: var(--kx-muted);
+}
+.kx-canvas-grid {
+  display: grid;
+  gap: 14px;
+}
+
+/* ---------- Tile ---------- */
+
+.kx-tile {
+  position: relative;
+  background: var(--kx-surface);
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  box-shadow: var(--kx-shadow-1);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  cursor: pointer;
+}
+.kx-tile:hover:not(.focused) {
+  border-color: var(--kx-border-strong);
+  box-shadow: var(--kx-shadow-2);
+}
+.kx-tile.focused {
+  border-color: var(--kx-border-strong);
+  box-shadow: var(--kx-shadow-3);
+  cursor: default;
+}
+.kx-tile.dragging { border-color: var(--kx-muted-2); }
+
+/* Running indeterminate progress — thin bar sliding across the tile top. */
+.kx-tile-runbar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--kx-text), transparent);
+  background-size: 40% 100%;
+  background-repeat: no-repeat;
+  animation: cxRunbar 1.4s linear infinite;
+  z-index: 3;
+}
+@keyframes cxRunbar {
+  from { background-position: -40% 0; }
+  to { background-position: 140% 0; }
+}
+
+.kx-tile-grip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  border-bottom: 1px solid var(--kx-border);
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+  height: 38px;
+}
+.kx-tile-grip:active { cursor: grabbing; }
+.kx-tile-grip-dots {
+  color: var(--kx-muted-2);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: -2px;
+  flex-shrink: 0;
+  opacity: 0.7;
+  transition: opacity 120ms, color 120ms;
+}
+.kx-tile:hover .kx-tile-grip-dots { opacity: 1; color: var(--kx-muted); }
+.kx-tile-grip-label {
+  flex: 1;
+  font-size: 12.5px;
+  color: var(--kx-text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+  letter-spacing: -0.05px;
+}
+.kx-tile-action {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  border-radius: var(--kx-radius-sm);
+  color: var(--kx-muted);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 140ms, background 140ms, color 140ms;
+}
+.kx-tile-action svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+.kx-tile:hover .kx-tile-action,
+.kx-tile.focused .kx-tile-action { opacity: 1; }
+.kx-tile-action:hover { background: var(--kx-hover); color: var(--kx-text); }
+.kx-tile-action:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--kx-text);
+  outline-offset: 1px;
+}
+.kx-tile-action-danger:hover { background: rgba(197, 58, 58, 0.10); color: var(--kx-bad); }
+
+.kx-tile-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--kx-surface);
+}
+.kx-tile-body .kx-main {
+  height: 100%;
+  min-height: 0;
+}
+.kx-tile-body .kx-main-scroll { padding: 0; }
+.kx-tile-body .kx-thread-body {
+  padding: 14px 18px 8px;
+  gap: 2px;
+}
+.kx-tile-body .kx-msg { padding: 10px 0; }
+.kx-tile-body .kx-msg-text { font-size: 13.5px; line-height: 1.6; }
+.kx-tile-body .kx-msg-role { font-size: 10.5px; margin-bottom: 3px; }
+.kx-tile-body .kx-reasoning,
+.kx-tile-body .kx-tool { margin-left: 0; }
+.kx-tile-body .kx-tool { border-radius: var(--kx-radius); }
+.kx-tile-body .kx-tool-head { padding: 6px 10px; }
+.kx-tile-body .kx-tool-cmd,
+.kx-tile-body .kx-tool-out { padding: 8px 11px; font-size: 12px; }
+
+.kx-tile-resize {
+  position: absolute;
+  right: 0; bottom: 0;
+  width: 14px; height: 14px;
+  cursor: se-resize;
+  z-index: 4;
+  background:
+    linear-gradient(135deg, transparent 0 50%, var(--kx-muted-2) 50% 60%, transparent 60% 70%, var(--kx-muted-2) 70% 80%, transparent 80%);
+  opacity: 0;
+  transition: opacity 120ms;
+}
+.kx-tile:hover .kx-tile-resize,
+.kx-tile.focused .kx-tile-resize { opacity: 0.7; }
+.kx-tile-resize:hover { opacity: 1; }
+
+/* ---------- Composer show/hide animation ----------
+   Uses grid-template-rows 0fr↔1fr so height interpolates to the child's
+   actual measured height. Same trick as the claude Session composer. */
+
+.kx-composer-grid {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 260ms ease;
+}
+.kx-composer-grid.open {
+  grid-template-rows: 1fr;
+}
+.kx-composer-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Tile-mode composer sits inside the tile body (no page-level sticky). */
+.kx-tile-body .kx-composer-wrap {
+  position: relative;
+  padding: 8px 14px 14px;
+  background: transparent;
+  border-top: 1px solid var(--kx-border);
+}
+.kx-tile-body .kx-composer {
+  padding: 6px 10px 6px 14px;
+  border-radius: var(--kx-radius-lg);
+  box-shadow: var(--kx-shadow-1);
+}
+.kx-tile-body .kx-composer:focus-within { box-shadow: var(--kx-shadow-2); }
+.kx-tile-body .kx-composer textarea { font-size: 13px; padding: 5px 2px; }
+.kx-tile-body .kx-send { width: 28px; height: 28px; font-size: 13px; }
+.kx-tile-body .kx-composer-hint { display: none; }
+
+/* ---------- Scrollbar ---------- */
+
+.kx-app ::-webkit-scrollbar { width: 10px; height: 10px; }
+.kx-app ::-webkit-scrollbar-track { background: transparent; }
+.kx-app ::-webkit-scrollbar-thumb {
+  background: var(--kx-border-strong);
+  border-radius: 5px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+.kx-app ::-webkit-scrollbar-thumb:hover {
+  background: var(--kx-muted-2);
+  background-clip: content-box;
+}

--- a/web/src/views/Schedules.tsx
+++ b/web/src/views/Schedules.tsx
@@ -190,6 +190,7 @@ function ScheduleForm({ draft, onChange }: { draft: ScheduleInput; onChange: (pa
         <select id="s-engine" className="settings-input" value={draft.engine} onChange={(e) => onChange({ engine: e.target.value as SessionKind })}>
           <option value="claude">Claude</option>
           <option value="codex">Codex</option>
+          <option value="kimi">Kimi</option>
         </select>
       </div>
       <div className="settings-field">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,12 +18,13 @@ export default defineConfig({
     sourcemap: false,
     commonjsOptions: { transformMixedEsModules: true },
     rollupOptions: {
-      // Two SPA bundles: the claude UI at /index.html, the codex UI at
-      // /codex.html. Fastify picks which one to serve as `/` based on
-      // MACARON_ENGINE at boot.
+      // Three SPA bundles: the claude UI at /index.html, the codex UI at
+      // /codex.html, the kimi UI at /kimi.html. Fastify picks which one to
+      // serve as `/` based on MACARON_ENGINE at boot.
       input: {
         main: path.resolve(__dirname, 'index.html'),
         codex: path.resolve(__dirname, 'codex.html'),
+        kimi: path.resolve(__dirname, 'kimi.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds **Kimi Code** as a third engine alongside Claude Code and Codex, behind the same `MACARON_ENGINE` switch (`claude` / `codex` / `kimi`). One server binary, three SPA entries, three launchers.

- **Server** — new `/api/kimi/*` surface mirroring the codex routes: session discovery from `~/.kimi-code/sessions/` (`session_index.jsonl` fast path + bucket scan), a `wire.jsonl` transcript parser (user turns / thinking / tool calls / usage from `step.end`), and a runner that spawns `kimi -p <prompt> --output-format stream-json` (`-r <sid>` to resume). Custom providers are injected via the `KIMI_MODEL_*` env family, so the user's `~/.kimi-code/config.toml` is never rewritten; `system` = ambient OAuth login. Config lives in `~/.kimi-code/macaron-kimi-config.json`.
- **Web** — new `kimi.html` + `web/src/kimi/*` SPA cloned from the codex SPA (`kx-` styles, sans brand font per the d08527c precedent), minus runtime knobs / approval cards (kimi turns always auto-approve) and minus image attach (`kimi -p` has no verified headless image input — offering it would silently drop content).
- **Plugin** — `.kimi-plugin/plugin.json` + marketplace, `/macaron:macaron` slash command, and a `macaron-webui-kimi` launcher skill (port **7980**).
- **Packaging** — new `mkx` launcher package (`bunx mkx` → http://localhost:7980), `start.sh` kimi branch, pkg.pr.new publishes all three packages.
- **Docs/site** — README, USAGE, `architecture/kimi.mdx`, tri-engine overview/packaging/usage pages, and the hosted WebUI stages Kimi at `/app/kimi`.

## Verification

- `pnpm -w prepack` (shared → server bundle → web) ✅; `pnpm -C server test` 54/54 ✅; `pnpm -C web test` 53/53 ✅; site typecheck + 80 tests ✅
- Live smoke test (`MACARON_ENGINE=kimi` server): `/api/engine` → `kimi`, threads/workspaces/config endpoints return real `~/.kimi-code` data; SSE new-thread turn streams `delta` → `meta` (early session-id detection) → `usage` → `done`; resume via `-r` recalls context; delete works
- E2E through the actual WebUI (agent-browser): typed a prompt in the Kimi composer, watched the streamed reply land, workspace sidebar updated

## Notes

- stream-json carries no thinking/usage, so live turns emit no `reasoning` events; `usage` is derived best-effort from `wire.jsonl` after the turn
- New-session id is detected early by diffing the workDir bucket's session dirs (falls back to the final `session.resume_hint` meta line)