### PR TITLE
reject broken replay render frames

### DIFF
--- a/scripts/replay/fixture.mjs
+++ b/scripts/replay/fixture.mjs
@@ -62,13 +62,12 @@ export function expandReplayFixture(fixture) {
 
     const renderUi = entry.renderUi;
     const code = renderCode(renderUi);
-    let previousLength = 0;
-    for (let index = 1; index <= renderUi.chunks; index += 1) {
-      const length = Math.max(previousLength + 1, Math.floor((code.length * index) / renderUi.chunks));
-      previousLength = Math.min(code.length, length);
-      const partialCode = code.slice(0, previousLength);
+    const lineEnds = [...code.matchAll(/\n/g), { index: code.length - 1 }].map((match) => match.index + 1);
+    const chunkCount = Math.min(renderUi.chunks, lineEnds.length);
+    for (let index = 1; index <= chunkCount; index += 1) {
+      const partialCode = code.slice(0, lineEnds[Math.ceil((lineEnds.length * index) / chunkCount) - 1]);
       schedule.push({
-        at: entry.at + (renderUi.duration * index) / renderUi.chunks,
+        at: entry.at + (renderUi.duration * index) / chunkCount,
         sequence: sequence++,
         event: {
           type: 'tool_input_delta',

--- a/scripts/replay/render.mjs
+++ b/scripts/replay/render.mjs
@@ -88,6 +88,7 @@ async function main() {
     });
     const page = await context.newPage();
     const pageErrors = [];
+    const consoleErrors = new Set();
     const responseErrors = new Set();
     page.on('pageerror', (error) => pageErrors.push(error));
     page.on('response', (response) => {
@@ -98,6 +99,7 @@ async function main() {
     });
     page.on('console', (message) => {
       if (message.type() === 'error' && !message.text().includes('Failed to load resource')) {
+        consoleErrors.add(message.text());
         process.stderr.write(`[browser] ${message.text()}\n`);
       }
     });
@@ -140,6 +142,7 @@ async function main() {
 
     await page.screenshot({ path: options.proof, type: 'png' });
     if (pageErrors.length > 0) throw new AggregateError(pageErrors, 'The production web app raised browser errors during replay');
+    if (consoleErrors.size > 0) throw new Error(`The production web app logged browser errors during replay:\n${[...consoleErrors].join('\n')}`);
     const localResponseErrors = [...responseErrors].filter((failure) => failure.includes(origin));
     if (localResponseErrors.length > 0) {
       throw new Error(`The production web app requested missing replay resources:\n${localResponseErrors.join('\n')}`);

--- a/scripts/replay/replay.test.mjs
+++ b/scripts/replay/replay.test.mjs
@@ -18,6 +18,10 @@ test('expands render_ui descriptors into monotonic production SSE events', () =>
   const chunks = schedule.filter((item) => item.event.type === 'tool_input_delta');
   assert.ok(chunks.length > 20);
   assert.ok(chunks.every((item) => item.event.name === RENDER_UI_TOOL));
+  assert.ok(chunks.every((item) => {
+    const code = JSON.parse(item.event.accumulated).code;
+    return code.endsWith('\n') || code.endsWith('}');
+  }));
   for (const id of ['ui-baseline', 'ui-verified']) {
     const lengths = chunks
       .filter((item) => item.event.id === id)


### PR DESCRIPTION
## Summary

- split synthetic `render_ui` streams at source line boundaries so partial identifiers cannot execute as broken JavaScript
- fail replay recording when the production page logs a browser console error
- cover line-safe replay chunks in the fixture tests

## Verification

- `pnpm replay:test`
- `pnpm build:web`
- `node scripts/replay/render.mjs --input replays/checkout-latency.json --output out/checkout-latency-fixed-60fps.mp4 --proof out/checkout-latency-fixed-60fps.png --fps 60`
- production recorder completed all 1,440 frames without page, console, renderer, or local response errors

Fixes the transient `ReferenceError: re is not defined` observed in the default replay fixture.