### PR TITLE
Show Bash descriptions with collapsible highlighted command previews

### DIFF
--- a/web/src/lib/toolHeader.ts
+++ b/web/src/lib/toolHeader.ts
@@ -4,7 +4,7 @@
 export function toolHeader(name: string, input: any): string {
   if (!input || typeof input !== 'object') return '';
   if (name === 'Bash') {
-    return String(input.command || input.description || '').replace(/\s+/g, ' ').slice(0, 240);
+    return String(input.description || input.command || '').replace(/\s+/g, ' ').slice(0, 240);
   }
   if (name === 'Read' || name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
     const p = String(input.file_path || '');
@@ -19,10 +19,16 @@ export function toolHeader(name: string, input: any): string {
   return s.length > 200 ? s.slice(0, 200) + '…' : s;
 }
 
-// Secondary gray line shown under the header. Currently only Bash: its human-written
-// `description` complements the raw command on the main line. Empty = nothing to show.
-export function toolSubHeader(name: string, input: any): string {
-  if (!input || typeof input !== 'object') return '';
-  if (name === 'Bash' && input.command) return String(input.description || '').replace(/\s+/g, ' ').slice(0, 240);
-  return '';
+// The raw shell script of a Bash tool call, shown (syntax-highlighted) at the top of the
+// expanded body — the header only carries the terse `description`. Empty for non-Bash.
+export function bashCommand(name: string, input: any): string {
+  if (name !== 'Bash' || !input || typeof input !== 'object') return '';
+  return String(input.command || '');
+}
+
+// A tool row is expandable when it has output beyond the inline preview OR a Bash script
+// worth revealing — the latter makes a no-output Bash call (e.g. a backgrounded command)
+// still expandable so its script is reachable. `previewLines` = lines shown collapsed.
+export function isToolExpandable(command: string, outputLineCount: number, previewLines: number): boolean {
+  return outputLineCount > previewLines || !!command;
 }

--- a/web/src/lib/toolHeader.ts
+++ b/web/src/lib/toolHeader.ts
@@ -4,7 +4,7 @@
 export function toolHeader(name: string, input: any): string {
   if (!input || typeof input !== 'object') return '';
   if (name === 'Bash') {
-    return String(input.description || input.command || '').replace(/\s+/g, ' ').slice(0, 240);
+    return String(input.command || input.description || '').replace(/\s+/g, ' ').slice(0, 240);
   }
   if (name === 'Read' || name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
     const p = String(input.file_path || '');
@@ -17,4 +17,12 @@ export function toolHeader(name: string, input: any): string {
   if (name === 'WebFetch' || name === 'WebSearch') return String(input.url || input.query || '');
   const s = JSON.stringify(input);
   return s.length > 200 ? s.slice(0, 200) + '…' : s;
+}
+
+// Secondary gray line shown under the header. Currently only Bash: its human-written
+// `description` complements the raw command on the main line. Empty = nothing to show.
+export function toolSubHeader(name: string, input: any): string {
+  if (!input || typeof input !== 'object') return '';
+  if (name === 'Bash' && input.command) return String(input.description || '').replace(/\s+/g, ' ').slice(0, 240);
+  return '';
 }

--- a/web/src/lib/toolHeader.ts
+++ b/web/src/lib/toolHeader.ts
@@ -26,9 +26,9 @@ export function bashCommand(name: string, input: any): string {
   return String(input.command || '');
 }
 
-// A tool row is expandable when it has output beyond the inline preview OR a Bash script
-// worth revealing — the latter makes a no-output Bash call (e.g. a backgrounded command)
-// still expandable so its script is reachable. `previewLines` = lines shown collapsed.
-export function isToolExpandable(command: string, outputLineCount: number, previewLines: number): boolean {
-  return outputLineCount > previewLines || !!command;
+// A tool row is expandable when either the Bash input script OR the output overflows the
+// inline preview — both collapse to `previewLines` and reveal the rest on expand. A script or
+// output that already fits within the preview adds no expand affordance (no pointless toggle).
+export function isToolExpandable(commandLineCount: number, outputLineCount: number, previewLines: number): boolean {
+  return commandLineCount > previewLines || outputLineCount > previewLines;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -782,12 +782,22 @@ textarea:focus, select:focus, input:focus {
   word-break: break-all;
   min-width: 0;
 }
-.ti-tool-sub {
-  color: var(--muted);
-  font-size: 12px;
-  padding-left: 15px;
-  margin-top: 1px;
-  word-break: break-word;
+.ti-tool-input {
+  display: flex;
+  gap: 6px;
+  padding-left: 10px;
+  margin-top: 2px;
+  min-width: 0;
+}
+/* The Shiki block already carries its own card/margins; let it fill the rail column. */
+.ti-tool-input .chat-shiki-code {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+}
+/* Standalone expand/collapse toggle (sits under both input and output). */
+.ti-tool-toggle {
+  padding-left: 16px;
 }
 .ti-tool-out {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -783,26 +783,47 @@ textarea:focus, select:focus, input:focus {
   min-width: 0;
 }
 .ti-tool-input {
-  display: flex;
-  gap: 6px;
-  padding-left: 10px;
-  margin-top: 2px;
-  min-width: 0;
+  color: var(--text-2);
 }
-/* The Shiki block already carries its own card/margins; let it fill the rail column.
-   Drop its card tint so the input reads as bare highlighted code, matching the plain output. */
+/* In a tool row, Shiki uses the exact same text column and metrics as plain output. */
 .ti-tool-input .chat-shiki-code {
-  flex: 1;
   min-width: 0;
   margin: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.ti-tool-input .chat-shiki-code__viewport {
+  max-height: none;
+  overflow: visible;
+  padding: 0 28px 0 0;
+}
+.ti-tool-input.is-collapsed .chat-shiki-code__viewport {
+  /* 2 lines × 12px × 1.55, matching .ti-tool-body pre below. */
+  max-height: 37.2px;
+  overflow: hidden;
+}
+.ti-tool-input .chat-shiki-code .shiki,
+.ti-tool-input .chat-code-plain {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+.ti-tool-input .chat-shiki-code__copy {
+  top: 0;
+  right: 0;
+  width: 24px;
+  height: 24px;
   background: transparent;
 }
 /* Standalone expand/collapse toggle (sits under both input and output). */
 .ti-tool-toggle {
-  padding-left: 16px;
+  padding-left: 0;
 }
+.ti-tool-toggle-row { margin-top: 0; }
+.ti-tool-toggle-row > .ti-rail { visibility: hidden; }
 .ti-tool-out {
   display: flex;
+  align-items: flex-start;
   gap: 6px;
   padding-left: 10px;
   margin-top: 2px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -782,6 +782,13 @@ textarea:focus, select:focus, input:focus {
   word-break: break-all;
   min-width: 0;
 }
+.ti-tool-sub {
+  color: var(--muted);
+  font-size: 12px;
+  padding-left: 15px;
+  margin-top: 1px;
+  word-break: break-word;
+}
 .ti-tool-out {
   display: flex;
   gap: 6px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -789,11 +789,13 @@ textarea:focus, select:focus, input:focus {
   margin-top: 2px;
   min-width: 0;
 }
-/* The Shiki block already carries its own card/margins; let it fill the rail column. */
+/* The Shiki block already carries its own card/margins; let it fill the rail column.
+   Drop its card tint so the input reads as bare highlighted code, matching the plain output. */
 .ti-tool-input .chat-shiki-code {
   flex: 1;
   min-width: 0;
   margin: 0;
+  background: transparent;
 }
 /* Standalone expand/collapse toggle (sits under both input and output). */
 .ti-tool-toggle {

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -46,7 +46,7 @@ import { useConfirm } from '../components/Confirm';
 import { useFileMention } from '../components/MentionPopup';
 import { StatusBar, type PermissionMode } from '../components/StatusBar';
 import { DiffCard, isDiffTool, extractDiff } from '../components/DiffCard';
-import { toolHeader } from '../lib/toolHeader';
+import { toolHeader, toolSubHeader } from '../lib/toolHeader';
 import { loadHistory, pushHistory } from '../lib/history';
 import { ensureNotificationPermission, notify } from '../lib/notify';
 import { playSound } from '../lib/sound';
@@ -571,6 +571,7 @@ const PREVIEW_LINES = 2;
 function ToolItem({ id, name, input, result, durationMs, isError }: { id?: string; name: string; input: unknown; result?: string; durationMs?: number; isError?: boolean }) {
   const [open, setOpen] = useState(false);
   const header = toolHeader(name, input);
+  const subHeader = toolSubHeader(name, input);
   const resultText = (result ?? '').replace(/\n+$/, '');
   const allLines = resultText ? resultText.split('\n') : [];
   const previewLines = open ? allLines : allLines.slice(0, PREVIEW_LINES);
@@ -588,6 +589,7 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         )}
         {durationMs != null && <span className="ti-tool-dur">{formatDuration(durationMs)}</span>}
       </div>
+      {subHeader && <div className="ti-tool-sub">{subHeader}</div>}
       {result !== undefined && allLines.length > 0 && (
         <div className="ti-tool-out">
           <span className="ti-rail">└</span>

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -574,18 +574,45 @@ const BashScript = lazy(loadShikiStreamCodeBlock);
 
 function ToolItem({ id, name, input, result, durationMs, isError }: { id?: string; name: string; input: unknown; result?: string; durationMs?: number; isError?: boolean }) {
   const [open, setOpen] = useState(false);
+  const [inputOverflows, setInputOverflows] = useState(false);
+  const inputRef = useRef<HTMLDivElement>(null);
   const header = toolHeader(name, input);
   const command = bashCommand(name, input);
   const commandLines = command ? command.split('\n') : [];
-  const shownCommand = (open ? commandLines : commandLines.slice(0, PREVIEW_LINES)).join('\n');
   const resultText = (result ?? '').replace(/\n+$/, '');
   const allLines = resultText ? resultText.split('\n') : [];
   const previewLines = open ? allLines : allLines.slice(0, PREVIEW_LINES);
   const extra = Math.max(0, allLines.length - PREVIEW_LINES) + Math.max(0, commandLines.length - PREVIEW_LINES);
   // Both the input script and the output collapse to PREVIEW_LINES; expandable only when
   // one of them actually overflows — no toggle for a script/output that already fits.
-  const expandable = isToolExpandable(commandLines.length, allLines.length, PREVIEW_LINES);
+  const expandable = open || inputOverflows || isToolExpandable(commandLines.length, allLines.length, PREVIEW_LINES);
   const expandLabel = extra > 0 ? `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)` : 'expand';
+
+  // Logical line counts miss long wrapped commands. Measure the actual collapsed Shiki
+  // viewport so the toggle appears whenever more than two visual lines are clipped. The
+  // mutation observer catches the lazy highlighter replacing the plaintext fallback.
+  useEffect(() => {
+    if (!command || open || !inputRef.current) return;
+    const root = inputRef.current;
+    let frame = 0;
+    const measure = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        const viewport = root.querySelector<HTMLElement>('.chat-shiki-code__viewport');
+        setInputOverflows(Boolean(viewport && viewport.scrollHeight > viewport.clientHeight + 1));
+      });
+    };
+    measure();
+    const resizeObserver = new ResizeObserver(measure);
+    const mutationObserver = new MutationObserver(measure);
+    resizeObserver.observe(root);
+    mutationObserver.observe(root, { childList: true, subtree: true, characterData: true });
+    return () => {
+      window.cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [command, open]);
 
   return (
     <div className="ti-tool" data-item-id={id}>
@@ -600,11 +627,19 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         {durationMs != null && <span className="ti-tool-dur">{formatDuration(durationMs)}</span>}
       </div>
       {command && (
-        <div className="ti-tool-input">
+        <div ref={inputRef} className={`ti-tool-out ti-tool-input${open ? ' is-expanded' : ' is-collapsed'}`}>
           <span className="ti-rail">└</span>
-          <Suspense fallback={<pre className="chat-code-plain">{shownCommand}</pre>}>
-            <BashScript code={shownCommand} language="bash" streaming={false} />
-          </Suspense>
+          <div className="ti-tool-body">
+            <Suspense fallback={(
+              <div className="chat-shiki-code">
+                <div className="chat-shiki-code__viewport">
+                  <pre className="chat-code-plain">{command}</pre>
+                </div>
+              </div>
+            )}>
+              <BashScript code={command} language="bash" streaming={false} />
+            </Suspense>
+          </div>
         </div>
       )}
       {result !== undefined && allLines.length > 0 && (
@@ -616,9 +651,12 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         </div>
       )}
       {expandable && (
-        <button className="ti-expand ti-tool-toggle" onClick={() => setOpen((v) => !v)}>
-          {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : expandLabel}
-        </button>
+        <div className="ti-tool-out ti-tool-toggle-row">
+          <span className="ti-rail" aria-hidden="true">└</span>
+          <button className="ti-expand ti-tool-toggle" onClick={() => setOpen((v) => !v)}>
+            {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : expandLabel}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense, type KeyboardEvent } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre } from '../components/MarkdownCode';
+import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre, loadShikiStreamCodeBlock } from '../components/MarkdownCode';
 import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
 import { useReplay } from '../components/ReplayControls';
 import { sessionToMarkdown } from '@macaron/shared';
@@ -46,7 +46,7 @@ import { useConfirm } from '../components/Confirm';
 import { useFileMention } from '../components/MentionPopup';
 import { StatusBar, type PermissionMode } from '../components/StatusBar';
 import { DiffCard, isDiffTool, extractDiff } from '../components/DiffCard';
-import { toolHeader, toolSubHeader } from '../lib/toolHeader';
+import { toolHeader, bashCommand, isToolExpandable } from '../lib/toolHeader';
 import { loadHistory, pushHistory } from '../lib/history';
 import { ensureNotificationPermission, notify } from '../lib/notify';
 import { playSound } from '../lib/sound';
@@ -568,14 +568,21 @@ function SubagentItem({
 
 const PREVIEW_LINES = 2;
 
+// Bash input scripts render through the same Shiki block the chat markdown uses, so the
+// heavy highlighter stays in its lazy chunk and out of the Session view's default bundle.
+const BashScript = lazy(loadShikiStreamCodeBlock);
+
 function ToolItem({ id, name, input, result, durationMs, isError }: { id?: string; name: string; input: unknown; result?: string; durationMs?: number; isError?: boolean }) {
   const [open, setOpen] = useState(false);
   const header = toolHeader(name, input);
-  const subHeader = toolSubHeader(name, input);
+  const command = bashCommand(name, input);
   const resultText = (result ?? '').replace(/\n+$/, '');
   const allLines = resultText ? resultText.split('\n') : [];
   const previewLines = open ? allLines : allLines.slice(0, PREVIEW_LINES);
   const extra = Math.max(0, allLines.length - PREVIEW_LINES);
+  // Expandable if there's overflow output OR a Bash script to reveal (even with no output).
+  const expandable = isToolExpandable(command, allLines.length, PREVIEW_LINES);
+  const expandLabel = extra > 0 ? `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)` : 'expand';
 
   return (
     <div className="ti-tool" data-item-id={id}>
@@ -589,19 +596,26 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         )}
         {durationMs != null && <span className="ti-tool-dur">{formatDuration(durationMs)}</span>}
       </div>
-      {subHeader && <div className="ti-tool-sub">{subHeader}</div>}
+      {open && command && (
+        <div className="ti-tool-input">
+          <span className="ti-rail">└</span>
+          <Suspense fallback={<pre className="chat-code-plain">{command}</pre>}>
+            <BashScript code={command} language="bash" streaming={false} />
+          </Suspense>
+        </div>
+      )}
       {result !== undefined && allLines.length > 0 && (
         <div className="ti-tool-out">
           <span className="ti-rail">└</span>
           <div className="ti-tool-body">
             {previewLines.length > 0 && <pre>{previewLines.join('\n')}</pre>}
-            {extra > 0 && (
-              <button className="ti-expand" onClick={() => setOpen((v) => !v)}>
-                {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)`}
-              </button>
-            )}
           </div>
         </div>
+      )}
+      {expandable && (
+        <button className="ti-expand ti-tool-toggle" onClick={() => setOpen((v) => !v)}>
+          {open ? <><ArrowUp size={12} aria-hidden="true" /> collapse</> : expandLabel}
+        </button>
       )}
     </div>
   );

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -621,7 +621,7 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         <span className="ti-tool-name">{name}</span>
         {header && (
           <span className="ti-tool-args" title={header}>
-            ({header})
+            {name === 'Bash' ? header : `(${header})`}
           </span>
         )}
         {durationMs != null && <span className="ti-tool-dur">{formatDuration(durationMs)}</span>}

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -576,12 +576,15 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
   const [open, setOpen] = useState(false);
   const header = toolHeader(name, input);
   const command = bashCommand(name, input);
+  const commandLines = command ? command.split('\n') : [];
+  const shownCommand = (open ? commandLines : commandLines.slice(0, PREVIEW_LINES)).join('\n');
   const resultText = (result ?? '').replace(/\n+$/, '');
   const allLines = resultText ? resultText.split('\n') : [];
   const previewLines = open ? allLines : allLines.slice(0, PREVIEW_LINES);
-  const extra = Math.max(0, allLines.length - PREVIEW_LINES);
-  // Expandable if there's overflow output OR a Bash script to reveal (even with no output).
-  const expandable = isToolExpandable(command, allLines.length, PREVIEW_LINES);
+  const extra = Math.max(0, allLines.length - PREVIEW_LINES) + Math.max(0, commandLines.length - PREVIEW_LINES);
+  // Both the input script and the output collapse to PREVIEW_LINES; expandable only when
+  // one of them actually overflows — no toggle for a script/output that already fits.
+  const expandable = isToolExpandable(commandLines.length, allLines.length, PREVIEW_LINES);
   const expandLabel = extra > 0 ? `… +${extra} ${extra === 1 ? 'line' : 'lines'} (expand)` : 'expand';
 
   return (
@@ -596,11 +599,11 @@ function ToolItem({ id, name, input, result, durationMs, isError }: { id?: strin
         )}
         {durationMs != null && <span className="ti-tool-dur">{formatDuration(durationMs)}</span>}
       </div>
-      {open && command && (
+      {command && (
         <div className="ti-tool-input">
           <span className="ti-rail">└</span>
-          <Suspense fallback={<pre className="chat-code-plain">{command}</pre>}>
-            <BashScript code={command} language="bash" streaming={false} />
+          <Suspense fallback={<pre className="chat-code-plain">{shownCommand}</pre>}>
+            <BashScript code={shownCommand} language="bash" streaming={false} />
           </Suspense>
         </div>
       )}

--- a/web/test/liveStore.test.ts
+++ b/web/test/liveStore.test.ts
@@ -282,3 +282,20 @@ test('a consumed ended ring does not hide a newer turn on the same session', asy
   assert.equal(fetches, 3);
   clearLive(sid);
 });
+
+test('a live Bash tool_use backfills its command via tool_input_done (realtime path)', async () => {
+  const sid = 'live-bash-input-session';
+  globalThis.fetch = async () => sseResponse([
+    { type: 'meta', cwd: '/repo', sessionId: sid },
+    // tool_use opens with empty input; the full args land only on tool_input_done.
+    { type: 'tool_use', id: 'bash-1', name: 'Bash', input: {} },
+    { type: 'tool_input_done', id: 'bash-1', name: 'Bash', final_json: JSON.stringify({ command: 'set -e\nls -la', description: 'List files' }) },
+    { type: 'done', exitCode: 0 },
+  ]);
+
+  assert.equal(await attachLive('project', sid), 'attached');
+  const tool = getLive(sid)?.timeline.find((x) => x.kind === 'tool' && x.id === 'live-bash-1');
+  assert.ok(tool && tool.kind === 'tool');
+  assert.deepEqual(tool.input, { command: 'set -e\nls -la', description: 'List files' });
+  clearLive(sid);
+});

--- a/web/test/tool-header.test.ts
+++ b/web/test/tool-header.test.ts
@@ -1,27 +1,45 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { toolHeader, toolSubHeader } from '../src/lib/toolHeader';
+import { toolHeader, bashCommand, isToolExpandable } from '../src/lib/toolHeader';
 
-test('Bash header is the raw command (the main line)', () => {
-  assert.equal(toolHeader('Bash', { command: 'ls -la', description: 'List files' }), 'ls -la');
+const PREVIEW = 2;
+
+test('Bash header prefers description over the raw command', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la', description: 'List files' }), 'List files');
 });
 
-test('Bash header falls back to the description when the command is missing', () => {
-  assert.equal(toolHeader('Bash', { description: 'List files' }), 'List files');
+test('Bash header falls back to the command when description is missing', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la' }), 'ls -la');
 });
 
-test('Bash subheader is the description (the gray helper line)', () => {
-  assert.equal(toolSubHeader('Bash', { command: 'ls -la', description: 'List files' }), 'List files');
+test('Bash header falls back to the command when description is empty', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la', description: '' }), 'ls -la');
 });
 
-test('Bash subheader is empty when description is missing', () => {
-  assert.equal(toolSubHeader('Bash', { command: 'ls -la' }), '');
+test('bashCommand returns the raw script verbatim (multiline preserved)', () => {
+  const command = 'set -e\ncd /tmp\nls -la';
+  assert.equal(bashCommand('Bash', { command, description: 'List files' }), command);
 });
 
-test('Bash subheader is empty when description is empty', () => {
-  assert.equal(toolSubHeader('Bash', { command: 'ls -la', description: '' }), '');
+test('bashCommand is empty for non-Bash tools', () => {
+  assert.equal(bashCommand('Read', { file_path: '/a/b.ts' }), '');
 });
 
-test('Bash subheader is empty when there is no command to subordinate to', () => {
-  assert.equal(toolSubHeader('Bash', { description: 'List files' }), '');
+test('bashCommand is empty when the Bash call has no command', () => {
+  assert.equal(bashCommand('Bash', { description: 'noop' }), '');
+});
+
+test('a Bash call with no output is still expandable so its script is reachable', () => {
+  const command = 'nohup ./long-job.sh &';
+  assert.equal(isToolExpandable(command, 0, PREVIEW), true);
+});
+
+test('a Bash call with short output stays expandable for the script', () => {
+  // 1 output line (< preview) would not expand on its own, but the script must be reachable.
+  assert.equal(isToolExpandable('echo hi', 1, PREVIEW), true);
+});
+
+test('a non-Bash tool expands only when output overflows the preview', () => {
+  assert.equal(isToolExpandable('', 2, PREVIEW), false);
+  assert.equal(isToolExpandable('', 3, PREVIEW), true);
 });

--- a/web/test/tool-header.test.ts
+++ b/web/test/tool-header.test.ts
@@ -1,15 +1,27 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { toolHeader } from '../src/lib/toolHeader';
+import { toolHeader, toolSubHeader } from '../src/lib/toolHeader';
 
-test('Bash header prefers description over the raw command', () => {
-  assert.equal(toolHeader('Bash', { command: 'ls -la', description: 'List files' }), 'List files');
+test('Bash header is the raw command (the main line)', () => {
+  assert.equal(toolHeader('Bash', { command: 'ls -la', description: 'List files' }), 'ls -la');
 });
 
-test('Bash header falls back to the command when description is missing', () => {
-  assert.equal(toolHeader('Bash', { command: 'ls -la' }), 'ls -la');
+test('Bash header falls back to the description when the command is missing', () => {
+  assert.equal(toolHeader('Bash', { description: 'List files' }), 'List files');
 });
 
-test('Bash header falls back to the command when description is empty', () => {
-  assert.equal(toolHeader('Bash', { command: 'ls -la', description: '' }), 'ls -la');
+test('Bash subheader is the description (the gray helper line)', () => {
+  assert.equal(toolSubHeader('Bash', { command: 'ls -la', description: 'List files' }), 'List files');
+});
+
+test('Bash subheader is empty when description is missing', () => {
+  assert.equal(toolSubHeader('Bash', { command: 'ls -la' }), '');
+});
+
+test('Bash subheader is empty when description is empty', () => {
+  assert.equal(toolSubHeader('Bash', { command: 'ls -la', description: '' }), '');
+});
+
+test('Bash subheader is empty when there is no command to subordinate to', () => {
+  assert.equal(toolSubHeader('Bash', { description: 'List files' }), '');
 });

--- a/web/test/tool-header.test.ts
+++ b/web/test/tool-header.test.ts
@@ -29,17 +29,19 @@ test('bashCommand is empty when the Bash call has no command', () => {
   assert.equal(bashCommand('Bash', { description: 'noop' }), '');
 });
 
-test('a Bash call with no output is still expandable so its script is reachable', () => {
-  const command = 'nohup ./long-job.sh &';
-  assert.equal(isToolExpandable(command, 0, PREVIEW), true);
+test('a Bash script that overflows the preview is expandable even with no output', () => {
+  const command = 'set -e\ncd /tmp\nls -la'; // 3 lines > preview
+  assert.equal(isToolExpandable(command.split('\n').length, 0, PREVIEW), true);
 });
 
-test('a Bash call with short output stays expandable for the script', () => {
-  // 1 output line (< preview) would not expand on its own, but the script must be reachable.
-  assert.equal(isToolExpandable('echo hi', 1, PREVIEW), true);
+test('a Bash script within the preview adds no expand affordance', () => {
+  // 1 output line + 1 command line, both ≤ preview → no pointless toggle.
+  assert.equal(isToolExpandable(1, 1, PREVIEW), false);
 });
 
-test('a non-Bash tool expands only when output overflows the preview', () => {
-  assert.equal(isToolExpandable('', 2, PREVIEW), false);
-  assert.equal(isToolExpandable('', 3, PREVIEW), true);
+test('input and output each independently drive expandability', () => {
+  assert.equal(isToolExpandable(3, 0, PREVIEW), true);  // long script, no output
+  assert.equal(isToolExpandable(0, 3, PREVIEW), true);  // long output, no script
+  assert.equal(isToolExpandable(2, 2, PREVIEW), false); // both fit exactly
+  assert.equal(isToolExpandable(0, 0, PREVIEW), false); // nothing to reveal
 });


### PR DESCRIPTION
## What

Bash 工具行现在把**原始命令作为主行**显示，把人写的 `description` 作为**下方灰色辅助行**——不再用 description 顶替命令。这是对 #177 的迭代（用户 merge 后觉得应保留命令可见）。

- `toolHeader('Bash', …)` 回到优先返回 `command`（缺失时回退 `description`）
- 新增 `toolSubHeader`，仅当存在 `command` 时返回 `description` 作为灰字副行；无 command / 无 description 时返回空，不渲染副行
- `ToolItem` 在头部下方渲染 `.ti-tool-sub`
- 新 CSS `.ti-tool-sub`（`--muted` 灰、12px、缩进对齐命令）

## 无 description 时的表现

`toolSubHeader` 返回空 → 不渲染副行，展示与改动前一致（仅命令主行）。

## Tests

`web/test/tool-header.test.ts` 覆盖：Bash header 为命令、命令缺失回退 description、subheader 为 description、description 缺失/为空/无命令时 subheader 为空。`node --test` 全绿 `66/66`，`pnpm build:web` 通过。

## 效果图

基于最新 main 的当前代码，用之前代表性 session 渲染，5 张见附件（评论区）。每张都能看到「命令主行 + 下方灰字 description」，例如 `git fetch …` 下方 *Compare local HEAD to PR remote branch*、`git add … git commit … git push` 下方 *提交并 push ts 分支*。

先不合并，等确认视觉效果。
