### PR TITLE
consume native session titles across providers

### DIFF
--- a/server/src/lib/codex-store.ts
+++ b/server/src/lib/codex-store.ts
@@ -343,6 +343,7 @@ export async function readCodexSessionMessages(sid: string): Promise<SessionDeta
     project: encodeCodexProjectName(cwd),
     cwd,
     gitBranch,
+    title: getCodexTitle(sid),
     messages,
     truncated: false,
     totalBytes: st.size,

--- a/server/src/lib/session-store.ts
+++ b/server/src/lib/session-store.ts
@@ -14,7 +14,7 @@ import type {
   Workspace,
 } from '@macaron/shared';
 import { CLAUDE_PROJECTS, HOME } from '../config.js';
-import { getLabels } from './label-store.js';
+import { deleteLabel, getLabels } from './label-store.js';
 
 export function basename(p: string): string {
   if (!p) return '';
@@ -27,6 +27,11 @@ export function decodeClaudeProjectName(encoded: string): string {
 
 type SessionSummary = {
   firstUserText: string;
+  // Claude-native session title, resolved with the same priority the CLI and
+  // the official Agent SDK use for `/resume`'s list: customTitle > aiTitle >
+  // lastPrompt > summary. Empty when the session has none of them (falls back
+  // to firstUserText downstream). See resolveNativeTitle.
+  title: string;
   cwd: string;
   gitBranch: string;
   headLines: number;
@@ -34,6 +39,36 @@ type SessionSummary = {
   mtime: number;
   size: number;
 };
+
+// Native title fields harvested from a session's jsonl, last-occurrence-wins
+// per field (the CLI appends `ai-title` / `custom-title` / updates lastPrompt
+// over the session's life). Kept as a struct so the head scan and the tail
+// scan can feed the same resolver.
+export type NativeTitleFields = {
+  customTitle?: string;
+  aiTitle?: string;
+  lastPrompt?: string;
+  summary?: string;
+};
+
+// Priority mirrors the official Agent SDK's list_sessions:
+// customTitle > aiTitle > lastPrompt > summary. firstPrompt is intentionally
+// NOT here — callers use it as the preview-level fallback instead.
+export function resolveNativeTitle(f: NativeTitleFields): string {
+  return f.customTitle || f.aiTitle || f.lastPrompt || f.summary || '';
+}
+
+// Fold one parsed jsonl entry into the accumulating title fields. Last write
+// wins, so calling this over head then tail yields the CLI's tail-preferred,
+// head-fallback semantics for free.
+function foldTitleFields(o: Record<string, unknown>, f: NativeTitleFields): void {
+  // A custom-title record with an empty string is an explicit clear tombstone
+  // (macaron's blank rename): reset the override so it falls back to ai-title.
+  if (o.type === 'custom-title' && typeof o.customTitle === 'string') f.customTitle = o.customTitle.trim() || undefined;
+  else if (o.type === 'ai-title' && typeof o.aiTitle === 'string' && o.aiTitle.trim()) f.aiTitle = o.aiTitle.trim();
+  if (typeof o.lastPrompt === 'string' && o.lastPrompt.trim()) f.lastPrompt = o.lastPrompt.trim();
+  if (o.type === 'summary' && typeof o.summary === 'string' && o.summary.trim()) f.summary = o.summary.trim();
+}
 
 type CacheEntry = { mtimeMs: number; size: number; summary: SessionSummary };
 
@@ -46,6 +81,30 @@ export async function deleteSession(project: string, sid: string): Promise<void>
   const filePath = path.join(CLAUDE_PROJECTS, project, `${sid}.jsonl`);
   await fs.unlink(filePath);
   summaryCache.delete(filePath);
+}
+
+// Rename a Claude session the native way: append a `custom-title` record to the
+// jsonl, exactly like the CLI's `/rename` does. Because resolveNativeTitle reads
+// customTitle first and foldTitleFields is last-write-wins, this both surfaces
+// in macaron's sidebar and is what `claude --resume` shows — the two stay in
+// sync instead of diverging into a separate label sidecar. A blank name appends
+// an empty customTitle, which clears the override (falling back to ai-title /
+// preview). Returns the trimmed title.
+export async function renameSession(project: string, sid: string, name: string): Promise<string> {
+  const base = path.resolve(CLAUDE_PROJECTS);
+  const filePath = path.resolve(base, project, `${sid}.jsonl`);
+  if (!(filePath + path.sep).startsWith(base + path.sep)) throw new Error('invalid session path');
+  const st = await fs.stat(filePath);
+  if (!st.isFile()) throw new Error('session is not a file');
+  const trimmed = name.trim();
+  const record = JSON.stringify({ type: 'custom-title', customTitle: trimmed, sessionId: sid, timestamp: new Date().toISOString() }) + '\n';
+  await fs.appendFile(filePath, record, 'utf8');
+  summaryCache.delete(filePath);
+  // Older Macaron releases stored labels in a sidecar. Remove that legacy
+  // override once the user renames natively, otherwise it would keep winning
+  // in the UI even though Claude now has a newer custom-title record.
+  await deleteLabel(sid);
+  return trimmed;
 }
 
 // Duplicate a claude session as a brand-new sid so both can be resumed
@@ -256,6 +315,7 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
 
   const summary: SessionSummary = {
     firstUserText: '',
+    title: '',
     cwd: '',
     gitBranch: '',
     headLines: 0,
@@ -263,6 +323,10 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
     mtime: st.mtimeMs,
     size: st.size,
   };
+
+  // Native title fields, folded head-first then tail-last so the tail's
+  // freshest ai-title/custom-title/lastPrompt win over any head occurrence.
+  const titleFields: NativeTitleFields = {};
 
   try {
     const fh = await fs.open(filePath, 'r');
@@ -277,9 +341,10 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
         const line = lines[i]!;
         if (!line.trim()) continue;
         summary.headLines++;
-        if (summary.firstUserText && summary.cwd) continue;
         try {
           const o = JSON.parse(line);
+          foldTitleFields(o, titleFields);
+          if (summary.firstUserText && summary.cwd) continue;
           if (!summary.cwd && o.cwd) summary.cwd = o.cwd;
           if (!summary.gitBranch && o.gitBranch) summary.gitBranch = o.gitBranch;
           if (!summary.firstUserText && o.type === 'user' && o.message?.content) {
@@ -306,9 +371,10 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
   // cwd sits at the END of each jsonl line (after `message`), so a huge first
   // paste can push the head's only cwd-bearing line past HEAD_BYTES, truncating
   // it unparseably. The same cwd repeats on every later line, and trailing lines
-  // are usually small — so when the head read came up empty on a truncated file,
-  // recover cwd (and gitBranch) from a tail read instead.
-  if (summary.truncated && !summary.cwd) {
+  // are usually small — so on a truncated file, tail-scan to recover cwd and to
+  // pick up the native title records (ai-title / custom-title / lastPrompt) the
+  // CLI appends near the end, which live past HEAD_BYTES.
+  if (summary.truncated) {
     try {
       const fh = await fs.open(filePath, 'r');
       try {
@@ -323,6 +389,7 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
           if (!line.trim()) continue;
           try {
             const o = JSON.parse(line);
+            foldTitleFields(o, titleFields);
             if (o.cwd) summary.cwd = o.cwd;
             if (!summary.gitBranch && o.gitBranch) summary.gitBranch = o.gitBranch;
           } catch {
@@ -337,6 +404,7 @@ export async function readSessionSummary(filePath: string): Promise<SessionSumma
     }
   }
 
+  summary.title = resolveNativeTitle(titleFields);
   summaryCache.set(filePath, { mtimeMs: st.mtimeMs, size: st.size, summary });
   return summary;
 }
@@ -497,6 +565,7 @@ export async function listAllSessions(): Promise<SessionListItem[]> {
       sessionId: t.sid,
       preview: (meta.firstUserText || '').slice(0, 220),
       label: labels[t.sid],
+      title: meta.title || undefined,
       messageCount: meta.headLines,
       messageCountSuffix: meta.truncated ? '+' : '',
       mtime: meta.mtime,
@@ -736,10 +805,15 @@ export async function readSessionMessages(project: string, sid: string): Promise
   } =
     await parseTranscriptFile(filePath);
 
-  const [claudeMdCount, mcpCount] = await Promise.all([
+  const [claudeMdCount, mcpCount, labels] = await Promise.all([
     countClaudeMd(cwd),
     countMcpServers(),
+    getLabels(),
   ]);
+
+  // Reuse the (cached) head/tail scan for the native title so the session
+  // header names the session the same way the sidebar does.
+  const title = (await readSessionSummary(filePath))?.title || undefined;
 
   // Tail reads intentionally drop the oldest bytes, so the measured visible
   // transcript can no longer explain the aggregate usage. Keep the accurate
@@ -757,6 +831,8 @@ export async function readSessionMessages(project: string, sid: string): Promise
     project,
     cwd,
     gitBranch,
+    label: labels[sid],
+    title,
     messages,
     truncated,
     totalBytes,

--- a/server/src/lib/session-title.test.ts
+++ b/server/src/lib/session-title.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+
+const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcc-title-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const { CLAUDE_PROJECTS } = await import('../config.js');
+const { getLabels, setLabel } = await import('./label-store.js');
+const { resolveNativeTitle, readSessionMessages, readSessionSummary, renameSession } = await import('./session-store.js');
+
+const project = 'mac-title-test';
+const projDir = path.join(CLAUDE_PROJECTS, project);
+await fs.mkdir(projDir, { recursive: true });
+after(() => fs.rm(tmpHome, { recursive: true, force: true }));
+
+// resolveNativeTitle mirrors the official Agent SDK's list priority:
+// customTitle > aiTitle > lastPrompt > summary.
+test('resolveNativeTitle honors customTitle > aiTitle > lastPrompt > summary', () => {
+  assert.equal(resolveNativeTitle({ customTitle: 'c', aiTitle: 'a', lastPrompt: 'l', summary: 's' }), 'c');
+  assert.equal(resolveNativeTitle({ aiTitle: 'a', lastPrompt: 'l', summary: 's' }), 'a');
+  assert.equal(resolveNativeTitle({ lastPrompt: 'l', summary: 's' }), 'l');
+  assert.equal(resolveNativeTitle({ summary: 's' }), 's');
+  assert.equal(resolveNativeTitle({}), '');
+});
+
+// End-to-end over a real jsonl: readSessionSummary must surface the native
+// title and renameSession's custom-title append must win over an ai-title.
+test('readSessionSummary + renameSession round-trip native titles', async () => {
+  const sid = 'sess';
+  const file = path.join(projDir, `${sid}.jsonl`);
+  const lines = [
+    { type: 'user', cwd: '/repo', gitBranch: 'main', message: { content: 'first prompt' } },
+    { type: 'assistant', message: { content: 'hi' } },
+    { type: 'ai-title', aiTitle: 'Old AI Title' },
+    { type: 'ai-title', aiTitle: 'Fresh AI Title' },
+  ];
+  await fs.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+
+  const s = await readSessionSummary(file);
+  assert.ok(s);
+  assert.equal(s.title, 'Fresh AI Title');
+  assert.equal(s.firstUserText, 'first prompt');
+
+  // A custom-title (native /rename) wins over any ai-title and reaches detail.
+  await renameSession(project, sid, 'My Custom Name');
+  assert.equal((await readSessionSummary(file))?.title, 'My Custom Name');
+  assert.equal((await readSessionMessages(project, sid)).title, 'My Custom Name');
+
+  // Macaron treats a blank custom-title record as a clear tombstone.
+  await renameSession(project, sid, '   ');
+  assert.equal((await readSessionSummary(file))?.title, 'Fresh AI Title');
+});
+
+test('rename removes a legacy sidecar label so the native title can win', async () => {
+  const sid = 'legacy';
+  const file = path.join(projDir, `${sid}.jsonl`);
+  await fs.writeFile(file, `${JSON.stringify({ type: 'user', cwd: '/repo', message: { content: 'prompt' } })}\n`, 'utf8');
+  await setLabel(sid, 'Legacy Label');
+
+  assert.equal((await readSessionMessages(project, sid)).label, 'Legacy Label');
+  await renameSession(project, sid, 'Native Name');
+  assert.equal((await getLabels())[sid], undefined);
+  const detail = await readSessionMessages(project, sid);
+  assert.equal(detail.label, undefined);
+  assert.equal(detail.title, 'Native Name');
+});
+
+test('tail scan finds titles beyond the head read limit', async () => {
+  const sid = 'tail';
+  const file = path.join(projDir, `${sid}.jsonl`);
+  const lines = [
+    { type: 'user', cwd: '/repo', message: { content: 'x'.repeat(100 * 1024) } },
+    { type: 'ai-title', aiTitle: 'Tail Title' },
+  ];
+  await fs.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+  assert.equal((await readSessionSummary(file))?.title, 'Tail Title');
+});
+
+test('rename rejects paths outside the Claude projects directory', async () => {
+  await assert.rejects(renameSession('..', 'escape', 'Nope'), /invalid session path/);
+});

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -7,13 +7,14 @@ import {
   readSessionMessages,
   resolveProjectCwd,
   readSubagentMessages,
+  renameSession,
   resolveSessionCwd,
   rewindSession,
   searchMessages,
   writeCompactedSession,
 } from '../lib/session-store.js';
 import { startSSE, sseSend, sseDone } from '../lib/sse.js';
-import { setLabel, deleteLabel } from '../lib/label-store.js';
+import { deleteLabel } from '../lib/label-store.js';
 import { liveGet, liveStart, livePush, liveEnd } from '../lib/live-registry.js';
 import { runClaude, runFollowup, type AttachedImage, type RunOptions, type RunnerEvent } from '../lib/claude-runner.js';
 import { getActiveProviderEnv, getActiveProviderRaw, getFollowupSuggestionsEnabled } from '../lib/settings-store.js';
@@ -104,13 +105,19 @@ export async function registerSessionRoutes(app: FastifyInstance, options: Sessi
     }
   });
 
-  // Rename: set (or clear, when blank) a human label for this session. The
-  // label lives in a macaron sidecar, not the Claude-owned jsonl.
+  // Rename: append a native `custom-title` record to the Claude-owned jsonl,
+  // the same way the CLI's `/rename` does — so the new name shows in both
+  // macaron's sidebar and `claude --resume`, instead of diverging into a
+  // separate label sidecar. A blank name clears the override.
   app.patch<{ Params: Params; Body: { name?: string } }>(
     '/api/sessions/claude/:project/:sid/label',
     async (req, reply) => {
-      const label = await setLabel(req.params.sid, String(req.body?.name ?? ''));
-      return reply.send({ ok: true, label });
+      try {
+        const label = await renameSession(req.params.project, req.params.sid, String(req.body?.name ?? ''));
+        return reply.send({ ok: true, label });
+      } catch (e) {
+        return reply.status(404).send({ error: (e as Error).message });
+      }
     },
   );
 

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -27,8 +27,9 @@ export type SessionListItem = {
   // User-assigned human label, stored in a macaron sidecar (not in the
   // Claude-owned jsonl). Takes display precedence over `preview` when set.
   label?: string;
-  // Generated human-readable label. Codex-only for now (see codex-title.ts);
-  // the sidebar prefers it over `preview` when present.
+  // Native/generated human-readable title. Claude reads ai-title/custom-title
+  // records; Codex uses its persisted generated title. The UI prefers it over
+  // `preview` when present.
   title?: string;
   messageCount: number;
   messageCountSuffix?: string;
@@ -90,6 +91,13 @@ export type SessionDetail = {
   project: string;
   cwd: string;
   gitBranch?: string;
+  // Legacy Macaron sidecar label, retained only so older renamed sessions
+  // display consistently until their next native rename migrates them.
+  label?: string;
+  // Native session title (custom-title / ai-title / lastPrompt / summary)
+  // resolved server-side, so the session header can show the same name the
+  // sidebar does. Undefined when the session has none.
+  title?: string;
   messages: Message[];
   truncated?: boolean;
   totalBytes?: number;

--- a/web/src/codex/CodexChat.tsx
+++ b/web/src/codex/CodexChat.tsx
@@ -11,6 +11,7 @@ import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
 import type { SessionDetail, Message, Block, CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
 import { codexApi } from './api';
+import { basename } from '../lib/api';
 import type { CodexRuntimeOverride } from './api';
 import { sendCodexMessage, startCodexThread, subscribeCodexLive, type CodexStreamEvent } from './stream';
 import { CodexComposer, type ComposerImage } from './CodexComposer';
@@ -611,7 +612,7 @@ export function CodexChat(props: CodexChatProps = {}) {
 
   const title = isNew
     ? 'New thread'
-    : detail?.cwd?.split('/').filter(Boolean).pop() || 'Thread';
+    : detail?.title || basename(detail?.cwd || '') || sid.slice(0, 8);
 
   return (
     <div className={'cx-main' + (hideBar ? ' tile' : '')}>

--- a/web/src/codex/CodexSidebar.tsx
+++ b/web/src/codex/CodexSidebar.tsx
@@ -12,6 +12,7 @@ import {
 import { subscribeSystemEvents } from '../lib/systemEvents';
 import { useConfirm } from '../components/Confirm';
 import { useToast } from '../components/Toast';
+import { sessionTitle } from '../lib/api';
 
 type WsData = CodexWorkspace & { sessions: CodexThread[] };
 
@@ -179,7 +180,7 @@ export function CodexSidebar({ onNavigate }: {
                 <div className="cx-sb-ws-sessions">
                   {w.sessions.map((s) => {
                     const pinned = (canvasBy[w.project] || []).includes(s.sessionId);
-                    const label = s.title || s.preview || s.sessionId.slice(0, 8);
+                    const label = sessionTitle(s);
                     return (
                       <div
                         key={s.sessionId}

--- a/web/src/codex/CodexWorkspace.tsx
+++ b/web/src/codex/CodexWorkspace.tsx
@@ -32,6 +32,7 @@ import {
   type TileGeom,
 } from '../lib/canvas';
 import { subscribeSystemEvents } from '../lib/systemEvents';
+import { sessionTitle } from '../lib/api';
 
 const ROW_UNIT_PX = 48;
 
@@ -187,7 +188,7 @@ export function CodexWorkspace() {
                   <SortableTile
                     key={tile.sid}
                     tile={tile}
-                    label={meta?.preview?.slice(0, 60) || tile.sid.slice(0, 8)}
+                    label={meta ? sessionTitle(meta) : tile.sid.slice(0, 8)}
                     isFocused={isFocused}
                     onFocus={() => canvas.focus(tile.sid)}
                     onRemove={() => canvas.remove(tile.sid)}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { LayoutGrid, MessageSquare, Pencil, Zap } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { SEARCH_HL_CLOSE, SEARCH_HL_OPEN } from '@macaron/shared';
-import { api, basename, fmtAgo, type MessageSearchHit, type SessionListItem, type Workspace } from '../lib/api';
+import { api, basename, sessionTitle, fmtAgo, type MessageSearchHit, type SessionListItem, type Workspace } from '../lib/api';
 import { addDraftSid } from '../lib/canvas';
 import { hasActiveModal } from '../lib/modal';
 
@@ -238,7 +238,7 @@ export function CommandPalette() {
           kind: 'session',
           project: w.project,
           sid: s.sessionId,
-          title: s.preview || s.sessionId.slice(0, 8),
+          title: sessionTitle(s),
           subtitle: `${name} · ${fmtAgo(s.mtime)}`,
           mtime: s.mtime,
         });

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
   Unlink,
   X,
 } from 'lucide-react';
-import { api, basename, HttpError, type Workspace, type SessionListItem, type WorktreeInfo } from '../lib/api';
+import { api, basename, sessionTitle, HttpError, type Workspace, type SessionListItem, type WorktreeInfo } from '../lib/api';
 import { useToast } from './Toast';
 import { useConfirm } from './Confirm';
 import { ContextMenu, type MenuItem } from './ContextMenu';
@@ -197,7 +197,9 @@ export function Sidebar({ onNavigate }: {
   const startRename = (s: SessionListItem) => {
     renameDoneRef.current = false;
     setRenamingSid(s.sessionId);
-    setRenameDraft(s.label || '');
+    // Prefill with the current override (manual label or native title) so an
+    // edit tweaks the existing name rather than starting blank.
+    setRenameDraft(s.label || s.title || '');
   };
 
   const commitRename = async (project: string, sid: string) => {
@@ -489,7 +491,7 @@ export function Sidebar({ onNavigate }: {
                           >
                             <span className={'sb-sess-dot sb-sess-dot-' + st} />
                             <span className="sb-sess-name">
-                              {s.label || s.preview || s.sessionId.slice(0, 8)}
+                              {sessionTitle(s)}
                             </span>
                           </button>
                         )}
@@ -505,7 +507,7 @@ export function Sidebar({ onNavigate }: {
                             onNavigate?.();
                           }}
                           title={pinned ? 'Remove from canvas' : 'Add to canvas'}
-                          aria-label={`${pinned ? 'Remove' : 'Add'} ${s.label || s.preview || s.sessionId.slice(0, 8)} ${pinned ? 'from' : 'to'} canvas`}
+                          aria-label={`${pinned ? 'Remove' : 'Add'} ${sessionTitle(s)} ${pinned ? 'from' : 'to'} canvas`}
                         >
                           {pinned ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
                         </button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -559,6 +559,15 @@ export function basename(p: string): string {
   return parts[parts.length - 1] || p;
 }
 
+// Single source of truth for a session row's display name, shared by the
+// sidebar, dashboard, workspace tiles and command palette so every surface
+// agrees. Priority: user/native title (`label` for a manual rename, `title` for
+// the native ai-title/custom-title the server resolved) > first-prompt preview >
+// short sid. Both Claude and Codex populate `title`, so this is provider-neutral.
+export function sessionTitle(s: { label?: string; title?: string; preview?: string; sessionId: string }): string {
+  return s.label || s.title || s.preview || s.sessionId.slice(0, 8);
+}
+
 // Trigger a client-side download of `text` as a file named `name`. Used by the
 // session Markdown export — no server round-trip since the WebUI already holds
 // the parsed transcript.

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { api, basename, fmtAgo, type Workspace, type SessionListItem } from '../lib/api';
+import { api, basename, sessionTitle, fmtAgo, type Workspace, type SessionListItem } from '../lib/api';
 import { NewProjectModal } from '../components/NewProjectModal';
 import { subscribeSystemEvents } from '../lib/systemEvents';
 
@@ -91,7 +91,7 @@ export function Dashboard() {
                     return (
                       <div key={s.sessionId} className="wk-sess-row">
                         <span className={'wk-sess-dot wk-sess-dot-' + st} />
-                        <span className="wk-sess-name">{s.label || s.preview || s.sessionId.slice(0, 8)}</span>
+                        <span className="wk-sess-name">{sessionTitle(s)}</span>
                         <span className="wk-sess-time">{fmtAgo(s.mtime)}</span>
                       </div>
                     );

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -9,6 +9,7 @@ import {
   api,
   basename,
   downloadTextFile,
+  sessionTitle,
   type Message,
   type SessionDetail,
   type PrContext,
@@ -2605,7 +2606,7 @@ export function Session(props: SessionProps = {}) {
             <span className="sep">›</span>
             <Link to={`/w/${encodeURIComponent(project)}`} className="crumb-link">{name}</Link>
             <span className="sep">›</span>
-            <span className="sess-id-crumb">{isNew ? 'new' : sid.slice(0, 8)}</span>
+            <span className="sess-id-crumb" title={isNew ? undefined : sid}>{isNew ? 'new' : (data ? sessionTitle(data) : sid.slice(0, 8))}</span>
             {data?.gitBranch && <span className="sess-branch">{data.gitBranch}</span>}
           </div>
           <div className="session-bar-right">

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -26,7 +26,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { api, basename, type SessionListItem, type Workspace as Wk } from '../lib/api';
+import { api, basename, sessionTitle, type SessionListItem, type Workspace as Wk } from '../lib/api';
 import {
   useCanvas,
   CANVAS_COLS,
@@ -344,7 +344,7 @@ export function Workspace() {
                     ? 'Terminal'
                     : file
                       ? filePath(tile.sid).split('/').pop() || 'File'
-                      : meta?.label || meta?.preview?.slice(0, 60) || tile.sid.slice(0, 8);
+                      : meta ? sessionTitle(meta) : tile.sid.slice(0, 8);
                 return (
                   <SortableTile
                     key={tile.sid}


### PR DESCRIPTION
## Summary

Follow-up to [MAC-8742](https://multica.macaron.xin/issues/844c8566-f7ae-4068-8d55-3caec16eb93c "确认 macaron-artifacts 项目的标题生成方式"): Claude Code natively generates and persists session titles (`ai-title` and `custom-title`), while macaron-artifacts now consumes those records instead of inventing a second Claude title source.

## Changes

- Resolve Claude titles with the native priority `customTitle > aiTitle > lastPrompt > summary`, including tail records beyond the head scan limit.
- Append native `custom-title` records for rename, validate the session path, and remove a legacy `macaron-labels.json` override after a successful native rename. Blank rename remains a clear tombstone that falls back to the AI title locally.
- Use one `sessionTitle()` display helper across Claude and Codex sidebar, dashboard/workspace tiles, command palette, and session headers. Legacy sidecar labels are returned in detail so older sessions stay visually consistent until migration.
- Keep Codex's generated title in list/detail responses and consume it in its workspace canvas and chat header.

## Verification

- Focused native-title suite: 5/5 tests pass, with an isolated temporary HOME covering priority, rename/detail, blank fallback, legacy-label cleanup, tail scan, and traversal rejection.
- Shared typecheck passes. Server typecheck is otherwise clean; the remaining `sendFile` errors are existing Fastify static-plugin typing errors. Web typecheck remains limited to existing vendored GenUI/source and alias errors.
- Browser smoke with seeded Claude/Codex sessions showed both native/generated titles in their sidebars with no browser console errors at desktop size.
- GitHub `publish`, `notify`, and Continuous Releases checks pass; PR is open and mergeable.
