### PR TITLE
Fix Files panel search icon overlapping input text

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4959,6 +4959,7 @@ textarea:focus, select:focus, input:focus {
 @media (max-width: 768px) {
   /* Stack tree above editor: a fixed 280px tree would squeeze the editor to
      an unusable sliver on phones. */
+  .fx { height: 100dvh; } /* 100vh runs under mobile browser chrome */
   .fx-body { flex-direction: column; }
   .fx-tree {
     width: 100%;
@@ -5351,7 +5352,10 @@ textarea:focus, select:focus, input:focus {
   color: var(--muted);
   pointer-events: none;
 }
-.fp-input {
+/* Descendant selector on purpose: the bare `.fp-input` class loses specificity
+   to the generic `input[type="text"]` rule above, which collapses the left
+   padding and makes the search icon overlap the text. */
+.fp-search .fp-input {
   flex: 1;
   width: 100%;
   height: 36px;


### PR DESCRIPTION
Closes [MAC-9153](https://multica.macaron.xin/issues/fbab4103-1bc9-4777-a99b-1a0d44e4e2ca "为参考界面实现响应式设计")

## What

Follow-up to #169 — two remaining occlusion bugs in the file browsers, both in `web/src/styles.css` (+5/-1):

- **Files panel search box (all viewports)**: the generic `input[type="text"]` rule out-specifies bare `.fp-input`, collapsing its left padding from 32px to 14px — the absolute search icon sat on top of the placeholder/text ("Qearch files"). Switch to the descendant `.fp-search .fp-input` selector so the intended padding wins. Verified 10px overlap → 8px clearance at 390×844 and 320×568.
- **Dedicated Files route (mobile)**: `height: 100vh` runs past the visible viewport on mobile browsers, hiding the bottom of the editor under browser chrome. Use `100dvh` ≤768px, matching the canvas/home convention.

## Verification

- `pnpm --filter @macaron/web test`: 53/53 pass; web build passes.
- Browser smoke: workspace Files panel open at 1440×900 / 390×844 / 320×568, dedicated Files route with a file open at 390×844 / 320×568, nav drawer over the Files route at 390×844 — no element overlap with the hamburger, no horizontal overflow.