### PR TITLE
Document codex-cli >= 0.142.0 requirement for plugin install

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://macaron.im"
   },
   "homepage": "https://macaron.im",
-  "repository": "https://github.com/MindLab-Research/macaron-artifacts",
+  "repository": "https://github.com/mindverse-ltd/macaron-artifacts",
   "license": "MIT",
   "keywords": ["macaron", "genui", "webui", "session-manager", "codex"],
   "skills": "./skills/",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://macaron.im"
   },
   "homepage": "https://macaron.im",
-  "repository": "https://github.com/MindLab-Research/macaron-artifacts",
+  "repository": "https://github.com/mindverse-ltd/macaron-artifacts",
   "license": "MIT",
   "keywords": ["macaron", "genui", "webui", "session-manager", "kimi"],
   "skills": "./skills/",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
+Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin rooted at the marketplace root ([openai/codex#28771](https://github.com/openai/codex/pull/28771)) and fail with ``plugin `macaron` was not found in marketplace `macaron` ``. Note that re-running `marketplace add` does **not** refresh an already-added marketplace; if you hit that error on a supported CLI, the cached clone is stale — remove and re-add it:
+
+```bash
+codex plugin marketplace remove macaron
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
+```
+
 ### Kimi Code
 
 In a Kimi Code session, install from the GitHub URL, then reload to activate:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The repo doubles as its own plugin marketplace. Use the full https URL — the `
 In a Claude Code session, run each command separately (pasting both lines at once merges them into one command):
 
 ```
-/plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+/plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 ```
 
 ```
@@ -29,7 +29,7 @@ In a Claude Code session, run each command separately (pasting both lines at onc
 or from the shell:
 
 ```bash
-claude plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+claude plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 claude plugin install macaron@macaron
 ```
 
@@ -38,7 +38,7 @@ For local development, install your checkout directly: `claude plugin install /p
 ### Codex
 
 ```bash
-codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
@@ -46,7 +46,7 @@ Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin roo
 
 ```bash
 codex plugin marketplace remove macaron
-codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 ```
 
 ### Kimi Code
@@ -54,7 +54,7 @@ codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifac
 In a Kimi Code session, install from the GitHub URL, then reload to activate:
 
 ```
-/plugins install https://github.com/MindLab-Research/macaron-artifacts
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
 /reload
 ```
 
@@ -63,20 +63,20 @@ In a Kimi Code session, install from the GitHub URL, then reload to activate:
 Three independent packages, each self-contained (its own prebuilt server + web bundles) — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Install one, get only that one. Launch any of them in one command, no plugin install needed:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
 `npx` works the same way — bin name = package name for all three:
 
 ```bash
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
-Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/MindLab-Research/macaron-artifacts/commits/main)). All three accept `--host` / `--port`; run with `--help` for the full list.
+Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/mindverse-ltd/macaron-artifacts/commits/main)). All three accept `--host` / `--port`; run with `--help` for the full list.
 
 Verify:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,8 @@ codex plugin add macaron@macaron
 
 Open it in a session with `open macaron web ui`.
 
+Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin rooted at the marketplace root ([openai/codex#28771](https://github.com/openai/codex/pull/28771)) and fail with ``plugin `macaron` was not found in marketplace `macaron` ``. Re-running `marketplace add` does **not** refresh an already-added marketplace; on a supported CLI, fix a stale cache with `codex plugin marketplace remove macaron` + re-add.
+
 ### Kimi Code
 
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,7 +11,7 @@ A local WebUI that ships as a plugin for Claude Code, Codex, and Kimi Code — i
 ### Claude Code
 
 ```
-/plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+/plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 /plugin install macaron@macaron
 ```
 
@@ -20,7 +20,7 @@ Open it in a session with `/macaron`.
 ### Codex
 
 ```bash
-codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
@@ -31,7 +31,7 @@ Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin roo
 ### Kimi Code
 
 ```
-/plugins install https://github.com/MindLab-Research/macaron-artifacts
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
 /reload
 ```
 
@@ -44,17 +44,17 @@ Three independent packages, each shipping its own prebuilt server + web assets:
 Install none of them; run whichever you want directly:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
 `npx` works the same — all three packages have `bin` name == package name:
 
 ```bash
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
 Replace `<sha>` with any commit on `main`. Each launcher just boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run with `--help` for the full flag list.
@@ -91,4 +91,4 @@ Open `/plugins`, select `macaron` on the **Installed** tab, and press `Enter` to
 
 ## Feedback
 
-Open an issue: <https://github.com/MindLab-Research/macaron-artifacts/issues>
+Open an issue: <https://github.com/mindverse-ltd/macaron-artifacts/issues>

--- a/mcx/README.md
+++ b/mcx/README.md
@@ -5,7 +5,7 @@ Launcher for the **Macaron Codex WebUI** (ChatGPT-style chat over the Codex SDK)
 Self-contained — ships its own prebuilt server + web bundles, installs nothing from `mcc`. Run without installing:
 
 ```bash
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex → http://localhost:7979
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex → http://localhost:7979
 ```
 
 Accepts `--host` / `--port`; run with `--help` for the full list.

--- a/mkx/README.md
+++ b/mkx/README.md
@@ -5,9 +5,9 @@ Launcher for the **Macaron Kimi Code WebUI** (ChatGPT-style chat over the Kimi C
 Self-contained — ships its own prebuilt server + web bundles, installs nothing from `mcc`. Run without installing:
 
 ```bash
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi → http://localhost:7980
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi → http://localhost:7980
 # or
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>
 ```
 
 Sessions are discovered from `~/.kimi-code/sessions/` (honors `KIMI_CODE_HOME`); provider settings persist to `~/.kimi-code/macaron-kimi-config.json`.

--- a/server/src/lib/push-store.ts
+++ b/server/src/lib/push-store.ts
@@ -70,7 +70,7 @@ export async function sendPush(payload: PushNotifyPayload): Promise<void> {
   if (s.subscriptions.length === 0) return;
   // A VAPID subject must be a resolvable https:// or mailto: with a real domain;
   // some push services reject a non-routable one like `.local`.
-  webpush.setVapidDetails('https://github.com/MindLab-Research/macaron-artifacts', s.vapid.publicKey, s.vapid.privateKey);
+  webpush.setVapidDetails('https://github.com/mindverse-ltd/macaron-artifacts', s.vapid.publicKey, s.vapid.privateKey);
   const body = JSON.stringify(payload);
   // Snapshot before the multi-second await: a concurrent /unsubscribe can
   // reassign s.subscriptions, which would misalign these indices and prune the

--- a/site/app/lib/shared.ts
+++ b/site/app/lib/shared.ts
@@ -4,7 +4,7 @@ export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';
 
 export const gitConfig = {
-  user: 'MindLab-Research',
+  user: 'mindverse-ltd',
   repo: 'macaron-artifacts',
   branch: 'main',
 };

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -55,9 +55,9 @@ export function meta({}: Route.MetaArgs) {
 }
 
 // pkg.pr.new ships prebuilt tarballs per commit; __COMMIT_SHA__ is injected at build time (falls back to `<sha>`).
-const PKG = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@${__COMMIT_SHA__}`;
-const PKG_MCX = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@${__COMMIT_SHA__}`;
-const PKG_MKX = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@${__COMMIT_SHA__}`;
+const PKG = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@${__COMMIT_SHA__}`;
+const PKG_MCX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@${__COMMIT_SHA__}`;
+const PKG_MKX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@${__COMMIT_SHA__}`;
 
 export default function Home() {
   return (
@@ -123,7 +123,7 @@ export default function Home() {
               <Steps>
                 <Step>
                   <p className="font-medium">Add the Marketplace Source</p>
-                  <Command code="claude plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts" />
+                  <Command code="claude plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts" />
                 </Step>
                 <Step>
                   <p className="font-medium">Install the Plugin</p>
@@ -143,7 +143,7 @@ export default function Home() {
               <Steps>
                 <Step>
                   <p className="font-medium">Add the Marketplace Source</p>
-                  <Command code="codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts" />
+                  <Command code="codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts" />
                 </Step>
                 <Step>
                   <p className="font-medium">Add the Plugin</p>
@@ -162,7 +162,7 @@ export default function Home() {
               <Steps>
                 <Step>
                   <p className="font-medium">Install from GitHub</p>
-                  <Command code="/plugins install https://github.com/MindLab-Research/macaron-artifacts" />
+                  <Command code="/plugins install https://github.com/mindverse-ltd/macaron-artifacts" />
                   <p className="text-sm text-fd-muted-foreground">
                     Run it in a Kimi Code session, then <code className="text-fd-foreground">/reload</code> to activate.
                   </p>

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -14,7 +14,7 @@ A WebUI that installs on Claude Code, Codex, and Kimi Code — run all three at 
 ### Claude Code
 
 ```
-/plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+/plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 /plugin install macaron@macaron
 ```
 
@@ -23,16 +23,18 @@ Then open it in a session with `/macaron`.
 ### Codex
 
 ```bash
-codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
 Then say `open macaron web ui` in a session to open it.
 
+Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin rooted at the marketplace root ([openai/codex#28771](https://github.com/openai/codex/pull/28771)) and fail with ``plugin `macaron` was not found in marketplace `macaron` ``. Re-running `marketplace add` does **not** refresh an already-added marketplace; on a supported CLI, fix a stale cache with `codex plugin marketplace remove macaron` + re-add.
+
 ### Kimi Code
 
 ```
-/plugins install https://github.com/MindLab-Research/macaron-artifacts
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
 /reload
 ```
 
@@ -43,13 +45,13 @@ Then open it in a session with `/macaron:macaron`.
 The published tarball ships the prebuilt server + web bundles as three independent packages — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Launch any of them in one command:
 
 ```bash
-bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 
-npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcc@<sha>    # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mcx@<sha>    # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-claude-code/mkx@<sha>    # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
 The commands are pinned to this build's commit; swap in any other commit on `main` to pull that build. Each launcher boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run `--help` for all flags.
@@ -86,4 +88,4 @@ Open `/plugins`, select `macaron` on the **Installed** tab, and press `Enter` to
 
 ## Feedback
 
-[github.com/MindLab-Research/macaron-artifacts/issues](https://github.com/MindLab-Research/macaron-artifacts/issues)
+[github.com/mindverse-ltd/macaron-artifacts/issues](https://github.com/mindverse-ltd/macaron-artifacts/issues)

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -14,7 +14,7 @@ A WebUI that installs on Claude Code, Codex, and Kimi Code — run all three at 
 ### Claude Code
 
 ```
-/plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+/plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 /plugin install macaron@macaron
 ```
 
@@ -23,7 +23,7 @@ Then open it in a session with `/macaron`.
 ### Codex
 
 ```bash
-codex plugin marketplace add https://github.com/MindLab-Research/macaron-artifacts
+codex plugin marketplace add https://github.com/mindverse-ltd/macaron-artifacts
 codex plugin add macaron@macaron
 ```
 
@@ -34,7 +34,7 @@ Requires **codex-cli ≥ 0.142.0** — older releases can't resolve a plugin roo
 ### Kimi Code
 
 ```
-/plugins install https://github.com/MindLab-Research/macaron-artifacts
+/plugins install https://github.com/mindverse-ltd/macaron-artifacts
 /reload
 ```
 
@@ -45,13 +45,13 @@ Then open it in a session with `/macaron:macaron`.
 The published tarball ships the prebuilt server + web bundles as three independent packages — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Launch any of them in one command:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
 The commands are pinned to this build's commit; swap in any other commit on `main` to pull that build. Each launcher boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run `--help` for all flags.
@@ -88,4 +88,4 @@ Open `/plugins`, select `macaron` on the **Installed** tab, and press `Enter` to
 
 ## Feedback
 
-[github.com/MindLab-Research/macaron-artifacts/issues](https://github.com/MindLab-Research/macaron-artifacts/issues)
+[github.com/mindverse-ltd/macaron-artifacts/issues](https://github.com/mindverse-ltd/macaron-artifacts/issues)

--- a/start.sh
+++ b/start.sh
@@ -152,7 +152,7 @@ if [ "$needs_install" = 1 ]; then
 [macaron] pnpm install failed.
 [macaron] fix: cd "$DIR" && rm -rf node_modules && $_PNPM install
 [macaron] if that still fails, the pnpm-lock.yaml may be corrupt; open
-[macaron] an issue at https://github.com/MindLab-Research/macaron-artifacts/issues
+[macaron] an issue at https://github.com/mindverse-ltd/macaron-artifacts/issues
 EOF
       exit 1
     fi


### PR DESCRIPTION
## Why

`codex plugin add macaron@macaron` failed with ``plugin `macaron` was not found in marketplace `macaron` `` for users on **codex-cli ≤ 0.141.x**: those releases can't resolve a marketplace plugin rooted at the repo root (fixed upstream in [openai/codex#28771](https://github.com/openai/codex/pull/28771), first shipped in `0.142.0`), so the entry is silently skipped at resolve time. A stale cached marketplace clone makes it worse — `marketplace add` never refreshes an already-added marketplace.

## What changed

- `README.md` / `docs/USAGE.md` / `site/content/docs/usage.mdx`: state the **codex-cli ≥ 0.142.0** requirement and the stale-cache remedy (`plugin marketplace remove macaron` + re-add).
- `site/content/docs/usage.mdx`: fix `MindLab-Research/...` and `macaron-claude-code` links missed by the repo rename.

## Verification

Tested against isolated `CODEX_HOME`s:

| codex-cli | clone state | result |
| --- | --- | --- |
| `0.140.0` | fresh | ❌ exact reported error |
| `0.141.0` | fresh | ❌ exact reported error |
| `0.142.0` | fresh | ✅ installs (`plugins/cache/macaron/macaron/0.6.0`) |
| `0.144.5` | fresh | ✅ installs, `plugin list` shows `macaron@macaron` installed+enabled |
| `0.144.5` | stale pre-rename manifest (`{"source":"github",...}`) | ❌ exact reported error → after `marketplace remove` + re-add ✅ |

No manifest changes needed — current `main` installs cleanly on any supported CLI.