### PR TITLE
Show Bash tool `description` instead of raw command in session view

### DIFF
--- a/web/src/lib/liveStore.ts
+++ b/web/src/lib/liveStore.ts
@@ -11,9 +11,6 @@ import type { Message } from '@macaron/shared';
 import { extractPartialCode } from './partialJson';
 import { authedFetch } from './auth';
 
-const DIFF_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'str_replace', 'str_replace_editor', 'str_replace_based_edit_tool']);
-const isDiffTool = (name: string) => DIFF_TOOLS.has(name);
-
 // A single item on the timeline. Text chunks and tool calls are stored in
 // one ordered list so the UI renders them in the exact interleaved order
 // they arrive (Claude often emits `text → tool → text → tool → text`, and
@@ -253,7 +250,11 @@ function applyLiveEvent(sid: string, p: { type?: string; [k: string]: unknown })
           notify(sid);
         }
       } catch { /* tolerate */ }
-    } else if (s && isDiffTool(String(p.name))) {
+    } else if (s) {
+      // Any other regular tool (Bash, Read, diff tools…): the tool_use started
+      // with an empty input, so backfill the fully parsed args now that they're
+      // complete — otherwise e.g. a live Bash row would show neither description
+      // nor command until the on-disk snapshot takes over.
       try {
         const obj = JSON.parse(String(p.final_json || ''));
         const t = s.timeline.find((x) => x.kind === 'tool' && x.id === `live-${p.id}`);
@@ -543,7 +544,9 @@ export function startNewSession(project: string, opts: NewSessionOptions): Promi
                       notify(sid);
                     }
                   } catch { /* tolerate */ }
-                } else if (s && isDiffTool(p.name)) {
+                } else if (s) {
+                  // Any other regular tool (Bash, Read, diff tools…): backfill
+                  // the fully parsed args now that streaming is complete.
                   try {
                     const obj = JSON.parse(p.final_json);
                     const t = s.timeline.find((x) => x.kind === 'tool' && x.id === `live-${p.id}`);

--- a/web/src/lib/toolHeader.ts
+++ b/web/src/lib/toolHeader.ts
@@ -1,0 +1,20 @@
+// Header line shown next to a tool call in the timeline — the most useful
+// one-liner for each tool. Pure and dependency-free so it can be unit-tested
+// without dragging in the Session view's GenUI runtime graph.
+export function toolHeader(name: string, input: any): string {
+  if (!input || typeof input !== 'object') return '';
+  if (name === 'Bash') {
+    return String(input.description || input.command || '').replace(/\s+/g, ' ').slice(0, 240);
+  }
+  if (name === 'Read' || name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+    const p = String(input.file_path || '');
+    return p ? '…' + p.split('/').slice(-2).join('/') : '';
+  }
+  if (name === 'Glob') return String(input.pattern || '');
+  if (name === 'Grep') return String(input.pattern || '');
+  if (name === 'TaskCreate') return String(input.subject || '');
+  if (name === 'TaskUpdate') return `#${input.taskId || ''} → ${input.status || input.subject || ''}`;
+  if (name === 'WebFetch' || name === 'WebSearch') return String(input.url || input.query || '');
+  const s = JSON.stringify(input);
+  return s.length > 200 ? s.slice(0, 200) + '…' : s;
+}

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -289,7 +289,7 @@ export function flatten(messages: Message[]): Item[] {
 export function toolHeader(name: string, input: any): string {
   if (!input || typeof input !== 'object') return '';
   if (name === 'Bash') {
-    return String(input.command || '').replace(/\s+/g, ' ').slice(0, 240);
+    return String(input.description || input.command || '').replace(/\s+/g, ' ').slice(0, 240);
   }
   if (name === 'Read' || name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
     const p = String(input.file_path || '');

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -46,6 +46,7 @@ import { useConfirm } from '../components/Confirm';
 import { useFileMention } from '../components/MentionPopup';
 import { StatusBar, type PermissionMode } from '../components/StatusBar';
 import { DiffCard, isDiffTool, extractDiff } from '../components/DiffCard';
+import { toolHeader } from '../lib/toolHeader';
 import { loadHistory, pushHistory } from '../lib/history';
 import { ensureNotificationPermission, notify } from '../lib/notify';
 import { playSound } from '../lib/sound';
@@ -282,26 +283,6 @@ export function flatten(messages: Message[]): Item[] {
     }
   }
   return out;
-}
-
-// ---- Tool header formatting (Bash → command first line, etc.) -------------
-
-export function toolHeader(name: string, input: any): string {
-  if (!input || typeof input !== 'object') return '';
-  if (name === 'Bash') {
-    return String(input.description || input.command || '').replace(/\s+/g, ' ').slice(0, 240);
-  }
-  if (name === 'Read' || name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
-    const p = String(input.file_path || '');
-    return p ? '…' + p.split('/').slice(-2).join('/') : '';
-  }
-  if (name === 'Glob') return String(input.pattern || '');
-  if (name === 'Grep') return String(input.pattern || '');
-  if (name === 'TaskCreate') return String(input.subject || '');
-  if (name === 'TaskUpdate') return `#${input.taskId || ''} → ${input.status || input.subject || ''}`;
-  if (name === 'WebFetch' || name === 'WebSearch') return String(input.url || input.query || '');
-  const s = JSON.stringify(input);
-  return s.length > 200 ? s.slice(0, 200) + '…' : s;
 }
 
 // ---- Items ----------------------------------------------------------------

--- a/web/test/tool-header.test.ts
+++ b/web/test/tool-header.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { toolHeader } from '../src/lib/toolHeader';
+
+test('Bash header prefers description over the raw command', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la', description: 'List files' }), 'List files');
+});
+
+test('Bash header falls back to the command when description is missing', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la' }), 'ls -la');
+});
+
+test('Bash header falls back to the command when description is empty', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la', description: '' }), 'ls -la');
+});


### PR DESCRIPTION
When Claude Code runs a `Bash` command, each tool call carries a human-readable `description`. The session view previously rendered the raw command as the header; now it prefers `description` and falls back to `command` when absent.

`web/src/views/Session.tsx:291-293`

Behavior for a missing/empty `description` is unchanged — it still shows the raw command.

Closes [MAC-9701](https://multica.macaron.xin/issues/bee62873-dc37-42a8-bc1b-696dbbb4d5a6 "展示 Bash 命令的 description 而非裸命令").
