### PR TITLE
Add Kimi Code as a third engine (ACP-driven)

### DIFF
--- a/server/src/lib/kimi-runner.ts
+++ b/server/src/lib/kimi-runner.ts
@@ -190,6 +190,12 @@ export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent
             const id = u.toolCallId;
             emitToolUseIfReady(id, u.title ?? undefined, (u as { rawInput?: unknown }).rawInput);
             if (u.status === 'completed' || u.status === 'failed') {
+              // Some agents carry rawInput only on rawOutput-bearing updates; if
+              // no tool_use went out yet, emit one now so the result isn't orphaned.
+              if (!toolUseEmitted.has(id)) {
+                toolUseEmitted.add(id);
+                push({ kind: 'tool_use', id, name: toolTitle.get(id) || 'tool', input: {} });
+              }
               const raw = (u as { rawOutput?: unknown }).rawOutput;
               let text = typeof raw === 'string' ? raw : raw != null ? JSON.stringify(raw) : '';
               if (!text && Array.isArray(u.content)) {
@@ -260,8 +266,12 @@ export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent
         push({ kind: 'session', sessionId: capturedSid });
       }
 
-      if (opts.abortController?.signal.aborted) onAbort();
-      else opts.abortController?.signal.addEventListener('abort', onAbort, { once: true });
+      if (opts.abortController?.signal.aborted) {
+        onAbort();
+        push({ kind: 'done', exitCode: -1 });
+        return;
+      }
+      opts.abortController?.signal.addEventListener('abort', onAbort, { once: true });
 
       const result = await conn.prompt({ sessionId: capturedSid, prompt: buildPromptBlocks(opts.prompt, opts.images || []) });
       const aborted = Boolean(opts.abortController?.signal.aborted) || result.stopReason === 'cancelled';

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,15 +1,18 @@
 import type { FastifyInstance } from 'fastify';
 import { getActiveProviderEnv } from '../lib/settings-store.js';
+import { getActiveKimiProvider } from '../lib/kimi-config.js';
 import { isSearchEnabled, indexStats } from '../lib/search-index.js';
 import { startSSE, sseSend } from '../lib/sse.js';
 import { subscribeSystemEvents } from '../lib/session-watcher.js';
 
 export async function registerHealthRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/health', async () => {
-    const { model } = getActiveProviderEnv();
+    const model = process.env.MACARON_ENGINE === 'kimi'
+      ? getActiveKimiProvider()?.model || null
+      : getActiveProviderEnv().model || null;
     return {
       ok: true,
-      model: model || null,
+      model,
       search: isSearchEnabled() ? indexStats() : null,
     };
   });

--- a/server/src/routes/kimi.ts
+++ b/server/src/routes/kimi.ts
@@ -38,7 +38,14 @@ type SidParams = { sid: string };
 type NewThreadBody = { text?: string; cwd?: string; images?: AttachedImage[] };
 type MessageBody = { text?: string; images?: AttachedImage[] };
 
-export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
+type KimiRouteOptions = {
+  runKimi?: typeof runKimi;
+  readKimiSessionMessages?: typeof readKimiSessionMessages;
+};
+
+export async function registerKimiRoutes(app: FastifyInstance, options: KimiRouteOptions = {}): Promise<void> {
+  const runKimiForRoute = options.runKimi ?? runKimi;
+  const readKimiSessionMessagesForRoute = options.readKimiSessionMessages ?? readKimiSessionMessages;
   // --- Threads -----------------------------------------------------------
 
   app.get('/api/kimi/threads', async () => {
@@ -74,7 +81,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
 
   app.get<{ Params: SidParams }>('/api/kimi/threads/:sid', async ({ params }, reply) => {
     try {
-      return await readKimiSessionMessages(params.sid);
+      return await readKimiSessionMessagesForRoute(params.sid);
     } catch (e) {
       return reply.status(404).send({ error: (e as Error).message });
     }
@@ -95,6 +102,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
     reply: Parameters<typeof startSSE>[0],
     stream: ReturnType<typeof runKimi>,
     sid: string | null,
+    owner: AbortController,
     live: { cwd: string; text: string; hasImages: boolean },
   ) => {
     let clientGone = false;
@@ -121,30 +129,47 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
       safeSend(payload);
       if (capturedSid) livePush(capturedSid, payload);
     };
-    (async () => {
-      for await (const ev of stream) {
-        if (ev.kind === 'session' && !capturedSid) {
-          capturedSid = ev.sessionId;
-          ensureLive();
-          safeSend({ type: 'meta', cwd: live.cwd, sessionId: capturedSid });
-        } else if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
-        else if (ev.kind === 'tool_use') relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
-        else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
-        else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
-        else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
-        else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
-        else if (ev.kind === 'done') {
-          safeSend({ type: 'done', exitCode: ev.exitCode });
-          if (capturedSid) { liveEnd(capturedSid, { type: 'done', exitCode: ev.exitCode }); endRun(capturedSid); }
-          if (!clientGone) sseDone(reply);
-        }
+    let terminalSent = false;
+    const finishRun = (exitCode: number, error?: string) => {
+      if (terminalSent) return;
+      terminalSent = true;
+      if (error) safeSend({ type: 'error', error });
+      const done = { type: 'done' as const, exitCode, ...(error ? { error } : {}) };
+      safeSend(done);
+      if (capturedSid) {
+        liveEnd(capturedSid, done);
+        endRun(capturedSid, owner);
       }
-    })().catch((e: unknown) => {
-      const msg = (e as Error).message;
-      if (capturedSid) { liveEnd(capturedSid, { type: 'done', exitCode: -1, error: msg }); endRun(capturedSid); }
-      safeSend({ type: 'error', error: msg });
-      if (!clientGone) sseDone(reply);
-    });
+    };
+    void (async () => {
+      try {
+        for await (const ev of stream) {
+          if (ev.kind === 'session' && !capturedSid) {
+            capturedSid = ev.sessionId;
+            ensureLive();
+            safeSend({ type: 'meta', cwd: live.cwd, sessionId: capturedSid });
+          } else if (ev.kind === 'delta') relay({ type: 'delta', text: ev.text });
+          else if (ev.kind === 'tool_use') relay({ type: 'tool_use', id: ev.id, name: ev.name, input: ev.input });
+          else if (ev.kind === 'tool_result') relay({ type: 'tool_result', tool_use_id: ev.tool_use_id, text: ev.text, isError: ev.isError });
+          else if (ev.kind === 'usage') relay({ type: 'usage', outputTokens: ev.outputTokens, thinkingTokens: ev.thinkingTokens });
+          else if (ev.kind === 'message') relay({ type: 'event', event: 'system', subtype: ev.subtype });
+          else if (ev.kind === 'error') relay({ type: 'error', error: ev.error });
+          else if (ev.kind === 'done') {
+            finishRun(ev.exitCode);
+            return;
+          }
+        }
+        finishRun(-1, 'runner ended without a terminal event');
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        finishRun(-1, msg);
+      } finally {
+        // Owner-guarded and idempotent: a stale iterator cannot release a newer
+        // controller, while every settled iterator gives up its own claim.
+        if (capturedSid) endRun(capturedSid, owner);
+        if (!clientGone) sseDone(reply);
+      }
+    })();
   };
 
   app.post<{ Body: NewThreadBody }>('/api/kimi/threads', async (req, reply) => {
@@ -163,7 +188,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
     startSSE(reply);
     sseSend(reply, { type: 'starting', cwd });
     const abortController = new AbortController();
-    const stream = runKimi({ prompt: text, cwd, images, abortController });
+    const stream = runKimiForRoute({ prompt: text, cwd, images, abortController });
     // pipeKimiToSSE owns the iteration, so wrap the runner to install the abort
     // under the sid once the first `session` event reveals it.
     const wrapped = (async function* () {
@@ -172,7 +197,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
         yield ev;
       }
     })();
-    pipeKimiToSSE(reply, wrapped as ReturnType<typeof runKimi>, null, { cwd, text, hasImages: images.length > 0 });
+    pipeKimiToSSE(reply, wrapped as ReturnType<typeof runKimi>, null, abortController, { cwd, text, hasImages: images.length > 0 });
   });
 
   app.post<{ Params: SidParams; Body: MessageBody }>(
@@ -186,7 +211,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
       }
       let cwd = process.env.HOME || '/tmp';
       try {
-        const detail = await readKimiSessionMessages(sid);
+        const detail = await readKimiSessionMessagesForRoute(sid);
         if (detail.cwd) cwd = detail.cwd;
       } catch (e) {
         return reply.status(404).send({ error: (e as Error).message });
@@ -197,7 +222,7 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
       }
       startSSE(reply);
       sseSend(reply, { type: 'meta', sessionId: sid, cwd });
-      pipeKimiToSSE(reply, runKimi({ prompt: text, cwd, resume: sid, images, abortController }), sid, { cwd, text, hasImages: images.length > 0 });
+      pipeKimiToSSE(reply, runKimiForRoute({ prompt: text, cwd, resume: sid, images, abortController }), sid, abortController, { cwd, text, hasImages: images.length > 0 });
     },
   );
 

--- a/server/src/routes/kimi.ts
+++ b/server/src/routes/kimi.ts
@@ -30,7 +30,7 @@ import {
 } from '../lib/kimi-config.js';
 import { startSSE, sseSend, sseDone } from '../lib/sse.js';
 import { liveStart, livePush, liveEnd, liveGet } from '../lib/live-registry.js';
-import { registerRun, abortRun, endRun } from '../lib/active-runs.js';
+import { registerRun, claimRun, abortRun, endRun } from '../lib/active-runs.js';
 import type { AttachedImage } from '../lib/claude-runner.js';
 import type { SessionStreamEvent } from '@macaron/shared';
 
@@ -191,10 +191,12 @@ export async function registerKimiRoutes(app: FastifyInstance): Promise<void> {
       } catch (e) {
         return reply.status(404).send({ error: (e as Error).message });
       }
+      const abortController = new AbortController();
+      if (!claimRun(sid, abortController)) {
+        return reply.status(409).send({ error: 'a turn is already in flight for this thread' });
+      }
       startSSE(reply);
       sseSend(reply, { type: 'meta', sessionId: sid, cwd });
-      const abortController = new AbortController();
-      registerRun(sid, abortController);
       pipeKimiToSSE(reply, runKimi({ prompt: text, cwd, resume: sid, images, abortController }), sid, { cwd, text, hasImages: images.length > 0 });
     },
   );

--- a/server/test/kimi-live-route.test.ts
+++ b/server/test/kimi-live-route.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Fastify from 'fastify';
+import type { SessionDetail } from '@macaron/shared';
+import type { RunnerEvent } from '../src/lib/claude-runner.js';
+import type { KimiRunOptions } from '../src/lib/kimi-runner.js';
+import { endRun } from '../src/lib/active-runs.js';
+import { registerKimiRoutes } from '../src/routes/kimi.js';
+
+function sessionDetail(sid: string, cwd: string): SessionDetail {
+  return {
+    kind: 'kimi',
+    sessionId: sid,
+    project: 'test-project',
+    cwd,
+    messages: [],
+  };
+}
+
+test('Kimi resume keeps a replacement claim safe from stale cleanup', { timeout: 10_000 }, async (t) => {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'mcc-kimi-owner-'));
+  const sid = 'kimi-stale-owner-session';
+  let allowFirstDone!: () => void;
+  let releaseStaleFinalizer!: () => void;
+  let finishReplacement!: () => void;
+  let firstStarted!: () => void;
+  let staleFinalizing!: () => void;
+  let replacementStarted!: () => void;
+  const firstDoneGate = new Promise<void>((resolve) => { allowFirstDone = resolve; });
+  const staleFinalizerGate = new Promise<void>((resolve) => { releaseStaleFinalizer = resolve; });
+  const replacementGate = new Promise<void>((resolve) => { finishReplacement = resolve; });
+  const firstStartedGate = new Promise<void>((resolve) => { firstStarted = resolve; });
+  const staleFinalizingGate = new Promise<void>((resolve) => { staleFinalizing = resolve; });
+  const replacementStartedGate = new Promise<void>((resolve) => { replacementStarted = resolve; });
+  let runnerCalls = 0;
+
+  async function* fakeRunKimi(): AsyncGenerator<RunnerEvent> {
+    runnerCalls += 1;
+    if (runnerCalls === 1) {
+      yield { kind: 'delta', text: 'first running' };
+      firstStarted();
+      await firstDoneGate;
+      try {
+        yield { kind: 'done', exitCode: 0 };
+      } finally {
+        staleFinalizing();
+        await staleFinalizerGate;
+        throw new Error('stale finalizer failed');
+      }
+      return;
+    }
+    if (runnerCalls === 2) {
+      yield { kind: 'delta', text: 'replacement running' };
+      replacementStarted();
+      await replacementGate;
+    }
+    yield { kind: 'done', exitCode: 0 };
+  }
+
+  const app = Fastify({ logger: false });
+  await registerKimiRoutes(app, {
+    runKimi: fakeRunKimi,
+    readKimiSessionMessages: async () => sessionDetail(sid, cwd),
+  });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    allowFirstDone();
+    releaseStaleFinalizer();
+    finishReplacement();
+    endRun(sid);
+    app.server.closeAllConnections();
+    await app.close();
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  const address = app.server.address();
+  assert.ok(address && typeof address !== 'string');
+  const sessionPath = `http://127.0.0.1:${address.port}/api/kimi/threads/${sid}`;
+  const postMessage = (text: string) => fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+
+  const first = await postMessage('first');
+  assert.equal(first.status, 200);
+  const firstText = first.text();
+  await firstStartedGate;
+
+  const duplicate = await postMessage('duplicate');
+  assert.equal(duplicate.status, 409);
+  assert.deepEqual(await duplicate.json(), { error: 'a turn is already in flight for this thread' });
+
+  allowFirstDone();
+  await staleFinalizingGate;
+  const replacement = await postMessage('replacement');
+  assert.equal(replacement.status, 200);
+  const replacementText = replacement.text();
+  await replacementStartedGate;
+
+  releaseStaleFinalizer();
+  assert.match(await firstText, /"type":"done","exitCode":0/);
+
+  const afterStaleCleanup = await postMessage('must stay blocked');
+  assert.equal(afterStaleCleanup.status, 409);
+
+  finishReplacement();
+  assert.match(await replacementText, /"type":"done","exitCode":0/);
+  assert.equal(runnerCalls, 2);
+});
+
+test('Kimi abort keeps ownership until a runner without done settles', { timeout: 10_000 }, async (t) => {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'mcc-kimi-abort-'));
+  const sid = 'kimi-abort-owner-session';
+  let finishAbort!: () => void;
+  let firstStarted!: () => void;
+  const abortGate = new Promise<void>((resolve) => { finishAbort = resolve; });
+  const firstStartedGate = new Promise<void>((resolve) => { firstStarted = resolve; });
+  let runnerCalls = 0;
+  let firstOptions: KimiRunOptions | undefined;
+
+  async function* fakeRunKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent> {
+    runnerCalls += 1;
+    if (runnerCalls > 1) {
+      yield { kind: 'done', exitCode: 0 };
+      return;
+    }
+    firstOptions = opts;
+    yield { kind: 'delta', text: 'still running' };
+    firstStarted();
+    await new Promise<void>((resolve) => opts.abortController?.signal.addEventListener('abort', () => resolve(), { once: true }));
+    await abortGate;
+    // Deliberately settle without the RunnerEvent contract's terminal `done`.
+  }
+
+  const app = Fastify({ logger: false });
+  await registerKimiRoutes(app, {
+    runKimi: fakeRunKimi,
+    readKimiSessionMessages: async () => sessionDetail(sid, cwd),
+  });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    finishAbort();
+    endRun(sid);
+    app.server.closeAllConnections();
+    await app.close();
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  const address = app.server.address();
+  assert.ok(address && typeof address !== 'string');
+  const sessionPath = `http://127.0.0.1:${address.port}/api/kimi/threads/${sid}`;
+  const postMessage = (text: string) => fetch(`${sessionPath}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+
+  const original = await postMessage('long turn');
+  assert.equal(original.status, 200);
+  const originalText = original.text();
+  await firstStartedGate;
+
+  const stopped = await fetch(`${sessionPath}/stop`, { method: 'POST' });
+  assert.deepEqual(await stopped.json(), { ok: true, running: true });
+  assert.equal(firstOptions?.abortController?.signal.aborted, true);
+
+  const competing = await postMessage('too early');
+  assert.equal(competing.status, 409);
+
+  finishAbort();
+  const terminalText = await originalText;
+  assert.match(terminalText, /runner ended without a terminal event/);
+  assert.match(terminalText, /"type":"done","exitCode":-1/);
+
+  const retry = await postMessage('after cleanup');
+  assert.equal(retry.status, 200);
+  assert.match(await retry.text(), /"type":"done","exitCode":0/);
+  assert.equal(runnerCalls, 2);
+});

--- a/web/src/kimi/KimiProviderPicker.tsx
+++ b/web/src/kimi/KimiProviderPicker.tsx
@@ -31,6 +31,12 @@ export function KimiProviderPicker() {
   }
 
   const activeId = settings.activeProviderId;
+  // The active provider may be a keyless custom one (excluded from options
+  // above) — surface it anyway so the controlled <select> value has a match.
+  if (!options.some((o) => o.id === activeId)) {
+    const p = settings.customProviders.find((cp) => cp.id === activeId);
+    if (p) options.push({ id: p.id, label: p.name, usable: false });
+  }
   const activeLabel =
     options.find((o) => o.id === activeId)?.label
     ?? (activeId === SYSTEM_ID ? 'System default' : '(unconfigured)');

--- a/web/src/kimi/KimiSettings.tsx
+++ b/web/src/kimi/KimiSettings.tsx
@@ -144,7 +144,7 @@ function ProviderList({
           {isAct(SYSTEM_ID) && <span className="kx-plist-active-badge">active</span>}
         </div>
         <div className="kx-plist-row-sub">
-          {builtin.detectedEndpoint || 'ambient OAuth login'}
+          ambient OAuth login
         </div>
       </button>
 
@@ -193,8 +193,6 @@ function SystemPane({
       </div>
       <p className="kx-section-body">{builtin.description}</p>
       <dl className="kx-kv">
-        <dt>Detected endpoint</dt>
-        <dd>{builtin.detectedEndpoint || <em>none</em>}</dd>
         <dt>Detected model</dt>
         <dd>{builtin.detectedModel || <em>none</em>}</dd>
       </dl>

--- a/web/src/kimi/api.ts
+++ b/web/src/kimi/api.ts
@@ -25,7 +25,6 @@ export type PublicKimiBuiltin = {
   id: 'system';
   name: string;
   description: string;
-  detectedEndpoint: string | null;
   detectedModel: string | null;
 };
 

--- a/web/src/kimi/stream.ts
+++ b/web/src/kimi/stream.ts
@@ -37,6 +37,7 @@ async function pump(resp: Response, h: KimiStreamHandlers): Promise<void> {
   if (!resp.ok || !resp.body) {
     const txt = await resp.text().catch(() => '');
     h.onError?.(`http ${resp.status}: ${txt.slice(0, 200)}`);
+    h.onDone?.(-1); // so callers waiting on onDone (setSending(false)) don't hang
     return;
   }
   const reader = resp.body.getReader();


### PR DESCRIPTION
## Summary

Adds **Kimi Code** as a third Macaron engine alongside claude and codex, selected via `MACARON_ENGINE=kimi`. The three engines share the same SPA shell, sidebar layout, and live-reattach plumbing.

- **Server** — a Kimi runner that drives the CLI in **ACP mode** (`kimi acp`, JSON-RPC over stdio). ACP's `session/new` / `session/load` accept an `mcpServers` list, so the Macaron stdio MCP bridge (`render_ui`) is injected as a real MCP tool — surfacing on the wire as a `tool_call` titled `mcp__macaron__render_ui`, exactly the string the web layer matches for inline GenUI. Per-turn usage is summed best-effort from the session's `wire.jsonl`.
- **Config** — a `system` pass-through built-in (ambient Kimi Code login, no env overrides) plus arbitrary custom providers synthesized at spawn time via the `KIMI_MODEL_*` env family, so the user's own `~/.kimi-code/config.toml` is never rewritten.
- **Web** — a Kimi SPA (`kimi.html`) with thread view, provider picker chip, settings page, and live snapshot-then-stream reattach mirroring the codex `/live` handler.
- **Packaging** — `mkx` launcher package, plugin manifest, and start-script wiring; landing + architecture docs updated.

## Review fixes (6af131a)

An xhigh-effort review of the ACP rewrite surfaced seven findings, all fixed and verified in this branch:

| Area | Fix |
| --- | --- |
| `stream.ts` | pump now calls `onDone` on non-OK responses, so the composer clears `sending` instead of locking up |
| `health.ts` | `/api/health` reports the active kimi model, not the claude fallback |
| `kimi.ts` | resume `claimRun`s the sid → concurrent turns get `409` instead of clobbering the controller / `wire.jsonl` |
| `kimi-runner.ts` | clean aborted-before-prompt exit; emit a `tool_use` before an otherwise-orphan `tool_result` |
| `KimiSettings.tsx` / `api.ts` | drop the never-sent `detectedEndpoint` field (front/back contract drift) |
| `KimiProviderPicker.tsx` | keep the active keyless provider selectable in the controlled `<select>` |

## Test plan

- [x] `/api/health` under `MACARON_ENGINE=kimi` returns the kimi provider model (verified live)
- [x] empty-body `POST /api/kimi/threads` → `400`; pump hits the `!resp.ok` path that now fires `onDone`
- [x] `claimRun` exclusivity: first claim succeeds, concurrent same-sid claim fails, `abortRun` only aborts the owner, re-claimable after `endRun`
- [x] `server` typechecks clean
- [ ] manual: trigger a 400/404 in the UI and confirm the composer recovers
- [ ] manual: concurrent resume of one thread returns 409
- [ ] manual: end-to-end `render_ui` GenUI render against a live ACP model