### PR TITLE
Fix mobile layout gaps in Examples and Files views

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1121,6 +1121,7 @@ textarea:focus, select:focus, input:focus {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap; /* narrow screens: whole tags drop to the next line instead of squeezing the name */
   margin-bottom: 3px;
 }
 .prov-name { font-weight: 600; }
@@ -1133,6 +1134,7 @@ textarea:focus, select:focus, input:focus {
   color: var(--muted);
   letter-spacing: 0.3px;
   text-transform: uppercase;
+  white-space: nowrap; /* never split a badge mid-word (e.g. "BUILT-IN") */
 }
 .prov-tag.ok { color: #3a7; background: rgba(76, 175, 80, 0.12); }
 .prov-tag.bad { color: #c65; background: rgba(198, 92, 82, 0.12); }
@@ -4954,6 +4956,19 @@ textarea:focus, select:focus, input:focus {
   padding: 40px;
   text-align: center;
 }
+@media (max-width: 768px) {
+  /* Stack tree above editor: a fixed 280px tree would squeeze the editor to
+     an unusable sliver on phones. */
+  .fx-body { flex-direction: column; }
+  .fx-tree {
+    width: 100%;
+    max-height: 45%;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  /* Clear the fixed hamburger (same 60px offset .view uses). */
+  .fx-head { padding-left: 60px; }
+}
 
 /* ---------- demos gallery ---------- */
 .examples-view {
@@ -5007,6 +5022,15 @@ textarea:focus, select:focus, input:focus {
   font-size: 13px;
   min-width: 220px;
   cursor: pointer;
+}
+@media (max-width: 768px) {
+  /* Side-by-side head leaves the intro a ~90px column once the 220px select
+     takes its share — stack instead and let the picker span full width.
+     Top padding mirrors .view's mobile rule to clear the fixed hamburger. */
+  .examples-view { padding: 60px 18px calc(40px + env(safe-area-inset-bottom)); }
+  .examples-head { flex-direction: column; }
+  .examples-target { width: 100%; }
+  .examples-target select { min-width: 0; width: 100%; }
 }
 .examples-section { margin-top: 28px; }
 .examples-section-title {


### PR DESCRIPTION
Closes [MAC-9153](https://multica.macaron.xin/issues/fbab4103-1bc9-4777-a99b-1a0d44e4e2ca "为参考界面实现响应式设计")

## What

Follow-up visual pass over every page of both shells (Claude + Codex, desktop 1440 and mobile 390/320) after #165. Three mobile-only gaps found and fixed, all in `web/src/styles.css` (+24):

- **Examples**: the flex head squeezed the intro paragraph into a ~90px column next to the 220px workspace picker on phones. Now stacks vertically ≤768px, picker goes full width, and `.examples-view` mirrors `.view`'s mobile padding so the title clears the fixed hamburger (it was overlapped).
- **Files**: the fixed 280px tree squeezed the editor pane to an unusable sliver at 390px. Tree now stacks above the editor (full width, `max-height: 45%`) ≤768px, and `.fx-head` gets the same 60px left offset `.view` uses so the back link clears the hamburger.
- **Settings / Prompts / Subagents rows**: badges like `BUILT-IN` split mid-word when the row wrapped. `.prov-tag` is `nowrap` now and `.prov-card-head` wraps whole tags to the next line instead.

## Verification

- `pnpm --filter @macaron/web test`: 53/53 pass; web build passes. CSS-only change.
- Browser smoke on the built bundle (isolated fixture home): every Claude route (`/`, dashboard, examples, usage, prompts, settings, agents, hooks, skills, schedules, mcp, workspace, files, session) and every Codex route (home, workspace, thread, settings) at 1440×900 + 390×844, plus 320×568 for the touched pages — no horizontal overflow anywhere, drawers and desktop layouts unchanged.