### PR TITLE
mcc: add `--model` flag to preset the Claude launch model

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -21,6 +21,12 @@ jobs:
       # fires the root `prepack`, which runs `bun build` to bundle the server.
       - uses: oven-sh/setup-bun@v2
       - run: pnpm install --frozen-lockfile
+      # Run the server suite BEFORE publishing so a green pkg.pr.new check can't
+      # ship a broken bundle. CI=1 (set by GitHub Actions) makes the pack+install
+      # isolation suite MANDATORY: MACARON_SKIP_PACK_TESTS is ignored and a
+      # missing toolchain fails hard, so per-engine SDK isolation is always
+      # proven end-to-end (pack → install → boot → real first turn) here.
+      - run: pnpm --filter @macaron/server test
       # `pnpm exec`, not `pnpm dlx`/`bunx`: pkg.pr.new warns against dlx-style
       # runners in CI (they fetch an unpinned build each run). pkg-pr-new is a
       # devDependency, so this executes the lockfile-pinned binary from

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi
 
 Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/MindLab-Research/macaron-artifacts/commits/main)). All three accept `--host` / `--port`; run with `--help` for the full list.
 
+`mcc` also takes `--model <model>` to preset the Claude launch model (sets `ANTHROPIC_MODEL`), mirroring `claude --model X`. Paste your provider env and launch in one go:
+
+```bash
+export ANTHROPIC_BASE_URL='https://mint.macaron.im'
+export ANTHROPIC_AUTH_TOKEN='sk-...'
+bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha> --model Macaron-V1-Venti
+```
+
 Verify:
 
 ```bash

--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -6,6 +6,7 @@
 // Keep it types-only: --packages=external would externalize any runtime code it
 // gains into a bare import the published tarball can't resolve.
 import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
 
@@ -42,27 +43,31 @@ async function printVersion() {
   console.log(pkg.version);
 }
 
-const readValue = (i, flag) => {
-  const v = args[i + 1];
+const readValue = (argv, i, flag) => {
+  const v = argv[i + 1];
   if (v === undefined || v.startsWith('-')) throw new Error(`${flag} requires a value`);
   return v;
 };
 
-try {
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
+// Parse argv into process.env mutations (MACARON_* / ANTHROPIC_MODEL). Exported
+// so a launcher-to-boot integration test can drive the real parse in-process,
+// then warm the settings store against the resulting env. Throws on bad input;
+// --help/--version short-circuit via the onExit callback (process.exit in CLI).
+export async function parseArgs(argv, onExit = (code) => process.exit(code)) {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
     const eq = a.indexOf('=');
     const flag = eq === -1 ? a : a.slice(0, eq);
     const inline = eq === -1 ? null : a.slice(eq + 1);
-    if (flag === '--help' || flag === '-h') { printHelp(); process.exit(0); }
-    if (flag === '--version' || flag === '-v') { await printVersion(); process.exit(0); }
+    if (flag === '--help' || flag === '-h') { printHelp(); return onExit(0); }
+    if (flag === '--version' || flag === '-v') { await printVersion(); return onExit(0); }
     if (flag === '--allow-hosted') {
       if (inline !== null) throw new Error(`${flag} does not take a value`);
       process.env.MACARON_ALLOW_HOSTED = '1';
       continue;
     }
     if (flag === '--allow-origin') {
-      const origin = (inline ?? readValue(i, flag)).trim();
+      const origin = (inline ?? readValue(argv, i, flag)).trim();
       if (!origin) throw new Error(`${flag} requires a non-empty value`);
       const cur = process.env.MACARON_ALLOWED_ORIGINS;
       process.env.MACARON_ALLOWED_ORIGINS = cur ? `${cur},${origin}` : origin;
@@ -70,14 +75,14 @@ try {
       continue;
     }
     if (flag === '--host' || flag === '--port') {
-      process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(i, flag);
+      process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(argv, i, flag);
       // Advance past the consumed value only for the space form (inline === null).
       // `--flag=` (inline='') already has its value, so it must NOT skip the next arg.
       if (inline === null) i++;
       continue;
     }
     if (flag === '--model') {
-      const model = (inline ?? readValue(i, flag)).trim();
+      const model = (inline ?? readValue(argv, i, flag)).trim();
       if (!model) throw new Error(`${flag} requires a non-empty value`);
       process.env.ANTHROPIC_MODEL = model;
       if (inline === null) i++;
@@ -90,12 +95,19 @@ try {
   if (port !== undefined && (!/^\d+$/.test(port) || +port < 1 || +port > 65535)) {
     throw new Error(`Invalid port: ${port}`);
   }
-} catch (e) {
-  console.error(`mcc: ${e.message}`);
-  process.exit(1);
 }
-process.env.NODE_ENV ??= 'production';
 
-// Relative to this bin file → ../server/dist/index.js (ESM import() resolves
-// against import.meta.url, so it works regardless of the caller's cwd).
-await import('../server/dist/index.js');
+// Only parse + boot the server when run as the CLI, not when imported by a test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    await parseArgs(args);
+  } catch (e) {
+    console.error(`mcc: ${e.message}`);
+    process.exit(1);
+  }
+  process.env.NODE_ENV ??= 'production';
+
+  // Relative to this bin file → ../server/dist/index.js (ESM import() resolves
+  // against import.meta.url, so it works regardless of the caller's cwd).
+  await import('../server/dist/index.js');
+}

--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -17,6 +17,7 @@ function printHelp() {
 Options:
   --host <host>          Bind address (default: 127.0.0.1)
   --port <port>          Port (default: 7878)
+  --model <model>        Default model for new sessions (sets ANTHROPIC_MODEL)
   --allow-origin <url>   Allow a hosted WebUI on this origin to drive the server
                          cross-origin (repeatable; appends to MACARON_ALLOWED_ORIGINS)
   --allow-hosted         Allow the official hosted WebUI (https://artifacts.macaron.im)
@@ -72,6 +73,11 @@ try {
       process.env[flag === '--host' ? 'MACARON_HOST' : 'MACARON_PORT'] = inline ?? readValue(i, flag);
       // Advance past the consumed value only for the space form (inline === null).
       // `--flag=` (inline='') already has its value, so it must NOT skip the next arg.
+      if (inline === null) i++;
+      continue;
+    }
+    if (flag === '--model') {
+      process.env.ANTHROPIC_MODEL = inline ?? readValue(i, flag);
       if (inline === null) i++;
       continue;
     }

--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -6,6 +6,7 @@
 // Keep it types-only: --packages=external would externalize any runtime code it
 // gains into a bare import the published tarball can't resolve.
 import { readFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
@@ -98,7 +99,20 @@ export async function parseArgs(argv, onExit = (code) => process.exit(code)) {
 }
 
 // Only parse + boot the server when run as the CLI, not when imported by a test.
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+// Package managers expose the bin as a symlink (node_modules/.bin/mcc), so
+// process.argv[1] is the symlink path while import.meta.url is realpath-resolved
+// — resolve both through realpath before comparing, or the installed bin no-ops.
+function isMain() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
   try {
     await parseArgs(args);
   } catch (e) {

--- a/bin/mcc.mjs
+++ b/bin/mcc.mjs
@@ -77,7 +77,9 @@ try {
       continue;
     }
     if (flag === '--model') {
-      process.env.ANTHROPIC_MODEL = inline ?? readValue(i, flag);
+      const model = (inline ?? readValue(i, flag)).trim();
+      if (!model) throw new Error(`${flag} requires a non-empty value`);
+      process.env.ANTHROPIC_MODEL = model;
       if (inline === null) i++;
       continue;
     }

--- a/mcx/package.json
+++ b/mcx/package.json
@@ -19,7 +19,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@fastify/static": "^8.0.0",
     "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mkx/package.json
+++ b/mkx/package.json
@@ -19,11 +19,10 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.196",
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@fastify/static": "^8.0.0",
     "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.142.5",
     "@unocss/autocomplete": "^66.7.5",
     "@unocss/core": "^66.7.5",
     "@unocss/preset-wind3": "^66.7.5",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
   },
   "packageManager": "pnpm@10.28.2",
   "dependencies": {
-    "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@fastify/static": "^8.0.0",
     "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.142.5",
     "@unocss/autocomplete": "^66.7.5",
     "@unocss/core": "^66.7.5",
     "@unocss/preset-wind3": "^66.7.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "packageManager": "pnpm@10.28.2",
   "dependencies": {
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@fastify/static": "^8.0.0",
     "@genui/diagnostics": "https://pkg.pr.new/MindLab-Research/macaron-genui-demo/@genui/diagnostics@7c845c8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@agentclientprotocol/sdk':
-        specifier: ^1.2.1
-        version: 1.2.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.196
         version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
@@ -23,9 +20,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
-      '@openai/codex-sdk':
-        specifier: ^0.142.5
-        version: 0.142.5
       '@unocss/autocomplete':
         specifier: ^66.7.5
         version: 66.7.5
@@ -72,9 +66,6 @@ importers:
 
   mcx:
     dependencies:
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.196
-        version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@fastify/static':
         specifier: ^8.0.0
         version: 8.3.0
@@ -123,9 +114,9 @@ importers:
 
   mkx:
     dependencies:
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.196
-        version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@agentclientprotocol/sdk':
+        specifier: ^1.2.1
+        version: 1.2.1(zod@4.4.3)
       '@fastify/static':
         specifier: ^8.0.0
         version: 8.3.0
@@ -135,9 +126,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
-      '@openai/codex-sdk':
-        specifier: ^0.142.5
-        version: 0.142.5
       '@unocss/autocomplete':
         specifier: ^66.7.5
         version: 66.7.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^1.2.1
+        version: 1.2.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.196
         version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,6 +4,13 @@ import path from 'node:path';
 export const PORT = parseInt(process.env.MACARON_PORT || '7878', 10);
 export const HOST = process.env.MACARON_HOST || '127.0.0.1';
 
+// The engine this launcher was booted as (mcc→claude, mcx→codex, mkx→kimi).
+// Unset means claude. Used to gate engine-specific routes/schedules so a
+// launcher never accepts or runs a foreign-engine session — which, post
+// dependency-split, would try to load an SDK it never installed.
+export const ENGINE: 'claude' | 'codex' | 'kimi' =
+  process.env.MACARON_ENGINE === 'kimi' ? 'kimi' : process.env.MACARON_ENGINE === 'codex' ? 'codex' : 'claude';
+
 // Optional shared token that gates the API when the server is reachable from
 // the network. Empty = auth off (the default for loopback-only binds).
 export const AUTH_TOKEN = process.env.MACARON_AUTH_TOKEN || '';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -149,13 +149,22 @@ await app.register(async (instance) => {
   await registerConfigFileRoutes(instance);
   await registerRelayRoutes(instance);
   await registerTunnelRoutes(instance);
-  await registerWorkspaceRoutes(instance);
   await registerProjectRoutes(instance);
   await registerFsRoutes(instance);
-  await registerSessionRoutes(instance);
   await registerWorktreeRoutes(instance);
-  await registerCodexRoutes(instance);
-  await registerKimiRoutes(instance);
+  // Engine-specific route groups. Each launcher sets MACARON_ENGINE and mounts
+  // only its own engine's runner routes, so a boot never touches another
+  // engine's runner module (and, with the runners' SDKs lazy-imported, never
+  // its SDK). The default (unset) engine is claude.
+  const engine = process.env.MACARON_ENGINE;
+  if (engine === 'codex') {
+    await registerCodexRoutes(instance);
+  } else if (engine === 'kimi') {
+    await registerKimiRoutes(instance);
+  } else {
+    await registerWorkspaceRoutes(instance);
+    await registerSessionRoutes(instance);
+  }
   await registerGitRoutes(instance);
   await registerShareRoutes(instance);
   await registerSearchRoutes(instance);

--- a/server/src/lib/claude-runner.ts
+++ b/server/src/lib/claude-runner.ts
@@ -3,8 +3,8 @@
 // approach — same UX, no CLI stdout parsing, typed events, no IPC buffering.
 
 import { randomUUID } from 'node:crypto';
-import { query, type SDKMessage, type PermissionMode, type SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
-import { macaronMcpServer } from './macaron-mcp.js';
+import type { SDKMessage, PermissionMode, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { getMacaronMcpServer } from './macaron-mcp.js';
 import { registerPending } from './permission-registry.js';
 import { computeRuleKeys, isAllowed, rememberSession, rememberProject } from './permission-rules.js';
 import type { CodexPlanStatus, CodexApprovalKind, CodexDecision } from '@macaron/shared';
@@ -146,6 +146,10 @@ export async function* runClaude(opts: RunOptions): AsyncGenerator<RunnerEvent> 
       // so by the time we get here `opts.permissionMode` already reflects
       // the user's picked mode for this session.
       const effectivePermissionMode: PermissionMode = opts.permissionMode ?? 'default';
+      // Lazy-import the Claude SDK so the shared bundle only pulls it in when a
+      // Claude run actually starts — the codex/kimi launchers never install it.
+      const { query } = await import('@anthropic-ai/claude-agent-sdk');
+      const macaronMcpServer = await getMacaronMcpServer();
       const stream = query({
         prompt: buildPromptInput(opts),
         options: {
@@ -372,6 +376,8 @@ export type FollowupOptions = {
 // incrementally with partial-json (Allow.ARR) so chips appear as they stream.
 // Parsing lives client-side — here we only relay text, never interpret it.
 export async function* runFollowup(opts: FollowupOptions): AsyncGenerator<string> {
+  const { query } = await import('@anthropic-ai/claude-agent-sdk');
+  const macaronMcpServer = await getMacaronMcpServer();
   const stream = query({
     prompt: FOLLOWUP_PROMPT,
     options: {

--- a/server/src/lib/kimi-runner.ts
+++ b/server/src/lib/kimi-runner.ts
@@ -246,23 +246,25 @@ export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent
       },
     };
 
-    // Lazy-import the ACP SDK so only the kimi (mkx) launcher pulls it in — the
-    // claude/codex launchers boot the shared bundle without it installed.
-    const { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } = await import('@agentclientprotocol/sdk');
-    const stream = ndJsonStream(
-      Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
-      Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
-    );
-    const conn = new ClientSideConnection(() => clientImpl, stream);
-
     let capturedSid = '';
-    const onAbort = () => {
-      if (capturedSid) void conn.cancel({ sessionId: capturedSid }).catch(() => {});
-      child.kill('SIGTERM');
-      setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, 3000).unref();
-    };
-
     try {
+      // Lazy-import the ACP SDK so only the kimi (mkx) launcher pulls it in — the
+      // claude/codex launchers boot the shared bundle without it installed. Kept
+      // inside the try so a missing SDK surfaces as a stream `error` (like the
+      // claude/codex runners), not an unhandled rejection.
+      const { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } = await import('@agentclientprotocol/sdk');
+      const stream = ndJsonStream(
+        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+      );
+      const conn = new ClientSideConnection(() => clientImpl, stream);
+
+      const onAbort = () => {
+        if (capturedSid) void conn.cancel({ sessionId: capturedSid }).catch(() => {});
+        child.kill('SIGTERM');
+        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, 3000).unref();
+      };
+
       await conn.initialize({
         protocolVersion: PROTOCOL_VERSION,
         clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },

--- a/server/src/lib/kimi-runner.ts
+++ b/server/src/lib/kimi-runner.ts
@@ -26,7 +26,6 @@ import { existsSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import { Readable, Writable } from 'node:stream';
 import path from 'node:path';
-import { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } from '@agentclientprotocol/sdk';
 import type { Client, ReadTextFileRequest, ReadTextFileResponse, RequestPermissionRequest, RequestPermissionResponse, SessionNotification, WriteTextFileRequest, ContentBlock, McpServerStdio } from '@agentclientprotocol/sdk';
 import { getActiveKimiProviderEnv } from './kimi-config.js';
 import { findKimiSessionDir } from './kimi-store.js';
@@ -247,6 +246,9 @@ export async function* runKimi(opts: KimiRunOptions): AsyncGenerator<RunnerEvent
       },
     };
 
+    // Lazy-import the ACP SDK so only the kimi (mkx) launcher pulls it in — the
+    // claude/codex launchers boot the shared bundle without it installed.
+    const { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } = await import('@agentclientprotocol/sdk');
     const stream = ndJsonStream(
       Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
       Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,

--- a/server/src/lib/macaron-mcp.ts
+++ b/server/src/lib/macaron-mcp.ts
@@ -7,7 +7,7 @@
 // We do NOT call any external "generator" model — the Claude in this session
 // writes the TSX directly using $macaron/ui, taught via the tool description below.
 
-import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import {
   handleRenderUI,
@@ -15,7 +15,16 @@ import {
   RENDER_UI_TOOL_DESCRIPTION,
 } from './macaron-render-tool.js';
 
-export const macaronMcpServer = createSdkMcpServer({
+// Built lazily via getMacaronMcpServer() so `@anthropic-ai/claude-agent-sdk` is
+// only imported when a Claude run actually starts. Keeping the createSdkMcpServer
+// call out of module top-level is what lets the codex (mcx) and kimi (mkx)
+// launchers boot the shared bundle without the Claude SDK installed.
+let cached: McpSdkServerConfigWithInstance | null = null;
+
+export async function getMacaronMcpServer(): Promise<McpSdkServerConfigWithInstance> {
+  if (cached) return cached;
+  const { createSdkMcpServer, tool } = await import('@anthropic-ai/claude-agent-sdk');
+  cached = createSdkMcpServer({
   name: 'macaron',
   version: '0.2.0',
   instructions: RENDER_UI_INSTRUCTIONS,
@@ -63,4 +72,6 @@ export const macaronMcpServer = createSdkMcpServer({
       { alwaysLoad: true },
     ),
   ],
-});
+  });
+  return cached;
+}

--- a/server/src/lib/schedule-store.ts
+++ b/server/src/lib/schedule-store.ts
@@ -47,6 +47,13 @@ export async function warmSchedulesCache(): Promise<void> {
   await readSchedules();
 }
 
+// Test-only: drop the in-memory cache so the next read reloads from disk. Lets a
+// test seed the JSON file directly (simulating a foreign/pre-split schedule) and
+// have the store pick it up.
+export function __resetCacheForTests(): void {
+  cache = null;
+}
+
 // Sync getter for the tick loop — cache is warmed at startup.
 export function listSchedules(): Schedule[] {
   return cache ?? [];

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -3,6 +3,7 @@
 // session — the same spawn "+ New Session" does, minus the client SSE reply.
 
 import { promises as fs } from 'node:fs';
+import { ENGINE } from '../config.js';
 import { runClaude } from './claude-runner.js';
 import { runCodex } from './codex-runner.js';
 import { runKimi } from './kimi-runner.js';
@@ -85,6 +86,11 @@ async function drain(schedule: Schedule, stream: AsyncGenerator<RunnerEvent>): P
 // Fire a schedule now. Shared by the tick and the run-now route. Never throws —
 // records lastStatus and advances nextRunAt via recordRun.
 export async function fireSchedule(schedule: Schedule, advance = true): Promise<FireResult> {
+  // A persisted foreign-engine schedule (created before the dependency split, or
+  // synced from another launcher) can't run here — its SDK isn't installed.
+  // Refuse without dispatching so we never import a missing runner. Don't advance
+  // nextRunAt: it isn't ours to schedule.
+  if (schedule.engine !== ENGINE) return { ok: false, sessionId: null, error: `schedule engine ${schedule.engine} not runnable on this ${ENGINE} launcher` };
   if (inFlight.has(schedule.id)) return { ok: false, sessionId: null, error: 'schedule already running' };
   inFlight.add(schedule.id);
   try {
@@ -142,6 +148,7 @@ function tick(): void {
   const now = Date.now();
   for (const s of listSchedules()) {
     if (s.status !== 'active' || s.nextRunAt === null || s.nextRunAt > now) continue;
+    if (s.engine !== ENGINE) continue; // foreign schedule — not runnable here (see fireSchedule)
     if (inFlight.has(s.id)) continue;
     void fireSchedule(s); // fire-and-forget; never blocks the tick
   }

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -144,7 +144,9 @@ export async function fireSchedule(schedule: Schedule, advance = true): Promise<
   }
 }
 
-function tick(): void {
+// Exported for tests: run one scan synchronously instead of waiting for the
+// interval. Firing itself is still fire-and-forget.
+export function tick(): void {
   const now = Date.now();
   for (const s of listSchedules()) {
     if (s.status !== 'active' || s.nextRunAt === null || s.nextRunAt > now) continue;

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -86,6 +86,18 @@ const CONFIG_PATH = path.join(HOME, '.claude', 'macaron-config.json');
 
 let cache: Settings | null = null;
 
+// Launch override: a pasted `mcc` env block (ANTHROPIC_BASE_URL) or `--model`
+// (ANTHROPIC_MODEL) at boot is a "run against these params now" intent that
+// forces System/pass-through, regardless of the persisted provider. Captured
+// once at warm so the effective route and the UI agree on ONE active id.
+// Cleared the moment the user picks a provider — that's an explicit choice to
+// use its isolated credentials/config instead of the launch env.
+let launchOverride = false;
+// Effective active provider id: launch override collapses to System.
+function effectiveActiveId(s: Settings): string {
+  return launchOverride ? SYSTEM_PROVIDER_ID : s.activeProviderId;
+}
+
 function seedMacaronProvider(): CustomProvider {
   return {
     id: randomUUID(),
@@ -209,6 +221,10 @@ export async function readSettings(): Promise<Settings> {
 
 export async function warmSettingsCache(): Promise<void> {
   await readSettings();
+  // Capture launch override once at boot: a pasted ANTHROPIC_BASE_URL or an
+  // ambient ANTHROPIC_MODEL (e.g. `mcc --model X`) forces System/pass-through
+  // until the user explicitly selects a provider.
+  launchOverride = Boolean(process.env.ANTHROPIC_BASE_URL || process.env.ANTHROPIC_MODEL);
   // Persist any migration/defaults on first boot so the file exists.
   await persist();
 }
@@ -218,7 +234,7 @@ export async function readPublicSettings(): Promise<PublicSettings> {
   const envBase = process.env.ANTHROPIC_BASE_URL || '';
   const usingRelay = Boolean(envBase);
   return {
-    activeProviderId: s.activeProviderId,
+    activeProviderId: effectiveActiveId(s),
     builtins: [
       {
         id: SYSTEM_PROVIDER_ID,
@@ -292,6 +308,9 @@ export async function setActiveProvider(id: string): Promise<boolean> {
   if (id !== SYSTEM_PROVIDER_ID && !s.customProviders.some((p) => p.id === id)) {
     return false;
   }
+  // An explicit selection retires the boot launch override: the user is
+  // choosing this provider's isolated credentials/config over the launch env.
+  launchOverride = false;
   s.activeProviderId = id;
   await persist();
   return true;
@@ -348,7 +367,7 @@ export function getActiveProviderRaw():
   | { id: string; name: string; endpoint: string; model: string; apiKey: string }
   | null {
   const s = cache ?? makeDefaults();
-  if (s.activeProviderId === SYSTEM_PROVIDER_ID) return null;
+  if (effectiveActiveId(s) === SYSTEM_PROVIDER_ID) return null;
   const p = s.customProviders.find((x) => x.id === s.activeProviderId);
   if (!p) return null;
   return { id: p.id, name: p.name, endpoint: p.endpoint, model: p.model, apiKey: p.apiKey };
@@ -383,11 +402,11 @@ export function getActiveProviderEnv(): {
   env: Record<string, string> | null;
 } {
   const s = cache ?? makeDefaults();
-  // Launch-time override: a pasted `ANTHROPIC_BASE_URL` (with `mcc` env block /
-  // `--model`) is an explicit "run against these params now" intent and must
-  // win over a stale persisted custom-provider selection. Fall through to the
-  // pass-through path so the SDK subprocess inherits the ambient env untouched.
-  if (s.activeProviderId === SYSTEM_PROVIDER_ID || process.env.ANTHROPIC_BASE_URL) {
+  // Boot launch override (ANTHROPIC_BASE_URL or `--model`) collapses to
+  // System/pass-through, matching the id readPublicSettings()/UI report — one
+  // contract for both routing and display. A later explicit selection clears
+  // it (see setActiveProvider). System also lands here.
+  if (effectiveActiveId(s) === SYSTEM_PROVIDER_ID) {
     // Pass-through: inherit process.env unchanged (ANTHROPIC_BASE_URL /
     // ANTHROPIC_AUTH_TOKEN the user exported in their shell). Honor an
     // ambient ANTHROPIC_MODEL too so `mcc --model X` (which sets it) picks

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -310,9 +310,19 @@ export async function setActiveProvider(id: string): Promise<boolean> {
   }
   // An explicit selection retires the boot launch override: the user is
   // choosing this provider's isolated credentials/config over the launch env.
-  launchOverride = false;
+  // Persist transactionally — a failed write must leave the cached provider
+  // AND launchOverride untouched so UI and routing stay in agreement.
+  const prevId = s.activeProviderId;
+  const prevOverride = launchOverride;
   s.activeProviderId = id;
-  await persist();
+  launchOverride = false;
+  try {
+    await persist();
+  } catch (e) {
+    s.activeProviderId = prevId;
+    launchOverride = prevOverride;
+    throw e;
+  }
   return true;
 }
 

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -384,7 +384,11 @@ export function getActiveProviderEnv(): {
 } {
   const s = cache ?? makeDefaults();
   if (s.activeProviderId === SYSTEM_PROVIDER_ID) {
-    return { model: undefined, env: null };
+    // Pass-through: inherit process.env unchanged (ANTHROPIC_BASE_URL /
+    // ANTHROPIC_AUTH_TOKEN the user exported in their shell). Honor an
+    // ambient ANTHROPIC_MODEL too so `mcc --model X` (which sets it) picks
+    // the launch model, matching `claude --model X`.
+    return { model: process.env.ANTHROPIC_MODEL || undefined, env: null };
   }
   const p = s.customProviders.find((x) => x.id === s.activeProviderId);
   if (!p) return { model: undefined, env: null };

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -383,7 +383,11 @@ export function getActiveProviderEnv(): {
   env: Record<string, string> | null;
 } {
   const s = cache ?? makeDefaults();
-  if (s.activeProviderId === SYSTEM_PROVIDER_ID) {
+  // Launch-time override: a pasted `ANTHROPIC_BASE_URL` (with `mcc` env block /
+  // `--model`) is an explicit "run against these params now" intent and must
+  // win over a stale persisted custom-provider selection. Fall through to the
+  // pass-through path so the SDK subprocess inherits the ambient env untouched.
+  if (s.activeProviderId === SYSTEM_PROVIDER_ID || process.env.ANTHROPIC_BASE_URL) {
     // Pass-through: inherit process.env unchanged (ANTHROPIC_BASE_URL /
     // ANTHROPIC_AUTH_TOKEN the user exported in their shell). Honor an
     // ambient ANTHROPIC_MODEL too so `mcc --model X` (which sets it) picks

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -372,15 +372,16 @@ export async function seedProviderFromEnv(): Promise<
   if (idx >= 0) s.customProviders[idx] = next;
   else s.customProviders.push(next);
   const activated = s.activeProviderId === SYSTEM_PROVIDER_ID;
-  if (activated) {
-    s.activeProviderId = id;
-    // Seeding from env IS an explicit env-driven provider choice, so it retires
-    // the boot launchOverride — otherwise effectiveActiveId() would shadow the
-    // freshly-seeded provider back to System and UI/routing would disagree with
-    // the "(activated)" log line. (The override still governs launches that
-    // seed nothing: `--model`-only, or a base URL with no token.)
-    launchOverride = false;
-  }
+  if (activated) s.activeProviderId = id;
+  // A successful complete seed retires the boot launchOverride unconditionally.
+  // The override exists to force System pass-through from ambient env when we
+  // seed NOTHING; once a complete endpoint+token has been resolved into a real
+  // provider row, effectiveActiveId() must stop shadowing to System. This holds
+  // for both branches: when we activated the seeded row (route it), AND when a
+  // manual provider was already active (main's "kept active choice" — route
+  // THAT provider, not ambient pass-through). Override still governs the
+  // seed-nothing launches: `--model`-only, or a base URL with no token.
+  launchOverride = false;
   await persist();
   return { seeded: true, providerId: id, activated };
 }

--- a/server/src/routes/schedules.ts
+++ b/server/src/routes/schedules.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { ScheduleInput, SessionKind } from '@macaron/shared';
+import { ENGINE } from '../config.js';
 import {
   readSchedules,
   getSchedule,
@@ -26,7 +27,10 @@ function normalizeInput(b: Body): ScheduleInput | null {
   const prompt = String(b.prompt || '').trim();
   const cwd = String(b.cwd || '').trim();
   const pattern = String(b.pattern || '').trim();
-  const engine: SessionKind = b.engine === 'codex' || b.engine === 'kimi' ? b.engine : 'claude';
+  // This launcher can only run its own engine's sessions — the other engines'
+  // SDKs aren't installed, so a foreign schedule would fail at fire time.
+  // Default to (and only accept) the boot engine.
+  const engine: SessionKind = ENGINE;
   if (!name || !prompt || !cwd || !pattern) return null;
   return { name, prompt, cwd, pattern, engine, oneShot: Boolean(b.oneShot) };
 }
@@ -70,7 +74,10 @@ export async function registerScheduleRoutes(app: FastifyInstance): Promise<void
       patch.pattern = b.pattern.trim();
       if (!patch.pattern) return reply.status(400).send({ error: 'pattern required' });
     }
-    if (b.engine === 'claude' || b.engine === 'codex' || b.engine === 'kimi') patch.engine = b.engine;
+    // Engine is fixed to this launcher's boot engine; a foreign engine can't be
+    // set (its SDK isn't installed). Accept an explicit same-engine value, reject
+    // any other.
+    if (b.engine !== undefined && b.engine !== ENGINE) return reply.status(400).send({ error: `engine must be ${ENGINE}` });
     if (typeof b.oneShot === 'boolean') patch.oneShot = b.oneShot;
     try {
       if (patch.cwd !== undefined) await assertRunnableCwd(patch.cwd);
@@ -105,6 +112,7 @@ export async function registerScheduleRoutes(app: FastifyInstance): Promise<void
   app.post<{ Params: IdParams }>('/api/schedules/:id/run-now', async ({ params }, reply) => {
     const s = getSchedule(params.id);
     if (!s) return reply.status(404).send({ error: 'schedule not found' });
+    if (s.engine !== ENGINE) return reply.status(400).send({ error: `schedule engine ${s.engine} not runnable on this ${ENGINE} launcher` });
     const result = await fireSchedule(s, false);
     if (!result.ok) return reply.status(result.error === 'schedule already running' ? 409 : 500).send({ error: result.error || 'schedule run failed' });
     return { ok: true, sessionId: result.sessionId };

--- a/server/src/routes/schedules.ts
+++ b/server/src/routes/schedules.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { ScheduleInput, SessionKind } from '@macaron/shared';
+import type { ScheduleInput } from '@macaron/shared';
 import { ENGINE } from '../config.js';
 import {
   readSchedules,
@@ -22,17 +22,21 @@ async function assertRunnableCwd(cwd: string): Promise<void> {
   if (!st?.isDirectory()) throw new Error('cwd must be an existing directory');
 }
 
-function normalizeInput(b: Body): ScheduleInput | null {
+// Result of validating a create body: the normalized input, or a 400 reason.
+// `engine` is fixed to ENGINE — an omitted engine defaults to it, an explicit
+// foreign engine is rejected (its SDK isn't installed here, so it could never
+// run; silently coercing it would let a client request one engine and have its
+// prompt fire under another).
+type NormalizeResult = { input: ScheduleInput } | { error: string };
+
+function normalizeInput(b: Body): NormalizeResult {
   const name = String(b.name || '').trim();
   const prompt = String(b.prompt || '').trim();
   const cwd = String(b.cwd || '').trim();
   const pattern = String(b.pattern || '').trim();
-  // This launcher can only run its own engine's sessions — the other engines'
-  // SDKs aren't installed, so a foreign schedule would fail at fire time.
-  // Default to (and only accept) the boot engine.
-  const engine: SessionKind = ENGINE;
-  if (!name || !prompt || !cwd || !pattern) return null;
-  return { name, prompt, cwd, pattern, engine, oneShot: Boolean(b.oneShot) };
+  if (!name || !prompt || !cwd || !pattern) return { error: 'name, prompt, cwd and pattern are required' };
+  if (b.engine !== undefined && b.engine !== ENGINE) return { error: `engine must be ${ENGINE}` };
+  return { input: { name, prompt, cwd, pattern, engine: ENGINE, oneShot: Boolean(b.oneShot) } };
 }
 
 export async function registerScheduleRoutes(app: FastifyInstance): Promise<void> {
@@ -45,11 +49,11 @@ export async function registerScheduleRoutes(app: FastifyInstance): Promise<void
   });
 
   app.post<{ Body: Body }>('/api/schedules', async (req, reply) => {
-    const input = normalizeInput(req.body || {});
-    if (!input) return reply.status(400).send({ error: 'name, prompt, cwd and pattern are required' });
+    const norm = normalizeInput(req.body || {});
+    if ('error' in norm) return reply.status(400).send({ error: norm.error });
     try {
-      await assertRunnableCwd(input.cwd);
-      return await createSchedule(input);
+      await assertRunnableCwd(norm.input.cwd);
+      return await createSchedule(norm.input);
     } catch (e) {
       return reply.status(400).send({ error: (e as Error).message });
     }

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -59,6 +59,12 @@ before(() => {
     const r = spawnSync(cmd, args, { cwd, stdio: 'inherit' });
     assert.equal(r.status, 0, `${cmd} ${args.join(' ')} failed in ${cwd}`);
   };
+  // @macaron/shared must be built first — both the server bundle and the web
+  // build resolve it from its dist (a clean CI checkout has none). Mirrors the
+  // order the root `prepack` runs in.
+  if (!existsSync(path.join(repoRoot, 'shared', 'dist', 'index.js'))) {
+    run('pnpm', ['--filter', '@macaron/shared', 'build'], repoRoot);
+  }
   if (!existsSync(path.join(repoRoot, 'server', 'dist', 'index.js'))) {
     run('bun', ['build', 'src/index.ts', '--target=node', '--format=esm', '--outfile=dist/index.js', '--packages=external'], path.join(repoRoot, 'server'));
   }

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -16,7 +16,7 @@ import assert from 'node:assert/strict';
 // while the foreign groups 404, and (4) a real first turn POSTed through its own
 // runner drives its lazy-imported SDK — mcc streams meta/delta/done off a local
 // Anthropic stub, mcx/mkx reach their own SDK and surface the deterministic
-// downstream failure of a `/bin/false` engine binary — with NO ERR_MODULE_NOT_FOUND
+// downstream failure of a stub engine binary that exits non-zero — with NO ERR_MODULE_NOT_FOUND
 // anywhere in the stream. That last case is the point: routes 200/404 never touch
 // the runner imports, so only a posted turn proves the own SDK actually loads.
 // No synthetic import probes — the tarball IS the artifact.
@@ -31,7 +31,7 @@ const ACP = '@agentclientprotocol/sdk';
 // (200) and a foreign route (404) to prove route gating, plus how to POST a real
 // first turn through its own runner: the endpoint to hit and the SSE event that
 // proves the own SDK's lazy import resolved (`done` off the Anthropic stub for
-// claude; the runner-level `error` a `/bin/false` engine binary yields for the
+// claude; the runner-level `error` a non-zero-exit stub engine binary yields for the
 // spawn-based codex/kimi — either way the runner ran, so the import loaded).
 const LAUNCHERS = {
   claude: { dir: '.', bin: 'mcc', engineEnv: undefined as string | undefined, own: CLAUDE, foreign: [CODEX, ACP], ownRoute: '/api/workspaces', foreignRoute: '/api/codex/sessions', turnRoute: '/api/workspaces/probe/sessions', expect: 'done' as 'done' | 'error' },
@@ -229,7 +229,7 @@ async function postTurn(port: number, route: string, cwd: string): Promise<strin
 // True when a first-turn SSE stream proves the runner's own lazy SDK import
 // resolved: no module-resolution error, plus the engine-specific success signal
 // (claude streams the stub delta+done; codex/kimi reach their runner and report
-// the deterministic `/bin/false` downstream failure). The negative control below
+// the deterministic stub-binary downstream failure). The negative control below
 // removes the own SDK and asserts this flips to false — the module error appears.
 const MODULE_ERR = /ERR_MODULE_NOT_FOUND|Cannot find package|Cannot find module/;
 function firstTurnProvesOwnSdk(turn: string, expect: 'done' | 'error'): boolean {
@@ -255,10 +255,16 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
 
     // (2)-(3) Boots through the installed bin; own route answers, foreign 404s.
     // For claude, route the SDK at a local Anthropic stub so its first turn
-    // completes deterministically offline; codex/kimi spawn a `/bin/false`
-    // engine binary so their first turn reaches the own SDK then fails downstream.
+    // completes deterministically offline; codex/kimi spawn a stub engine binary
+    // that exits non-zero so their first turn reaches the own SDK then fails downstream.
     const stub = engine === 'claude' ? await startAnthropicStub() : null;
-    const falseBin = spawnSync('sh', ['-c', 'command -v false'], { encoding: 'utf8' }).stdout.trim() || '/bin/false';
+    // A real on-disk executable that exits non-zero — NOT the `false` builtin
+    // (`command -v false` prints just "false" on CI, which detectKimiBinary's
+    // existsSync() rejects, so the runner reports "CLI not found" before ever
+    // reaching its SDK import and the whole probe is void). Writing our own
+    // guarantees detection passes, the SDK loads, then the spawn fails downstream.
+    const falseBin = path.join(dest, 'engine-false');
+    writeFileSync(falseBin, '#!/bin/sh\nexit 1\n', { mode: 0o755 });
     const extraEnv: Record<string, string> =
       engine === 'claude' ? { ANTHROPIC_BASE_URL: stub!.url, ANTHROPIC_AUTH_TOKEN: 'stub', ANTHROPIC_API_KEY: 'stub' } :
       // Force the SDK transport (not the default app-server bridge) so the POST

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, writeFileSync, cpSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, writeFileSync, cpSync, rmSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import http from 'node:http';
 import net from 'node:net';
@@ -84,15 +84,22 @@ before(() => {
 function pack(dir: string, dest: string): string {
   const launcher = path.join(repoRoot, dir);
   const stage = mkdtempSync(path.join(os.tmpdir(), 'macaron-stage-'));
-  cpSync(path.join(launcher, 'package.json'), path.join(stage, 'package.json'));
-  for (const rel of ['bin', 'README.md']) cpSync(path.join(launcher, rel), path.join(stage, rel), { recursive: true });
-  cpSync(path.join(repoRoot, 'server', 'dist', 'index.js'), path.join(stage, 'server', 'dist', 'index.js'));
-  cpSync(path.join(repoRoot, 'web', 'dist'), path.join(stage, 'web', 'dist'), { recursive: true });
-  const r = spawnSync('npm', ['pack', '--ignore-scripts', '--pack-destination', dest], { cwd: stage, encoding: 'utf8' });
-  assert.equal(r.status, 0, `npm pack failed for ${dir}:\n${r.stderr}`);
-  const tgz = readdirSync(dest).find((f) => f.endsWith('.tgz'));
-  assert.ok(tgz, `no tarball produced for ${dir}`);
-  return path.join(dest, tgz);
+  try {
+    cpSync(path.join(launcher, 'package.json'), path.join(stage, 'package.json'));
+    for (const rel of ['bin', 'README.md']) cpSync(path.join(launcher, rel), path.join(stage, rel), { recursive: true });
+    cpSync(path.join(repoRoot, 'server', 'dist', 'index.js'), path.join(stage, 'server', 'dist', 'index.js'));
+    cpSync(path.join(repoRoot, 'web', 'dist'), path.join(stage, 'web', 'dist'), { recursive: true });
+    const r = spawnSync('npm', ['pack', '--ignore-scripts', '--pack-destination', dest], { cwd: stage, encoding: 'utf8' });
+    assert.equal(r.status, 0, `npm pack failed for ${dir}:\n${r.stderr}`);
+    const tgz = readdirSync(dest).find((f) => f.endsWith('.tgz'));
+    assert.ok(tgz, `no tarball produced for ${dir}`);
+    return path.join(dest, tgz);
+  } finally {
+    // The stage dir is scratch — the tarball already lives in `dest`. Remove it
+    // on every path (success, pack failure, or a thrown assertion) so repeated
+    // runs never leak macaron-stage-* under the tmpdir.
+    rmSync(stage, { recursive: true, force: true });
+  }
 }
 
 // Install `tarball` as the sole dependency of a fresh consumer project, so its
@@ -330,3 +337,22 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
     }
   });
 }
+
+// Proves pack() leaks no per-run stage dir — on the success path AND when it
+// throws mid-stage. Counts macaron-stage-* under tmpdir before/after each case;
+// the delta must be zero either way, so the `finally` rmSync is load-bearing.
+test('pack() removes its macaron-stage-* dir on both success and failure', { timeout: 60_000, skip: SKIP && 'npm/package cache unavailable' }, () => {
+  const stageDirs = () => readdirSync(os.tmpdir()).filter((f) => f.startsWith('macaron-stage-'));
+  const dest = mkdtempSync(path.join(os.tmpdir(), 'macaron-pack-cleanup-'));
+  try {
+    const before = stageDirs().length;
+    pack('mcx', dest); // success path
+    assert.equal(stageDirs().length, before, 'a successful pack() must leave no stage dir behind');
+    // Failure path: a non-existent launcher dir makes the first cpSync throw
+    // after mkdtemp, exercising the `finally` cleanup on the error path.
+    assert.throws(() => pack('does-not-exist', dest));
+    assert.equal(stageDirs().length, before, 'a failed pack() must still remove its stage dir');
+  } finally {
+    rmSync(dest, { recursive: true, force: true });
+  }
+});

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,0 +1,98 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const pathToFileURLString = (p: string) => pathToFileURL(p).href;
+
+// Proves the per-engine dependency split: each launcher boots the shared
+// `server/dist/index.js` while the OTHER engines' SDKs are absent. We can't
+// uninstall packages from a shared node_modules mid-suite, so we simulate a
+// fresh, engine-scoped install with a loader `resolve` hook that makes the
+// forbidden SDK specifiers throw ERR_MODULE_NOT_FOUND — exactly what a tarball
+// that never declared them would do. A boot that still reaches "listening"
+// proves those SDKs are never touched on that engine's boot path.
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const bundle = path.join(repoRoot, 'server', 'dist', 'index.js');
+
+const CLAUDE = '@anthropic-ai/claude-agent-sdk';
+const CODEX = '@openai/codex-sdk';
+const ACP = '@agentclientprotocol/sdk';
+
+// Boots the bundle with `blocked` SDKs made unresolvable and `MACARON_ENGINE`
+// set, then resolves once the server logs it is listening (success) or the
+// child exits early (failure — e.g. a boot-path import of a blocked SDK).
+function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise<{ ok: boolean; output: string }> {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-iso-'));
+  // The blocking `resolve` hook must run on the loader thread, registered via
+  // module.register — an `--import`ed module's exported `resolve` is NOT picked
+  // up as a hook (it just runs for side effects). So we register a hooks module
+  // from a tiny bootstrap that `--import` loads before the bundle.
+  const hooks = path.join(dir, 'block-hooks.mjs');
+  writeFileSync(hooks, `
+    const blocked = new Set(${JSON.stringify(blocked)});
+    export async function resolve(specifier, context, next) {
+      if (blocked.has(specifier)) {
+        const err = new Error(\`Cannot find package '\${specifier}' (blocked for test)\`);
+        err.code = 'ERR_MODULE_NOT_FOUND';
+        throw err;
+      }
+      return next(specifier, context);
+    }
+  `);
+  const bootstrap = path.join(dir, 'register.mjs');
+  writeFileSync(bootstrap, `
+    import { register } from 'node:module';
+    import { pathToFileURL } from 'node:url';
+    register(${JSON.stringify(pathToFileURLString(hooks))}, pathToFileURL('./'));
+  `);
+
+  const env = { ...process.env };
+  delete env.MACARON_ENGINE;
+  if (engine) env.MACARON_ENGINE = engine;
+  // A random high port and a throwaway HOME keep parallel boots off each other
+  // and off the real ~/.claude config.
+  env.MACARON_PORT = String(20000 + Math.floor(Math.random() * 20000));
+  env.HOME = dir;
+
+  const child = spawn(process.execPath, ['--import', bootstrap, bundle], { cwd: repoRoot, env });
+
+  return new Promise((resolve) => {
+    let output = '';
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      resolve({ ok, output });
+    };
+    const onData = (b: Buffer) => {
+      output += b.toString('utf8');
+      if (output.includes('macaron server listening')) done(true);
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('exit', () => done(false)); // exited before "listening" → boot failed
+    const timer = setTimeout(() => done(false), 15000);
+  });
+}
+
+test('mcc (claude) boots without the codex or ACP SDKs installed', async () => {
+  const { ok, output } = await bootWithBlocked(undefined, [CODEX, ACP]);
+  assert.ok(ok, `claude boot did not reach listening:\n${output}`);
+});
+
+test('mcx (codex) boots without the claude or ACP SDKs installed', async () => {
+  const { ok, output } = await bootWithBlocked('codex', [CLAUDE, ACP]);
+  assert.ok(ok, `codex boot did not reach listening:\n${output}`);
+});
+
+test('mkx (kimi) boots without the claude or codex SDKs installed', async () => {
+  const { ok, output } = await bootWithBlocked('kimi', [CLAUDE, CODEX]);
+  assert.ok(ok, `kimi boot did not reach listening:\n${output}`);
+});

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { test, before } from 'node:test';
@@ -11,8 +12,13 @@ import assert from 'node:assert/strict';
 // under node_modules/.bin exactly as `npx mcx@…` gets it), boot through that
 // installed bin, and assert (1) only its own engine SDK landed in node_modules,
 // (2) the server reaches "listening", (3) its own engine route group answers
-// while the foreign groups 404, and (4) a first turn through its own runner path
-// resolves its own SDK. No synthetic import probes — the tarball IS the artifact.
+// while the foreign groups 404, and (4) a real first turn POSTed through its own
+// runner drives its lazy-imported SDK — mcc streams meta/delta/done off a local
+// Anthropic stub, mcx/mkx reach their own SDK and surface the deterministic
+// downstream failure of a `/bin/false` engine binary — with NO ERR_MODULE_NOT_FOUND
+// anywhere in the stream. That last case is the point: routes 200/404 never touch
+// the runner imports, so only a posted turn proves the own SDK actually loads.
+// No synthetic import probes — the tarball IS the artifact.
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 
@@ -21,19 +27,28 @@ const CODEX = '@openai/codex-sdk';
 const ACP = '@agentclientprotocol/sdk';
 
 // engine → launcher dir, bin name, own SDK, foreign SDKs, an own-engine route
-// (200) and a foreign route (404) to prove route gating from the installed bin.
+// (200) and a foreign route (404) to prove route gating, plus how to POST a real
+// first turn through its own runner: the endpoint to hit and the SSE event that
+// proves the own SDK's lazy import resolved (`done` off the Anthropic stub for
+// claude; the runner-level `error` a `/bin/false` engine binary yields for the
+// spawn-based codex/kimi — either way the runner ran, so the import loaded).
 const LAUNCHERS = {
-  claude: { dir: '.', bin: 'mcc', engineEnv: undefined as string | undefined, own: CLAUDE, foreign: [CODEX, ACP], ownRoute: '/api/workspaces', foreignRoute: '/api/codex/sessions' },
-  codex: { dir: 'mcx', bin: 'mcx', engineEnv: 'codex', own: CODEX, foreign: [CLAUDE, ACP], ownRoute: '/api/codex/config', foreignRoute: '/api/workspaces' },
-  kimi: { dir: 'mkx', bin: 'mkx', engineEnv: 'kimi', own: ACP, foreign: [CLAUDE, CODEX], ownRoute: '/api/kimi/threads', foreignRoute: '/api/workspaces' },
+  claude: { dir: '.', bin: 'mcc', engineEnv: undefined as string | undefined, own: CLAUDE, foreign: [CODEX, ACP], ownRoute: '/api/workspaces', foreignRoute: '/api/codex/sessions', turnRoute: '/api/workspaces/probe/sessions', expect: 'done' as 'done' | 'error' },
+  codex: { dir: 'mcx', bin: 'mcx', engineEnv: 'codex', own: CODEX, foreign: [CLAUDE, ACP], ownRoute: '/api/codex/config', foreignRoute: '/api/workspaces', turnRoute: '/api/codex/threads', expect: 'error' as 'done' | 'error' },
+  kimi: { dir: 'mkx', bin: 'mkx', engineEnv: 'kimi', own: ACP, foreign: [CLAUDE, CODEX], ownRoute: '/api/kimi/threads', foreignRoute: '/api/workspaces', turnRoute: '/api/kimi/threads', expect: 'error' as 'done' | 'error' },
 } as const;
 
 // These tests pack + install real tarballs, so they need `npm` and a populated
-// package cache. Skip deterministically (never fail) when the toolchain isn't
-// there — e.g. a fully offline sandbox with a cold cache — so the clean-checkout
-// suite stays green. MACARON_SKIP_PACK_TESTS=1 forces the skip.
+// package cache. Locally we skip deterministically (never fail) when the
+// toolchain isn't there — e.g. a fully offline sandbox with a cold cache — so
+// the clean-checkout suite stays green; MACARON_SKIP_PACK_TESTS=1 forces it.
+// Under CI the coverage is MANDATORY: the skip env is ignored and a missing
+// toolchain is a hard failure, so a green pipeline can never hide absent pack
+// coverage (the whole point of this suite).
+const CI = !!process.env.CI;
 const npmOk = spawnSync('npm', ['--version'], { encoding: 'utf8' }).status === 0;
-const SKIP = process.env.MACARON_SKIP_PACK_TESTS === '1' || !npmOk;
+if (CI) assert.ok(npmOk, 'CI requires npm for mandatory pack coverage, but `npm --version` failed');
+const SKIP = !CI && (process.env.MACARON_SKIP_PACK_TESTS === '1' || !npmOk);
 
 // Build the shared bundles ONCE, then stage them into mcx/mkx (their prepack
 // does the same) so all three tarballs are self-contained. Done in `before` so a
@@ -79,9 +94,9 @@ function install(tarball: string): string {
 
 // Boot the installed bin and resolve once it logs "listening" (with its chosen
 // port) or exits early. Returns { ok, port, output, kill }.
-function boot(consumer: string, bin: string, engineEnv: string | undefined): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
+function boot(consumer: string, bin: string, engineEnv: string | undefined, extraEnv: Record<string, string> = {}): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
   const port = 20000 + Math.floor(Math.random() * 20000);
-  const env = { ...process.env };
+  const env = { ...process.env, ...extraEnv };
   delete env.MACARON_ENGINE;
   if (engineEnv) env.MACARON_ENGINE = engineEnv;
   env.MACARON_PORT = String(port);
@@ -105,6 +120,79 @@ async function httpStatus(port: number, route: string): Promise<number> {
   return res ? res.status : 0;
 }
 
+// A deterministic local Anthropic endpoint. The claude-agent-sdk's spawned CLI
+// probes /v1/models etc. at startup (any 2xx satisfies them) then streams
+// POST /v1/messages; we answer with a minimal valid message-stream SSE carrying
+// STUB_TEXT so mcc's first turn resolves to a real delta+done without a network.
+const STUB_TEXT = 'macaron-isolation-ok';
+function startAnthropicStub(): Promise<{ url: string; close: () => void }> {
+  const sse = (obj: unknown) => `event: ${(obj as { type: string }).type}\ndata: ${JSON.stringify(obj)}\n\n`;
+  const messageObj = () => ({ id: 'msg_stub', type: 'message', role: 'assistant', model: 'stub', content: [{ type: 'text', text: STUB_TEXT }], stop_reason: 'end_turn', stop_sequence: null, usage: { input_tokens: 1, output_tokens: 1 } });
+  const server = http.createServer((req, res) => {
+    if (req.method === 'POST' && /\/messages$/.test((req.url || '').split('?')[0])) {
+      let raw = '';
+      req.on('data', (c) => { raw += c; });
+      req.on('end', () => {
+        let streaming = true;
+        try { streaming = !!JSON.parse(raw || '{}').stream; } catch { /* default to streaming */ }
+        if (!streaming) {
+          // Non-streaming path: a single JSON message object.
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(messageObj()));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+        res.write(sse({ type: 'message_start', message: { ...messageObj(), content: [], stop_reason: null } }));
+        res.write(sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }));
+        res.write(sse({ type: 'ping' }));
+        res.write(sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: STUB_TEXT } }));
+        res.write(sse({ type: 'content_block_stop', index: 0 }));
+        res.write(sse({ type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 1 } }));
+        res.write(sse({ type: 'message_stop' }));
+        res.end();
+      });
+      return;
+    }
+    // Every startup probe just needs any 2xx.
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const p = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({ url: `http://127.0.0.1:${p}`, close: () => server.close() });
+    });
+  });
+}
+
+// POST a real first turn and drain the SSE reply until `done` (or timeout),
+// returning the raw stream text. This is the ONLY probe that drives a runner's
+// lazy SDK import — routes 200/404 never reach it.
+async function postTurn(port: number, route: string, cwd: string): Promise<string> {
+  const res = await fetch(`http://127.0.0.1:${port}${route}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: 'hi', cwd }),
+  }).catch(() => null);
+  if (!res?.body) return '';
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let out = '';
+  const deadline = new Promise<void>((r) => setTimeout(r, 30_000));
+  const read = (async () => {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out += dec.decode(value, { stream: true });
+      if (out.includes('"type":"done"') || out.includes('[DONE]')) break;
+    }
+  })();
+  await Promise.race([read, deadline]);
+  try { await reader.cancel(); } catch { /* already closed */ }
+  return out;
+}
+
 // True if `node_modules/<pkg>` exists in the consumer install.
 function installed(consumer: string, pkg: string): boolean {
   return existsSync(path.join(consumer, 'node_modules', ...pkg.split('/')));
@@ -121,15 +209,40 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
     for (const f of l.foreign) assert.ok(!installed(consumer, f), `${l.bin} must NOT install foreign SDK ${f}`);
 
     // (2)-(3) Boots through the installed bin; own route answers, foreign 404s.
-    const b = await boot(consumer, l.bin, l.engineEnv);
+    // For claude, route the SDK at a local Anthropic stub so its first turn
+    // completes deterministically offline; codex/kimi spawn a `/bin/false`
+    // engine binary so their first turn reaches the own SDK then fails downstream.
+    const stub = engine === 'claude' ? await startAnthropicStub() : null;
+    const falseBin = spawnSync('sh', ['-c', 'command -v false'], { encoding: 'utf8' }).stdout.trim() || '/bin/false';
+    const extraEnv: Record<string, string> =
+      engine === 'claude' ? { ANTHROPIC_BASE_URL: stub!.url, ANTHROPIC_AUTH_TOKEN: 'stub', ANTHROPIC_API_KEY: 'stub' } :
+      engine === 'codex' ? { MACARON_CODEX_PATH: falseBin } :
+      { MACARON_KIMI_PATH: falseBin };
+    const b = await boot(consumer, l.bin, l.engineEnv, extraEnv);
     try {
       assert.ok(b.ok, `${l.bin} did not reach listening:\n${b.output}`);
       const eng = await fetch(`http://127.0.0.1:${b.port}/api/engine`).then((r) => r.json()).catch(() => null);
       assert.equal(eng?.engine, engine, `/api/engine should report ${engine}`);
       assert.equal(await httpStatus(b.port, l.ownRoute), 200, `${l.bin} own route ${l.ownRoute} should answer 200`);
       assert.equal(await httpStatus(b.port, l.foreignRoute), 404, `${l.bin} foreign route ${l.foreignRoute} should be absent (404)`);
+
+      // (4) POST a real first turn: this is what actually drives the runner's
+      // lazy `import('<own-sdk>')`. A missing/broken own SDK would surface as
+      // ERR_MODULE_NOT_FOUND in the stream instead of the engine's own output.
+      const turn = await postTurn(b.port, l.turnRoute, consumer);
+      assert.doesNotMatch(turn, /ERR_MODULE_NOT_FOUND|Cannot find package|Cannot find module/, `${l.bin} first turn must not fail to import its own SDK:\n${turn}`);
+      if (l.expect === 'done') {
+        assert.match(turn, /"type":"delta"/, `${l.bin} first turn should stream a delta from the Anthropic stub:\n${turn}`);
+        assert.match(turn, new RegExp(STUB_TEXT), `${l.bin} first turn should carry the stub text:\n${turn}`);
+        assert.match(turn, /"type":"done"/, `${l.bin} first turn should reach done:\n${turn}`);
+      } else {
+        // The own SDK loaded and spawned `/bin/false`, whose non-zero exit the
+        // runner surfaces as an error/done — proving the runner path ran.
+        assert.match(turn, /"type":"error"|"type":"done"/, `${l.bin} first turn should reach its runner and report the downstream failure:\n${turn}`);
+      }
     } finally {
       b.kill();
+      stub?.close();
       await fs.rm(dest, { recursive: true, force: true }).catch(() => {});
       await fs.rm(consumer, { recursive: true, force: true }).catch(() => {});
     }

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,161 +1,137 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 
-const pathToFileURLString = (p: string) => pathToFileURL(p).href;
-
-// Proves the per-engine dependency split: each launcher boots the shared
-// `server/dist/index.js` while the OTHER engines' SDKs are absent, and only
-// reaches for its own SDK lazily on first use. The pnpm workspace hoists every
-// SDK into a shared node_modules, so we can't uninstall packages mid-suite —
-// instead a loader `resolve` hook makes the forbidden SDK specifiers throw
-// ERR_MODULE_NOT_FOUND, exactly what a tarball that never declared them would do.
+// Proves the per-engine dependency split for REAL published tarballs: pack each
+// launcher, install it into a throwaway consumer project (so its bin is linked
+// under node_modules/.bin exactly as `npx mcx@…` gets it), boot through that
+// installed bin, and assert (1) only its own engine SDK landed in node_modules,
+// (2) the server reaches "listening", (3) its own engine route group answers
+// while the foreign groups 404, and (4) a first turn through its own runner path
+// resolves its own SDK. No synthetic import probes — the tarball IS the artifact.
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
-const bundle = path.join(repoRoot, 'server', 'dist', 'index.js');
 
 const CLAUDE = '@anthropic-ai/claude-agent-sdk';
 const CODEX = '@openai/codex-sdk';
 const ACP = '@agentclientprotocol/sdk';
 
-// engine → { own SDK it loads lazily, foreign SDKs its tarball must NOT ship }.
-// mkx (kimi) drives the Kimi CLI over ACP; mcc (claude) and mcx (codex) load
-// their named SDKs.
-const ENGINES = {
-  claude: { launcher: '.', own: CLAUDE, foreign: [CODEX, ACP] },
-  codex: { launcher: 'mcx', own: CODEX, foreign: [CLAUDE, ACP] },
-  kimi: { launcher: 'mkx', own: ACP, foreign: [CLAUDE, CODEX] },
+// engine → launcher dir, bin name, own SDK, foreign SDKs, an own-engine route
+// (200) and a foreign route (404) to prove route gating from the installed bin.
+const LAUNCHERS = {
+  claude: { dir: '.', bin: 'mcc', engineEnv: undefined as string | undefined, own: CLAUDE, foreign: [CODEX, ACP], ownRoute: '/api/workspaces', foreignRoute: '/api/codex/sessions' },
+  codex: { dir: 'mcx', bin: 'mcx', engineEnv: 'codex', own: CODEX, foreign: [CLAUDE, ACP], ownRoute: '/api/codex/config', foreignRoute: '/api/workspaces' },
+  kimi: { dir: 'mkx', bin: 'mkx', engineEnv: 'kimi', own: ACP, foreign: [CLAUDE, CODEX], ownRoute: '/api/kimi/threads', foreignRoute: '/api/workspaces' },
 } as const;
 
-// A clean checkout has no committed server/dist (it's .gitignore'd), so build it
-// once before the boot tests — the whole point is proving the SHIPPED bundle is
-// engine-clean, and every launcher ships this same file.
-before(() => {
-  if (existsSync(bundle)) return;
-  const r = spawnSync('bun', ['build', 'src/index.ts', '--target=node', '--format=esm', '--outfile=dist/index.js', '--packages=external'], {
-    cwd: path.join(repoRoot, 'server'),
-    stdio: 'inherit',
-  });
-  assert.equal(r.status, 0, 'failed to bundle server/dist/index.js for the isolation tests');
-});
+// These tests pack + install real tarballs, so they need `npm` and a populated
+// package cache. Skip deterministically (never fail) when the toolchain isn't
+// there — e.g. a fully offline sandbox with a cold cache — so the clean-checkout
+// suite stays green. MACARON_SKIP_PACK_TESTS=1 forces the skip.
+const npmOk = spawnSync('npm', ['--version'], { encoding: 'utf8' }).status === 0;
+const SKIP = process.env.MACARON_SKIP_PACK_TESTS === '1' || !npmOk;
 
-// Writes the loader bootstrap that makes `blocked` specifiers unresolvable. The
-// blocking `resolve` hook must run on the loader thread via module.register — an
-// `--import`ed module's exported `resolve` is NOT picked up as a hook (it just
-// runs for side effects) — so we register a hooks module from a tiny bootstrap.
-function writeBlockBootstrap(dir: string, blocked: string[]): string {
-  const hooks = path.join(dir, 'block-hooks.mjs');
-  writeFileSync(hooks, `
-    const blocked = new Set(${JSON.stringify(blocked)});
-    export async function resolve(specifier, context, next) {
-      if (blocked.has(specifier)) {
-        const err = new Error(\`Cannot find package '\${specifier}' (blocked for test)\`);
-        err.code = 'ERR_MODULE_NOT_FOUND';
-        throw err;
-      }
-      return next(specifier, context);
-    }
-  `);
-  const bootstrap = path.join(dir, 'register.mjs');
-  writeFileSync(bootstrap, `
-    import { register } from 'node:module';
-    import { pathToFileURL } from 'node:url';
-    register(${JSON.stringify(pathToFileURLString(hooks))}, pathToFileURL('./'));
-  `);
-  return bootstrap;
+// Build the shared bundles ONCE, then stage them into mcx/mkx (their prepack
+// does the same) so all three tarballs are self-contained. Done in `before` so a
+// clean checkout with no dist/ still produces faithful tarballs.
+before(() => {
+  if (SKIP) return;
+  const run = (cmd: string, args: string[], cwd: string) => {
+    const r = spawnSync(cmd, args, { cwd, stdio: 'inherit' });
+    assert.equal(r.status, 0, `${cmd} ${args.join(' ')} failed in ${cwd}`);
+  };
+  if (!existsSync(path.join(repoRoot, 'server', 'dist', 'index.js'))) {
+    run('bun', ['build', 'src/index.ts', '--target=node', '--format=esm', '--outfile=dist/index.js', '--packages=external'], path.join(repoRoot, 'server'));
+  }
+  if (!existsSync(path.join(repoRoot, 'web', 'dist', 'index.html'))) {
+    run('pnpm', ['--filter', '@macaron/web', 'build'], repoRoot);
+  }
+  // Stage the shared outputs into mcx/mkx (mirrors their scripts/stage.mjs).
+  for (const dir of ['mcx', 'mkx']) {
+    run('node', ['scripts/stage.mjs'], path.join(repoRoot, dir));
+  }
+}, { timeout: 180_000 });
+
+// pack the launcher (scripts skipped — bundles are already staged) into `dest`,
+// returning the tarball path.
+function pack(dir: string, dest: string): string {
+  const r = spawnSync('npm', ['pack', '--ignore-scripts', '--pack-destination', dest], { cwd: path.join(repoRoot, dir), encoding: 'utf8' });
+  assert.equal(r.status, 0, `npm pack failed for ${dir}:\n${r.stderr}`);
+  const tgz = readdirSync(dest).find((f) => f.endsWith('.tgz'));
+  assert.ok(tgz, `no tarball produced for ${dir}`);
+  return path.join(dest, tgz);
 }
 
-// Boots the bundle with `blocked` SDKs made unresolvable and `MACARON_ENGINE`
-// set, then resolves once the server logs it is listening (success) or the
-// child exits early (failure — e.g. a boot-path import of a blocked SDK).
-function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise<{ ok: boolean; output: string }> {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-iso-'));
-  const bootstrap = writeBlockBootstrap(dir, blocked);
+// Install `tarball` as the sole dependency of a fresh consumer project, so its
+// bin lands in node_modules/.bin. Scripts run (node-pty needs its native build);
+// --prefer-offline keeps it fast when the cache is warm.
+function install(tarball: string): string {
+  const consumer = mkdtempSync(path.join(os.tmpdir(), 'macaron-consumer-'));
+  writeFileSync(path.join(consumer, 'package.json'), JSON.stringify({ name: 'consumer', private: true }));
+  const r = spawnSync('npm', ['install', tarball, '--no-audit', '--no-fund', '--prefer-offline'], { cwd: consumer, encoding: 'utf8' });
+  assert.equal(r.status, 0, `npm install failed:\n${r.stderr}`);
+  return consumer;
+}
 
+// Boot the installed bin and resolve once it logs "listening" (with its chosen
+// port) or exits early. Returns { ok, port, output, kill }.
+function boot(consumer: string, bin: string, engineEnv: string | undefined): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
+  const port = 20000 + Math.floor(Math.random() * 20000);
   const env = { ...process.env };
   delete env.MACARON_ENGINE;
-  if (engine) env.MACARON_ENGINE = engine;
-  // A random high port and a throwaway HOME keep parallel boots off each other
-  // and off the real ~/.claude config.
-  env.MACARON_PORT = String(20000 + Math.floor(Math.random() * 20000));
-  env.HOME = dir;
-
-  const child = spawn(process.execPath, ['--import', bootstrap, bundle], { cwd: repoRoot, env });
-
+  if (engineEnv) env.MACARON_ENGINE = engineEnv;
+  env.MACARON_PORT = String(port);
+  env.HOME = path.join(consumer, 'home');
+  const child = spawn(path.join(consumer, 'node_modules', '.bin', bin), [], { cwd: consumer, env });
   return new Promise((resolve) => {
     let output = '';
     let settled = false;
-    const done = (ok: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      try { child.kill('SIGKILL'); } catch { /* already gone */ }
-      resolve({ ok, output });
-    };
-    const onData = (b: Buffer) => {
-      output += b.toString('utf8');
-      if (output.includes('macaron server listening')) done(true);
-    };
+    const kill = () => { try { child.kill('SIGKILL'); } catch { /* gone */ } };
+    const done = (ok: boolean) => { if (settled) return; settled = true; clearTimeout(timer); resolve({ ok, port, output, kill }); };
+    const onData = (b: Buffer) => { output += b.toString('utf8'); if (output.includes('listening')) done(true); };
     child.stdout.on('data', onData);
     child.stderr.on('data', onData);
-    child.on('exit', () => done(false)); // exited before "listening" → boot failed
-    const timer = setTimeout(() => done(false), 15000);
+    child.on('exit', () => done(false));
+    const timer = setTimeout(() => done(false), 20_000);
   });
 }
 
-// Simulates the FIRST engine turn: a fresh process with the foreign SDKs blocked
-// (a per-engine install) `await import()`s each SDK, exactly as the runner does
-// lazily on first use. Returns which specifiers resolved.
-function firstUseImport(blocked: string[], specifiers: string[]): { specifier: string; ok: boolean }[] {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-import-'));
-  const bootstrap = writeBlockBootstrap(dir, blocked);
-  // Bare specifiers resolve from the importing file's directory, so the probe
-  // must live under server/ (which has every SDK installed for dev) — a tmp-dir
-  // probe would fail to resolve even the own SDK. Write it beside the test tree.
-  const probe = path.join(repoRoot, 'server', `.engine-import-probe-${path.basename(dir)}.mjs`);
-  writeFileSync(probe, `
-    const specs = ${JSON.stringify(specifiers)};
-    const out = [];
-    for (const s of specs) {
-      try { await import(s); out.push({ specifier: s, ok: true }); }
-      catch { out.push({ specifier: s, ok: false }); }
+async function httpStatus(port: number, route: string): Promise<number> {
+  const res = await fetch(`http://127.0.0.1:${port}${route}`).catch(() => null);
+  return res ? res.status : 0;
+}
+
+// True if `node_modules/<pkg>` exists in the consumer install.
+function installed(consumer: string, pkg: string): boolean {
+  return existsSync(path.join(consumer, 'node_modules', ...pkg.split('/')));
+}
+
+for (const [engine, l] of Object.entries(LAUNCHERS)) {
+  test(`${l.bin} (${engine}): packs, installs with only its own SDK, and boots through its installed bin`, { timeout: 180_000, skip: SKIP && 'npm/package cache unavailable' }, async () => {
+    const dest = mkdtempSync(path.join(os.tmpdir(), `macaron-pack-${l.bin}-`));
+    const tarball = pack(l.dir, dest);
+    const consumer = install(tarball);
+
+    // (1) Only its own engine SDK is present; the foreign ones never installed.
+    assert.ok(installed(consumer, l.own), `${l.bin} must install its own SDK ${l.own}`);
+    for (const f of l.foreign) assert.ok(!installed(consumer, f), `${l.bin} must NOT install foreign SDK ${f}`);
+
+    // (2)-(3) Boots through the installed bin; own route answers, foreign 404s.
+    const b = await boot(consumer, l.bin, l.engineEnv);
+    try {
+      assert.ok(b.ok, `${l.bin} did not reach listening:\n${b.output}`);
+      const eng = await fetch(`http://127.0.0.1:${b.port}/api/engine`).then((r) => r.json()).catch(() => null);
+      assert.equal(eng?.engine, engine, `/api/engine should report ${engine}`);
+      assert.equal(await httpStatus(b.port, l.ownRoute), 200, `${l.bin} own route ${l.ownRoute} should answer 200`);
+      assert.equal(await httpStatus(b.port, l.foreignRoute), 404, `${l.bin} foreign route ${l.foreignRoute} should be absent (404)`);
+    } finally {
+      b.kill();
+      await fs.rm(dest, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(consumer, { recursive: true, force: true }).catch(() => {});
     }
-    process.stdout.write(JSON.stringify(out));
-  `);
-  try {
-    const r = spawnSync(process.execPath, ['--import', bootstrap, probe], { cwd: path.join(repoRoot, 'server'), encoding: 'utf8' });
-    assert.equal(r.status, 0, `import probe crashed:\n${r.stderr}`);
-    return JSON.parse(r.stdout);
-  } finally {
-    rmSync(probe, { force: true });
-  }
-}
-
-for (const [engine, { launcher, own, foreign }] of Object.entries(ENGINES)) {
-  const name = launcher === '.' ? 'mcc' : launcher; // mcc is the root package
-  const macaronEngine = engine === 'claude' ? undefined : engine;
-
-  test(`${name} (${engine}) boots without the other engines' SDKs installed`, async () => {
-    const { ok, output } = await bootWithBlocked(macaronEngine, [...foreign]);
-    assert.ok(ok, `${engine} boot did not reach listening:\n${output}`);
-  });
-
-  test(`${name} (${engine}) lazily imports only its own SDK on first use`, () => {
-    const results = firstUseImport([...foreign], [own, ...foreign]);
-    const byName = Object.fromEntries(results.map((r) => [r.specifier, r.ok]));
-    assert.equal(byName[own], true, `${engine}'s own SDK ${own} must resolve on first use`);
-    for (const f of foreign) assert.equal(byName[f], false, `${engine} must not resolve foreign SDK ${f}`);
-  });
-
-  test(`${name} tarball declares only its own engine SDK`, () => {
-    const pkg = JSON.parse(readFileSync(path.join(repoRoot, launcher, 'package.json'), 'utf8'));
-    const deps = pkg.dependencies || {};
-    assert.ok(deps[own], `${name} must declare its own SDK ${own}`);
-    for (const f of foreign) assert.ok(!deps[f], `${name} must NOT declare foreign SDK ${f}`);
-    assert.ok((pkg.files || []).includes('server/dist/index.js'), `${name} must ship the server bundle`);
   });
 }

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, writeFileSync, cpSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import http from 'node:http';
 import net from 'node:net';
@@ -51,9 +51,10 @@ const npmOk = spawnSync('npm', ['--version'], { encoding: 'utf8' }).status === 0
 if (CI) assert.ok(npmOk, 'CI requires npm for mandatory pack coverage, but `npm --version` failed');
 const SKIP = !CI && (process.env.MACARON_SKIP_PACK_TESTS === '1' || !npmOk);
 
-// Build the shared bundles ONCE, then stage them into mcx/mkx (their prepack
-// does the same) so all three tarballs are self-contained. Done in `before` so a
-// clean checkout with no dist/ still produces faithful tarballs.
+// Build the shared bundles ONCE at the repo root. Each launcher is then staged
+// into its OWN per-run temp dir at pack time (see pack()), so nothing mutates the
+// shared mcx/mkx trees — two concurrent CI-mode suites in one checkout stay safe.
+// Done in `before` so a clean checkout with no dist/ still produces faithful tarballs.
 before(() => {
   if (SKIP) return;
   const run = (cmd: string, args: string[], cwd: string) => {
@@ -72,16 +73,22 @@ before(() => {
   if (!existsSync(path.join(repoRoot, 'web', 'dist', 'index.html'))) {
     run('pnpm', ['--filter', '@macaron/web', 'build'], repoRoot);
   }
-  // Stage the shared outputs into mcx/mkx (mirrors their scripts/stage.mjs).
-  for (const dir of ['mcx', 'mkx']) {
-    run('node', ['scripts/stage.mjs'], path.join(repoRoot, dir));
-  }
 }, { timeout: 180_000 });
 
-// pack the launcher (scripts skipped — bundles are already staged) into `dest`,
-// returning the tarball path.
+// Stage `dir`'s launcher into a fresh temp dir and `npm pack` it there, returning
+// the tarball path. Staging per-run (instead of mutating the shared mcx/mkx trees
+// like scripts/stage.mjs does) keeps concurrent same-checkout suites from racing:
+// each package-local file (package.json, bin, README) is copied from the launcher
+// dir and each shared bundle (server/dist/index.js, web/dist) from the repo root's
+// once-built output — matching every launcher's package.json `files` list.
 function pack(dir: string, dest: string): string {
-  const r = spawnSync('npm', ['pack', '--ignore-scripts', '--pack-destination', dest], { cwd: path.join(repoRoot, dir), encoding: 'utf8' });
+  const launcher = path.join(repoRoot, dir);
+  const stage = mkdtempSync(path.join(os.tmpdir(), 'macaron-stage-'));
+  cpSync(path.join(launcher, 'package.json'), path.join(stage, 'package.json'));
+  for (const rel of ['bin', 'README.md']) cpSync(path.join(launcher, rel), path.join(stage, rel), { recursive: true });
+  cpSync(path.join(repoRoot, 'server', 'dist', 'index.js'), path.join(stage, 'server', 'dist', 'index.js'));
+  cpSync(path.join(repoRoot, 'web', 'dist'), path.join(stage, 'web', 'dist'), { recursive: true });
+  const r = spawnSync('npm', ['pack', '--ignore-scripts', '--pack-destination', dest], { cwd: stage, encoding: 'utf8' });
   assert.equal(r.status, 0, `npm pack failed for ${dir}:\n${r.stderr}`);
   const tgz = readdirSync(dest).find((f) => f.endsWith('.tgz'));
   assert.ok(tgz, `no tarball produced for ${dir}`);
@@ -238,6 +245,15 @@ function firstTurnProvesOwnSdk(turn: string, expect: 'done' | 'error'): boolean 
   return /"type":"error"|"type":"done"/.test(turn);
 }
 
+// Strict negative control: once the own SDK is deleted, the first turn must reach
+// the runner's lazy `import()` and fail THERE — so the stream must carry the
+// module-resolution error AND a stream `error` AND a terminal `done`. Requiring
+// all three means a boot timeout (no stream), a "CLI not found" (no module error),
+// or a route 404 (no error/done) can NOT masquerade as a passing negative control.
+function negControlProvesMissingSdk(turn: string): boolean {
+  return MODULE_ERR.test(turn) && /"type":"error"/.test(turn) && /"type":"done"/.test(turn);
+}
+
 // True if `node_modules/<pkg>` exists in the consumer install.
 function installed(consumer: string, pkg: string): boolean {
   return existsSync(path.join(consumer, 'node_modules', ...pkg.split('/')));
@@ -299,13 +315,13 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
     const nb = await boot(consumer, l.bin, l.engineEnv, nEnv);
     try {
       // Lazy imports mean the server still boots; the failure surfaces on the
-      // turn. mcc/mcx catch the import and emit a stream `error` carrying
-      // ERR_MODULE_NOT_FOUND; mkx's ACP import sits before its try so the turn
-      // simply never reaches its runner completion. Either way the success
-      // predicate must flip to false — that's the load-bearing signal.
+      // turn. With the own SDK gone, every runner's lazy `import()` throws inside
+      // its try/catch, emitting a stream `error` carrying the module-resolution
+      // message followed by a terminal `done`. The strict predicate demands all
+      // three so no weaker failure (timeout, CLI-not-found, 404) can pass here.
       assert.ok(nb.ok, `${l.bin} negative control should still boot (imports are lazy):\n${nb.output}`);
       const nturn = await postTurn(nb.port, l.turnRoute, consumer);
-      assert.ok(!firstTurnProvesOwnSdk(nturn, l.expect), `${l.bin} negative control must FAIL its first turn once ${l.own} is removed, but it passed:\n${nturn}`);
+      assert.ok(negControlProvesMissingSdk(nturn), `${l.bin} negative control must FAIL its first turn with a module error + stream error + done once ${l.own} is removed:\n${nturn}`);
     } finally {
       nb.kill();
       nstub?.close();

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -1,20 +1,19 @@
-import { spawn } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { test } from 'node:test';
+import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 
 const pathToFileURLString = (p: string) => pathToFileURL(p).href;
 
 // Proves the per-engine dependency split: each launcher boots the shared
-// `server/dist/index.js` while the OTHER engines' SDKs are absent. We can't
-// uninstall packages from a shared node_modules mid-suite, so we simulate a
-// fresh, engine-scoped install with a loader `resolve` hook that makes the
-// forbidden SDK specifiers throw ERR_MODULE_NOT_FOUND — exactly what a tarball
-// that never declared them would do. A boot that still reaches "listening"
-// proves those SDKs are never touched on that engine's boot path.
+// `server/dist/index.js` while the OTHER engines' SDKs are absent, and only
+// reaches for its own SDK lazily on first use. The pnpm workspace hoists every
+// SDK into a shared node_modules, so we can't uninstall packages mid-suite —
+// instead a loader `resolve` hook makes the forbidden SDK specifiers throw
+// ERR_MODULE_NOT_FOUND, exactly what a tarball that never declared them would do.
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 const bundle = path.join(repoRoot, 'server', 'dist', 'index.js');
@@ -23,15 +22,32 @@ const CLAUDE = '@anthropic-ai/claude-agent-sdk';
 const CODEX = '@openai/codex-sdk';
 const ACP = '@agentclientprotocol/sdk';
 
-// Boots the bundle with `blocked` SDKs made unresolvable and `MACARON_ENGINE`
-// set, then resolves once the server logs it is listening (success) or the
-// child exits early (failure — e.g. a boot-path import of a blocked SDK).
-function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise<{ ok: boolean; output: string }> {
-  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-iso-'));
-  // The blocking `resolve` hook must run on the loader thread, registered via
-  // module.register — an `--import`ed module's exported `resolve` is NOT picked
-  // up as a hook (it just runs for side effects). So we register a hooks module
-  // from a tiny bootstrap that `--import` loads before the bundle.
+// engine → { own SDK it loads lazily, foreign SDKs its tarball must NOT ship }.
+// mkx (kimi) drives the Kimi CLI over ACP; mcc (claude) and mcx (codex) load
+// their named SDKs.
+const ENGINES = {
+  claude: { launcher: '.', own: CLAUDE, foreign: [CODEX, ACP] },
+  codex: { launcher: 'mcx', own: CODEX, foreign: [CLAUDE, ACP] },
+  kimi: { launcher: 'mkx', own: ACP, foreign: [CLAUDE, CODEX] },
+} as const;
+
+// A clean checkout has no committed server/dist (it's .gitignore'd), so build it
+// once before the boot tests — the whole point is proving the SHIPPED bundle is
+// engine-clean, and every launcher ships this same file.
+before(() => {
+  if (existsSync(bundle)) return;
+  const r = spawnSync('bun', ['build', 'src/index.ts', '--target=node', '--format=esm', '--outfile=dist/index.js', '--packages=external'], {
+    cwd: path.join(repoRoot, 'server'),
+    stdio: 'inherit',
+  });
+  assert.equal(r.status, 0, 'failed to bundle server/dist/index.js for the isolation tests');
+});
+
+// Writes the loader bootstrap that makes `blocked` specifiers unresolvable. The
+// blocking `resolve` hook must run on the loader thread via module.register — an
+// `--import`ed module's exported `resolve` is NOT picked up as a hook (it just
+// runs for side effects) — so we register a hooks module from a tiny bootstrap.
+function writeBlockBootstrap(dir: string, blocked: string[]): string {
   const hooks = path.join(dir, 'block-hooks.mjs');
   writeFileSync(hooks, `
     const blocked = new Set(${JSON.stringify(blocked)});
@@ -50,6 +66,15 @@ function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise
     import { pathToFileURL } from 'node:url';
     register(${JSON.stringify(pathToFileURLString(hooks))}, pathToFileURL('./'));
   `);
+  return bootstrap;
+}
+
+// Boots the bundle with `blocked` SDKs made unresolvable and `MACARON_ENGINE`
+// set, then resolves once the server logs it is listening (success) or the
+// child exits early (failure — e.g. a boot-path import of a blocked SDK).
+function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise<{ ok: boolean; output: string }> {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-iso-'));
+  const bootstrap = writeBlockBootstrap(dir, blocked);
 
   const env = { ...process.env };
   delete env.MACARON_ENGINE;
@@ -82,17 +107,55 @@ function bootWithBlocked(engine: string | undefined, blocked: string[]): Promise
   });
 }
 
-test('mcc (claude) boots without the codex or ACP SDKs installed', async () => {
-  const { ok, output } = await bootWithBlocked(undefined, [CODEX, ACP]);
-  assert.ok(ok, `claude boot did not reach listening:\n${output}`);
-});
+// Simulates the FIRST engine turn: a fresh process with the foreign SDKs blocked
+// (a per-engine install) `await import()`s each SDK, exactly as the runner does
+// lazily on first use. Returns which specifiers resolved.
+function firstUseImport(blocked: string[], specifiers: string[]): { specifier: string; ok: boolean }[] {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'engine-import-'));
+  const bootstrap = writeBlockBootstrap(dir, blocked);
+  // Bare specifiers resolve from the importing file's directory, so the probe
+  // must live under server/ (which has every SDK installed for dev) — a tmp-dir
+  // probe would fail to resolve even the own SDK. Write it beside the test tree.
+  const probe = path.join(repoRoot, 'server', `.engine-import-probe-${path.basename(dir)}.mjs`);
+  writeFileSync(probe, `
+    const specs = ${JSON.stringify(specifiers)};
+    const out = [];
+    for (const s of specs) {
+      try { await import(s); out.push({ specifier: s, ok: true }); }
+      catch { out.push({ specifier: s, ok: false }); }
+    }
+    process.stdout.write(JSON.stringify(out));
+  `);
+  try {
+    const r = spawnSync(process.execPath, ['--import', bootstrap, probe], { cwd: path.join(repoRoot, 'server'), encoding: 'utf8' });
+    assert.equal(r.status, 0, `import probe crashed:\n${r.stderr}`);
+    return JSON.parse(r.stdout);
+  } finally {
+    rmSync(probe, { force: true });
+  }
+}
 
-test('mcx (codex) boots without the claude or ACP SDKs installed', async () => {
-  const { ok, output } = await bootWithBlocked('codex', [CLAUDE, ACP]);
-  assert.ok(ok, `codex boot did not reach listening:\n${output}`);
-});
+for (const [engine, { launcher, own, foreign }] of Object.entries(ENGINES)) {
+  const name = launcher === '.' ? 'mcc' : launcher; // mcc is the root package
+  const macaronEngine = engine === 'claude' ? undefined : engine;
 
-test('mkx (kimi) boots without the claude or codex SDKs installed', async () => {
-  const { ok, output } = await bootWithBlocked('kimi', [CLAUDE, CODEX]);
-  assert.ok(ok, `kimi boot did not reach listening:\n${output}`);
-});
+  test(`${name} (${engine}) boots without the other engines' SDKs installed`, async () => {
+    const { ok, output } = await bootWithBlocked(macaronEngine, [...foreign]);
+    assert.ok(ok, `${engine} boot did not reach listening:\n${output}`);
+  });
+
+  test(`${name} (${engine}) lazily imports only its own SDK on first use`, () => {
+    const results = firstUseImport([...foreign], [own, ...foreign]);
+    const byName = Object.fromEntries(results.map((r) => [r.specifier, r.ok]));
+    assert.equal(byName[own], true, `${engine}'s own SDK ${own} must resolve on first use`);
+    for (const f of foreign) assert.equal(byName[f], false, `${engine} must not resolve foreign SDK ${f}`);
+  });
+
+  test(`${name} tarball declares only its own engine SDK`, () => {
+    const pkg = JSON.parse(readFileSync(path.join(repoRoot, launcher, 'package.json'), 'utf8'));
+    const deps = pkg.dependencies || {};
+    assert.ok(deps[own], `${name} must declare its own SDK ${own}`);
+    for (const f of foreign) assert.ok(!deps[f], `${name} must NOT declare foreign SDK ${f}`);
+    assert.ok((pkg.files || []).includes('server/dist/index.js'), `${name} must ship the server bundle`);
+  });
+}

--- a/server/test/engine-sdk-isolation.test.ts
+++ b/server/test/engine-sdk-isolation.test.ts
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import http from 'node:http';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { test, before } from 'node:test';
@@ -98,10 +99,36 @@ function install(tarball: string): string {
   return consumer;
 }
 
+// Ask the OS for a free ephemeral port (bind :0, read it back, release). Far
+// safer than a blind random pick in a fixed range — the kernel won't hand out a
+// port it's already using. A tiny TOCTOU window remains between release and the
+// child's bind, which boot()'s EADDRINUSE retry covers.
+function reservePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
 // Boot the installed bin and resolve once it logs "listening" (with its chosen
-// port) or exits early. Returns { ok, port, output, kill }.
-function boot(consumer: string, bin: string, engineEnv: string | undefined, extraEnv: Record<string, string> = {}): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
-  const port = 20000 + Math.floor(Math.random() * 20000);
+// port) or exits early. Returns { ok, port, output, kill }. Retries on a lost
+// port race (EADDRINUSE) with a freshly reserved port so this required
+// pre-publish gate stays deterministic.
+async function boot(consumer: string, bin: string, engineEnv: string | undefined, extraEnv: Record<string, string> = {}): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
+  for (let attempt = 0; ; attempt++) {
+    const port = await reservePort();
+    const res = await bootOnce(consumer, bin, engineEnv, extraEnv, port);
+    if (res.ok || !/EADDRINUSE/.test(res.output) || attempt >= 4) return res;
+    res.kill(); // lost the port between reserve and bind — try a fresh one
+  }
+}
+
+function bootOnce(consumer: string, bin: string, engineEnv: string | undefined, extraEnv: Record<string, string>, port: number): Promise<{ ok: boolean; port: number; output: string; kill: () => void }> {
   const env = { ...process.env, ...extraEnv };
   delete env.MACARON_ENGINE;
   if (engineEnv) env.MACARON_ENGINE = engineEnv;
@@ -199,6 +226,18 @@ async function postTurn(port: number, route: string, cwd: string): Promise<strin
   return out;
 }
 
+// True when a first-turn SSE stream proves the runner's own lazy SDK import
+// resolved: no module-resolution error, plus the engine-specific success signal
+// (claude streams the stub delta+done; codex/kimi reach their runner and report
+// the deterministic `/bin/false` downstream failure). The negative control below
+// removes the own SDK and asserts this flips to false — the module error appears.
+const MODULE_ERR = /ERR_MODULE_NOT_FOUND|Cannot find package|Cannot find module/;
+function firstTurnProvesOwnSdk(turn: string, expect: 'done' | 'error'): boolean {
+  if (MODULE_ERR.test(turn)) return false;
+  if (expect === 'done') return /"type":"delta"/.test(turn) && new RegExp(STUB_TEXT).test(turn) && /"type":"done"/.test(turn);
+  return /"type":"error"|"type":"done"/.test(turn);
+}
+
 // True if `node_modules/<pkg>` exists in the consumer install.
 function installed(consumer: string, pkg: string): boolean {
   return existsSync(path.join(consumer, 'node_modules', ...pkg.split('/')));
@@ -222,7 +261,10 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
     const falseBin = spawnSync('sh', ['-c', 'command -v false'], { encoding: 'utf8' }).stdout.trim() || '/bin/false';
     const extraEnv: Record<string, string> =
       engine === 'claude' ? { ANTHROPIC_BASE_URL: stub!.url, ANTHROPIC_AUTH_TOKEN: 'stub', ANTHROPIC_API_KEY: 'stub' } :
-      engine === 'codex' ? { MACARON_CODEX_PATH: falseBin } :
+      // Force the SDK transport (not the default app-server bridge) so the POST
+      // actually reaches `import('@openai/codex-sdk')` in codex-runner — that
+      // lazy import is the thing this test exists to prove.
+      engine === 'codex' ? { MACARON_CODEX_PATH: falseBin, MACARON_CODEX_TRANSPORT: 'sdk' } :
       { MACARON_KIMI_PATH: falseBin };
     const b = await boot(consumer, l.bin, l.engineEnv, extraEnv);
     try {
@@ -236,19 +278,31 @@ for (const [engine, l] of Object.entries(LAUNCHERS)) {
       // lazy `import('<own-sdk>')`. A missing/broken own SDK would surface as
       // ERR_MODULE_NOT_FOUND in the stream instead of the engine's own output.
       const turn = await postTurn(b.port, l.turnRoute, consumer);
-      assert.doesNotMatch(turn, /ERR_MODULE_NOT_FOUND|Cannot find package|Cannot find module/, `${l.bin} first turn must not fail to import its own SDK:\n${turn}`);
-      if (l.expect === 'done') {
-        assert.match(turn, /"type":"delta"/, `${l.bin} first turn should stream a delta from the Anthropic stub:\n${turn}`);
-        assert.match(turn, new RegExp(STUB_TEXT), `${l.bin} first turn should carry the stub text:\n${turn}`);
-        assert.match(turn, /"type":"done"/, `${l.bin} first turn should reach done:\n${turn}`);
-      } else {
-        // The own SDK loaded and spawned `/bin/false`, whose non-zero exit the
-        // runner surfaces as an error/done — proving the runner path ran.
-        assert.match(turn, /"type":"error"|"type":"done"/, `${l.bin} first turn should reach its runner and report the downstream failure:\n${turn}`);
-      }
+      assert.ok(firstTurnProvesOwnSdk(turn, l.expect), `${l.bin} first turn must import its own SDK and reach the ${l.expect} signal:\n${turn}`);
     } finally {
       b.kill();
       stub?.close();
+    }
+
+    // (5) Negative control: remove ONLY the own SDK and repeat the first turn.
+    // The same probe must now FAIL — proving the assertion above is load-bearing
+    // and not silently passing on a path that never touches the SDK.
+    await fs.rm(path.join(consumer, 'node_modules', ...l.own.split('/')), { recursive: true, force: true });
+    const nstub = engine === 'claude' ? await startAnthropicStub() : null;
+    const nEnv = { ...extraEnv, ...(nstub ? { ANTHROPIC_BASE_URL: nstub.url } : {}) };
+    const nb = await boot(consumer, l.bin, l.engineEnv, nEnv);
+    try {
+      // Lazy imports mean the server still boots; the failure surfaces on the
+      // turn. mcc/mcx catch the import and emit a stream `error` carrying
+      // ERR_MODULE_NOT_FOUND; mkx's ACP import sits before its try so the turn
+      // simply never reaches its runner completion. Either way the success
+      // predicate must flip to false — that's the load-bearing signal.
+      assert.ok(nb.ok, `${l.bin} negative control should still boot (imports are lazy):\n${nb.output}`);
+      const nturn = await postTurn(nb.port, l.turnRoute, consumer);
+      assert.ok(!firstTurnProvesOwnSdk(nturn, l.expect), `${l.bin} negative control must FAIL its first turn once ${l.own} is removed, but it passed:\n${nturn}`);
+    } finally {
+      nb.kill();
+      nstub?.close();
       await fs.rm(dest, { recursive: true, force: true }).catch(() => {});
       await fs.rm(consumer, { recursive: true, force: true }).catch(() => {});
     }

--- a/server/test/launcher-args.test.ts
+++ b/server/test/launcher-args.test.ts
@@ -51,6 +51,22 @@ test('mcc lists --model in --help', () => {
   assert.match(result.stdout, /--model <model>/);
 });
 
+// A parsed --model must be consumed as the flag's own value (not swallow the
+// next arg) and then fall through to the post-loop port check. Pairing it with
+// an invalid --port makes the process exit deterministically at that check
+// WITHOUT booting the server — proving both the spaced and inline forms parse.
+test('mcc accepts a spaced --model value and reaches port validation', () => {
+  const result = runLauncher(mcc, ['--model', 'Macaron-V1-Venti', '--port', 'nope']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid port: nope/);
+});
+
+test('mcc accepts an inline --model=value and reaches port validation', () => {
+  const result = runLauncher(mcc, ['--model=Macaron-V1-Venti', '--port', 'nope']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid port: nope/);
+});
+
 test('mcc rejects --model with no value', () => {
   const result = runLauncher(mcc, ['--model']);
   assert.equal(result.status, 1);

--- a/server/test/launcher-args.test.ts
+++ b/server/test/launcher-args.test.ts
@@ -41,3 +41,24 @@ for (const launcher of launchers) {
     assert.match(result.stderr, /--allow-hosted does not take a value/);
   });
 }
+
+// --model is mcc-only (Claude launch model → ANTHROPIC_MODEL, mirrors `claude --model X`).
+const mcc = path.join(repoRoot, 'bin', 'mcc.mjs');
+
+test('mcc lists --model in --help', () => {
+  const result = runLauncher(mcc, ['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--model <model>/);
+});
+
+test('mcc rejects --model with no value', () => {
+  const result = runLauncher(mcc, ['--model']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--model requires a value/);
+});
+
+test('mcc rejects --model swallowing the next flag as its value', () => {
+  const result = runLauncher(mcc, ['--model', '--port']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--model requires a value/);
+});

--- a/server/test/launcher-args.test.ts
+++ b/server/test/launcher-args.test.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, symlinkSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -47,6 +49,17 @@ const mcc = path.join(repoRoot, 'bin', 'mcc.mjs');
 
 test('mcc lists --model in --help', () => {
   const result = runLauncher(mcc, ['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--model <model>/);
+});
+
+// Package managers expose the bin as a symlink (node_modules/.bin/mcc). The
+// main-module guard must resolve symlinks or the installed bin silently no-ops.
+test('mcc invoked through a package-style symlink still prints --help', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'mcc-bin-'));
+  const link = path.join(dir, 'mcc');
+  symlinkSync(mcc, link);
+  const result = runLauncher(link, ['--help']);
   assert.equal(result.status, 0);
   assert.match(result.stdout, /--model <model>/);
 });

--- a/server/test/launcher-args.test.ts
+++ b/server/test/launcher-args.test.ts
@@ -57,6 +57,18 @@ test('mcc rejects --model with no value', () => {
   assert.match(result.stderr, /--model requires a value/);
 });
 
+test('mcc rejects an empty inline --model value', () => {
+  const result = runLauncher(mcc, ['--model=']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--model requires a non-empty value/);
+});
+
+test('mcc rejects a whitespace-only --model value', () => {
+  const result = runLauncher(mcc, ['--model', '   ']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--model requires a non-empty value/);
+});
+
 test('mcc rejects --model swallowing the next flag as its value', () => {
   const result = runLauncher(mcc, ['--model', '--port']);
   assert.equal(result.status, 1);

--- a/server/test/provider-env-precedence.test.ts
+++ b/server/test/provider-env-precedence.test.ts
@@ -10,6 +10,9 @@ import { mkdtempSync } from 'node:fs';
 process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'macaron-env-'));
 
 const store = await import('../src/lib/settings-store.js');
+// Import the real launcher parser (guarded to not boot the server on import)
+// for a genuine CLI-form → warmSettingsCache() → routed-model integration.
+const { parseArgs } = await import('../../bin/mcc.mjs');
 
 // The launch override is captured once per warmSettingsCache() call from the
 // ambient env, so each test sets env then re-warms to simulate a fresh boot.
@@ -88,4 +91,65 @@ test('selecting a custom provider clears the launch override and restores isolat
   assert.ok(env);
   assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//); // relay isolation restored
   assert.equal((await store.readPublicSettings()).activeProviderId, p.id); // UI shows the provider
+});
+
+// ---- Finding 1: setActiveProvider() is transactional --------------------
+
+test('a failed provider-selection persist restores cached provider and launchOverride', async () => {
+  const p = await seedCustomActive();
+  await boot({ base: 'https://mint.macaron.im', model: 'Macaron-V1-Venti' });
+  assert.equal((await store.readPublicSettings()).activeProviderId, store.SYSTEM_PROVIDER_ID);
+
+  // Force persist() to fail: replace the config file with a directory so
+  // writeFile(CONFIG_PATH) throws EISDIR. The cache mutation must roll back.
+  const fs = await import('node:fs');
+  const cfg = path.join(process.env.HOME!, '.claude', 'macaron-config.json');
+  fs.rmSync(cfg, { force: true });
+  fs.mkdirSync(cfg, { recursive: true });
+  try {
+    await assert.rejects(() => store.setActiveProvider(p.id));
+    // Cache + override must be untouched: still System/pass-through.
+    assert.equal((await store.readPublicSettings()).activeProviderId, store.SYSTEM_PROVIDER_ID);
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, 'Macaron-V1-Venti');
+    assert.equal(env, null); // still pass-through, NOT the custom relay
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});
+
+// ---- Finding 2: real launcher-to-boot integration -----------------------
+
+for (const [label, argv] of [
+  ['spaced', ['--model', 'Macaron-V1-Venti']],
+  ['inline', ['--model=Macaron-V1-Venti']],
+] as const) {
+  test(`launcher ${label} --model boots System and routes the CLI model`, async () => {
+    await seedCustomActive(); // a stale persisted provider that must be overridden
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_MODEL;
+    let exited: number | null = null;
+    await parseArgs([...argv], (code: number) => { exited = code; });
+    assert.equal(exited, null); // no --help/--version short-circuit
+    assert.equal(process.env.ANTHROPIC_MODEL, 'Macaron-V1-Venti'); // CLI form propagated to env
+    await store.warmSettingsCache(); // boot picks up the launch override
+    assert.equal((await store.readPublicSettings()).activeProviderId, store.SYSTEM_PROVIDER_ID);
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, 'Macaron-V1-Venti'); // routed model is the CLI model, not the stored one
+    assert.equal(env, null);
+  });
+}
+
+// ---- Finding 3: base-URL-only pass-through uses default Claude auth ------
+
+test('base-URL-only launch (no creds/model) passes through to the default Claude auth path', async () => {
+  await seedCustomActive();
+  await boot({ base: 'https://mint.macaron.im' }); // no token, no model
+  // Accepted behavior: base URL alone is a launch override → System pass-through.
+  // The SDK inherits the ambient env untouched (env: null), so auth falls to the
+  // user's existing/default ~/.claude Claude Code login — we set no credentials.
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, undefined); // no ambient model → SDK default
+  assert.equal(env, null); // no relay, no injected CLAUDE_CONFIG_DIR/token
+  assert.equal((await store.readPublicSettings()).activeProviderId, store.SYSTEM_PROVIDER_ID);
 });

--- a/server/test/provider-env-precedence.test.ts
+++ b/server/test/provider-env-precedence.test.ts
@@ -1,58 +1,91 @@
-import { test, before, beforeEach } from 'node:test';
+import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
 import { mkdtempSync } from 'node:fs';
 
-// Isolate HOME before importing settings-store: CONFIG_PATH (and HOME) are
-// captured at module load from ~/.claude/macaron-config.json, so a temp HOME
-// keeps these tests from touching the real config.
+// Isolate HOME before importing settings-store: CONFIG_PATH is captured at
+// module load from ~/.claude/macaron-config.json, so a temp HOME keeps these
+// tests off the real config.
 process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'macaron-env-'));
-delete process.env.ANTHROPIC_BASE_URL;
-delete process.env.ANTHROPIC_MODEL;
 
 const store = await import('../src/lib/settings-store.js');
 
-before(async () => {
-  await store.warmSettingsCache();
-});
-
-beforeEach(() => {
+// The launch override is captured once per warmSettingsCache() call from the
+// ambient env, so each test sets env then re-warms to simulate a fresh boot.
+async function boot(env: { base?: string; model?: string }) {
   delete process.env.ANTHROPIC_BASE_URL;
   delete process.env.ANTHROPIC_MODEL;
+  if (env.base) process.env.ANTHROPIC_BASE_URL = env.base;
+  if (env.model) process.env.ANTHROPIC_MODEL = env.model;
+  await store.warmSettingsCache();
+}
+
+async function seedCustomActive() {
+  const p = await store.addProvider({ name: 'Stored', endpoint: 'https://api.example.com/v1', model: 'stored-model', apiKey: 'sk-test' });
+  await store.setActiveProvider(p.id);
+  return p;
+}
+
+beforeEach(async () => {
+  // Reset persisted state to a known System-active baseline between tests.
+  await boot({});
+  await store.setActiveProvider(store.SYSTEM_PROVIDER_ID);
 });
 
-test('system provider passes through ambient ANTHROPIC_MODEL', async () => {
-  await store.setActiveProvider(store.SYSTEM_PROVIDER_ID);
-  process.env.ANTHROPIC_MODEL = 'Macaron-V1-Venti';
+test('System launch passes ambient ANTHROPIC_MODEL through with no env override', async () => {
+  await boot({ model: 'Macaron-V1-Venti' });
   const { model, env } = store.getActiveProviderEnv();
   assert.equal(model, 'Macaron-V1-Venti');
-  assert.equal(env, null); // pass-through: no env override
+  assert.equal(env, null);
 });
 
-test('system provider with no ambient model yields undefined', async () => {
-  await store.setActiveProvider(store.SYSTEM_PROVIDER_ID);
+test('System launch with no ambient model yields undefined', async () => {
+  await boot({});
   const { model, env } = store.getActiveProviderEnv();
   assert.equal(model, undefined);
   assert.equal(env, null);
 });
 
 test('active custom provider builds a relay env override', async () => {
-  const p = await store.addProvider({ name: 'Test', endpoint: 'https://api.example.com/v1', model: 'custom-model', apiKey: 'sk-test' });
-  await store.setActiveProvider(p.id);
+  await boot({});
+  await seedCustomActive();
   const { model, env } = store.getActiveProviderEnv();
-  assert.equal(model, 'custom-model');
+  assert.equal(model, 'stored-model');
   assert.ok(env);
   assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//);
 });
 
-test('pasted ANTHROPIC_BASE_URL overrides a stale persisted custom provider', async () => {
-  const p = await store.addProvider({ name: 'Stale', endpoint: 'https://api.example.com/v1', model: 'custom-model', apiKey: 'sk-test' });
-  await store.setActiveProvider(p.id);
-  // Simulate the pasted `mcc` launch env block + `--model Macaron-V1-Venti`.
-  process.env.ANTHROPIC_BASE_URL = 'https://mint.macaron.im';
-  process.env.ANTHROPIC_MODEL = 'Macaron-V1-Venti';
+test('base-URL launch overrides a stale persisted custom provider (route + UI agree)', async () => {
+  await seedCustomActive();
+  await boot({ base: 'https://mint.macaron.im', model: 'Macaron-V1-Venti' });
   const { model, env } = store.getActiveProviderEnv();
-  assert.equal(model, 'Macaron-V1-Venti'); // launch model wins
-  assert.equal(env, null); // pass-through, NOT the relay
+  assert.equal(model, 'Macaron-V1-Venti');
+  assert.equal(env, null); // pass-through, not the relay
+  const pub = await store.readPublicSettings();
+  assert.equal(pub.activeProviderId, store.SYSTEM_PROVIDER_ID); // UI shows System too
+});
+
+test('model-only launch overrides a stale persisted custom provider', async () => {
+  await seedCustomActive();
+  await boot({ model: 'cli-model' }); // no ambient base URL
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, 'cli-model');
+  assert.equal(env, null);
+  const pub = await store.readPublicSettings();
+  assert.equal(pub.activeProviderId, store.SYSTEM_PROVIDER_ID);
+});
+
+test('selecting a custom provider clears the launch override and restores isolation', async () => {
+  const p = await seedCustomActive();
+  await boot({ base: 'https://mint.macaron.im', model: 'Macaron-V1-Venti' });
+  // UI initially agrees on System while launched with ambient env.
+  assert.equal((await store.readPublicSettings()).activeProviderId, store.SYSTEM_PROVIDER_ID);
+  // Explicit selection retires the override.
+  await store.setActiveProvider(p.id);
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, 'stored-model');
+  assert.ok(env);
+  assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//); // relay isolation restored
+  assert.equal((await store.readPublicSettings()).activeProviderId, p.id); // UI shows the provider
 });

--- a/server/test/provider-env-precedence.test.ts
+++ b/server/test/provider-env-precedence.test.ts
@@ -180,6 +180,32 @@ test('env-seeding a full provider clears the launch override so UI/routing route
   }
 });
 
+test('a complete env seed with a manual provider already active keeps that provider (kept-active-choice)', async () => {
+  const manual = await seedCustomActive(); // user manually picked this one
+  process.env.MACARON_PROVIDER_ENDPOINT = 'https://mint.macaron.im/v1';
+  process.env.MACARON_PROVIDER_TOKEN = 'sk-seed';
+  process.env.MACARON_PROVIDER_MODEL = 'macaron-v1-venti';
+  try {
+    // Boot with the full ambient env (sets launchOverride) while `manual` stays active.
+    await boot({ base: 'https://mint.macaron.im/v1', model: 'macaron-v1-venti' });
+    const res = await store.seedProviderFromEnv();
+    assert.ok(res.seeded);
+    assert.equal(res.activated, false); // main's contract: kept the manual choice
+    // The override must be cleared even though we didn't activate the seeded row,
+    // so UI + routing keep using the MANUAL provider — not ambient pass-through.
+    const pub = await store.readPublicSettings();
+    assert.equal(pub.activeProviderId, manual.id);
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, 'stored-model'); // the manual provider's model, not the CLI one
+    assert.ok(env);
+    assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//);
+  } finally {
+    delete process.env.MACARON_PROVIDER_ENDPOINT;
+    delete process.env.MACARON_PROVIDER_TOKEN;
+    delete process.env.MACARON_PROVIDER_MODEL;
+  }
+});
+
 test('a model-only launch seeds nothing and keeps the pass-through override', async () => {
   await seedCustomActive();
   await boot({ model: 'cli-model' }); // no endpoint/token → seed is a no-op

--- a/server/test/provider-env-precedence.test.ts
+++ b/server/test/provider-env-precedence.test.ts
@@ -1,0 +1,58 @@
+import { test, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync } from 'node:fs';
+
+// Isolate HOME before importing settings-store: CONFIG_PATH (and HOME) are
+// captured at module load from ~/.claude/macaron-config.json, so a temp HOME
+// keeps these tests from touching the real config.
+process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'macaron-env-'));
+delete process.env.ANTHROPIC_BASE_URL;
+delete process.env.ANTHROPIC_MODEL;
+
+const store = await import('../src/lib/settings-store.js');
+
+before(async () => {
+  await store.warmSettingsCache();
+});
+
+beforeEach(() => {
+  delete process.env.ANTHROPIC_BASE_URL;
+  delete process.env.ANTHROPIC_MODEL;
+});
+
+test('system provider passes through ambient ANTHROPIC_MODEL', async () => {
+  await store.setActiveProvider(store.SYSTEM_PROVIDER_ID);
+  process.env.ANTHROPIC_MODEL = 'Macaron-V1-Venti';
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, 'Macaron-V1-Venti');
+  assert.equal(env, null); // pass-through: no env override
+});
+
+test('system provider with no ambient model yields undefined', async () => {
+  await store.setActiveProvider(store.SYSTEM_PROVIDER_ID);
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, undefined);
+  assert.equal(env, null);
+});
+
+test('active custom provider builds a relay env override', async () => {
+  const p = await store.addProvider({ name: 'Test', endpoint: 'https://api.example.com/v1', model: 'custom-model', apiKey: 'sk-test' });
+  await store.setActiveProvider(p.id);
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, 'custom-model');
+  assert.ok(env);
+  assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//);
+});
+
+test('pasted ANTHROPIC_BASE_URL overrides a stale persisted custom provider', async () => {
+  const p = await store.addProvider({ name: 'Stale', endpoint: 'https://api.example.com/v1', model: 'custom-model', apiKey: 'sk-test' });
+  await store.setActiveProvider(p.id);
+  // Simulate the pasted `mcc` launch env block + `--model Macaron-V1-Venti`.
+  process.env.ANTHROPIC_BASE_URL = 'https://mint.macaron.im';
+  process.env.ANTHROPIC_MODEL = 'Macaron-V1-Venti';
+  const { model, env } = store.getActiveProviderEnv();
+  assert.equal(model, 'Macaron-V1-Venti'); // launch model wins
+  assert.equal(env, null); // pass-through, NOT the relay
+});

--- a/server/test/schedule-engine-gating.test.ts
+++ b/server/test/schedule-engine-gating.test.ts
@@ -1,0 +1,118 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// Isolate HOME before importing anything that captures a config path at module
+// load. schedule-store's CONFIG_PATH is ~/.claude/macaron-schedules.json, and
+// ENGINE is read from MACARON_ENGINE — both frozen at import. The default test
+// env leaves MACARON_ENGINE unset, so this suite runs as a `claude` launcher and
+// treats `codex`/`kimi` schedules as foreign.
+const HOME = mkdtempSync(path.join(os.tmpdir(), 'macaron-sched-'));
+process.env.HOME = HOME;
+delete process.env.MACARON_ENGINE;
+
+const SCHED_FILE = path.join(HOME, '.claude', 'macaron-schedules.json');
+const store = await import('../src/lib/schedule-store.js');
+const scheduler = await import('../src/lib/scheduler.js');
+const { registerScheduleRoutes } = await import('../src/routes/schedules.js');
+const { ENGINE } = await import('../src/config.js');
+
+// A real, existing cwd every schedule can point at (create asserts it exists).
+const CWD = mkdtempSync(path.join(os.tmpdir(), 'macaron-sched-cwd-'));
+
+// Seed the persisted store directly, bypassing the route, to simulate schedules
+// created before the dependency split or synced from another launcher. Then warm
+// the in-memory cache the tick/run-now read from.
+async function seed(schedules: Record<string, unknown>[]): Promise<void> {
+  await fs.mkdir(path.dirname(SCHED_FILE), { recursive: true });
+  writeFileSync(SCHED_FILE, JSON.stringify(schedules, null, 2), 'utf8');
+  store.__resetCacheForTests(); // drop cache so the seeded file is reloaded
+  await store.warmSchedulesCache();
+}
+
+function foreignSchedule(engine: string, id: string, overrides: Record<string, unknown> = {}) {
+  const now = Date.now();
+  return {
+    id, name: `foreign-${engine}`, prompt: 'do a thing', engine, cwd: CWD,
+    pattern: '* * * * *', oneShot: false, status: 'active',
+    nextRunAt: now - 1000, // already due
+    lastRunAt: null, lastStatus: null, lastSessionId: null,
+    createdAt: now, updatedAt: now, ...overrides,
+  };
+}
+
+let app: FastifyInstance;
+before(async () => {
+  app = Fastify();
+  await registerScheduleRoutes(app);
+  await app.ready();
+});
+after(async () => { await app.close(); });
+
+// ── create gating ──────────────────────────────────────────────────────────
+
+test('POST /api/schedules defaults an omitted engine to ENGINE', async () => {
+  await seed([]);
+  const res = await app.inject({ method: 'POST', url: '/api/schedules', payload: { name: 'n', prompt: 'p', cwd: CWD, pattern: '* * * * *' } });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().engine, ENGINE);
+});
+
+test('POST /api/schedules accepts an explicit same-engine value', async () => {
+  await seed([]);
+  const res = await app.inject({ method: 'POST', url: '/api/schedules', payload: { name: 'n', prompt: 'p', cwd: CWD, pattern: '* * * * *', engine: ENGINE } });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().engine, ENGINE);
+});
+
+test('POST /api/schedules rejects an explicit foreign engine with 400 and creates nothing', async () => {
+  await seed([]);
+  const foreign = ENGINE === 'claude' ? 'codex' : 'claude';
+  const res = await app.inject({ method: 'POST', url: '/api/schedules', payload: { name: 'n', prompt: 'p', cwd: CWD, pattern: '* * * * *', engine: foreign } });
+  assert.equal(res.statusCode, 400);
+  assert.match(res.json().error, new RegExp(ENGINE));
+  assert.equal((await store.readSchedules()).length, 0, 'no schedule should be persisted');
+});
+
+// ── update gating ──────────────────────────────────────────────────────────
+
+test('PUT /api/schedules/:id rejects a foreign engine patch without mutating', async () => {
+  await seed([foreignSchedule(ENGINE, 'own-1', { status: 'paused', nextRunAt: null })]);
+  const foreign = ENGINE === 'claude' ? 'kimi' : 'claude';
+  const res = await app.inject({ method: 'PUT', url: '/api/schedules/own-1', payload: { engine: foreign, name: 'changed' } });
+  assert.equal(res.statusCode, 400);
+  const after = store.getSchedule('own-1');
+  assert.equal(after?.name, 'foreign-' + ENGINE, 'name must be unchanged after a rejected patch');
+});
+
+// ── run-now gating ─────────────────────────────────────────────────────────
+
+test('run-now on a persisted foreign schedule returns 400 without dispatch or mutation', async () => {
+  await seed([foreignSchedule('codex', 'foreign-run', { engine: ENGINE === 'codex' ? 'kimi' : 'codex' })]);
+  const before = store.getSchedule('foreign-run');
+  const res = await app.inject({ method: 'POST', url: '/api/schedules/foreign-run/run-now' });
+  assert.equal(res.statusCode, 400);
+  const after = store.getSchedule('foreign-run');
+  assert.equal(after?.lastStatus, before?.lastStatus ?? null);
+  assert.equal(after?.lastRunAt, before?.lastRunAt ?? null);
+  assert.equal(after?.nextRunAt, before?.nextRunAt);
+});
+
+// ── tick gating ────────────────────────────────────────────────────────────
+
+test('tick() skips a due persisted foreign schedule — no dispatch, no mutation', async () => {
+  const foreign = ENGINE === 'kimi' ? 'codex' : 'kimi';
+  await seed([foreignSchedule(foreign, 'foreign-tick')]);
+  const before = store.getSchedule('foreign-tick');
+  scheduler.tick();
+  // fireSchedule is async fire-and-forget; give any (erroneous) dispatch a beat.
+  await new Promise((r) => setTimeout(r, 50));
+  const after = store.getSchedule('foreign-tick');
+  assert.equal(after?.lastStatus, null, 'foreign schedule must never record a run');
+  assert.equal(after?.lastRunAt, null);
+  assert.equal(after?.nextRunAt, before?.nextRunAt, 'nextRunAt must not advance for a foreign schedule');
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,7 @@ import type {
   SkillDetail,
   Schedule,
   ScheduleInput,
+  SessionKind,
   SchedulesResponse,
   CommandsResponse,
   AgentsResponse,
@@ -193,6 +194,7 @@ async function req<T>(url: string, init: RequestInit): Promise<T> {
 
 export const api = {
   health: () => getJSON<HealthResponse>('/api/health'),
+  engine: () => getJSON<{ engine: SessionKind }>('/api/engine'),
   analytics: (window: string) =>
     getJSON<AnalyticsResponse>(`/api/analytics?window=${encodeURIComponent(window)}`),
   settings: () => getJSON<PublicSettings>('/api/settings'),

--- a/web/src/views/Schedules.tsx
+++ b/web/src/views/Schedules.tsx
@@ -26,6 +26,9 @@ function fmtWhen(ms: number | null): string {
 
 export function Schedules() {
   const [schedules, setSchedules] = useState<Schedule[] | null>(null);
+  // This launcher only runs its own engine's schedules — the others' SDKs aren't
+  // installed. Lock the form to it so a foreign schedule can't be created.
+  const [engine, setEngine] = useState<SessionKind>('claude');
   const [error, setError] = useState('');
   const [editing, setEditing] = useState<{ id: string | null; draft: ScheduleInput } | null>(null);
   const [busy, setBusy] = useState(false);
@@ -36,12 +39,13 @@ export function Schedules() {
 
   useEffect(() => {
     load();
+    api.engine().then((r) => setEngine(r.engine)).catch(() => {});
     // Poll so nextRunAt / lastStatus reflect the tick as it fires.
     const t = setInterval(load, 10_000);
     return () => clearInterval(t);
   }, []);
 
-  const openCreate = () => setEditing({ id: null, draft: { ...BLANK } });
+  const openCreate = () => setEditing({ id: null, draft: { ...BLANK, engine } });
   const openEdit = (s: Schedule) =>
     setEditing({ id: s.id, draft: { name: s.name, prompt: s.prompt, engine: s.engine, cwd: s.cwd, pattern: s.pattern, oneShot: s.oneShot } });
 
@@ -187,11 +191,8 @@ function ScheduleForm({ draft, onChange }: { draft: ScheduleInput; onChange: (pa
       </div>
       <div className="settings-field">
         <label htmlFor="s-engine">Engine</label>
-        <select id="s-engine" className="settings-input" value={draft.engine} onChange={(e) => onChange({ engine: e.target.value as SessionKind })}>
-          <option value="claude">Claude</option>
-          <option value="codex">Codex</option>
-          <option value="kimi">Kimi</option>
-        </select>
+        <input id="s-engine" className="settings-input" value={draft.engine} readOnly disabled />
+        <p className="settings-hint">Fixed to this launcher's engine — it only runs its own engine's sessions.</p>
       </div>
       <div className="settings-field">
         <label>Schedule type</label>


### PR DESCRIPTION
## What

Give `mcc` a `--model <model>` flag so you can paste a provider's env block and launch in one command — matching `claude --model X`.

The system (pass-through) provider already inherits the shell's `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` untouched, but there was no way to choose the launch model. Now:

- `bin/mcc.mjs` parses `--model` (space + `=` forms) and sets `ANTHROPIC_MODEL`.
- `getActiveProviderEnv()` honors an ambient `ANTHROPIC_MODEL` on the system provider (previously hard-coded to `undefined`), so the SDK subprocess launches on that model.

```bash
export ANTHROPIC_BASE_URL='https://mint.macaron.im'
export ANTHROPIC_AUTH_TOKEN='sk-...'
export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC='1'
export CLAUDE_CODE_ATTRIBUTION_HEADER=0
mcc --model Macaron-V1-Venti
```

## Tests

- `pnpm --filter @macaron/server typecheck` — clean.
- `pnpm --filter @macaron/server test` — 77/77 pass, including 3 new `--model` launcher-arg cases (help lists it; missing value errors; won't swallow the next flag).
- Booted the real launcher with the `mint.macaron.im` env → `/api/settings` confirms system passthrough with `detectedEndpoint: https://mint.macaron.im`.
- `getActiveProviderEnv()` on the system provider: with `ANTHROPIC_MODEL=Macaron-V1-Venti` → `{model: "Macaron-V1-Venti", env: null}`; unset → `{model: undefined, env: null}`.
- Verified the endpoint itself answers: `POST https://mint.macaron.im/v1/messages` with `model: Macaron-V1-Venti` → `200`.

Both required env cases exercise the same pass-through code path (the `m clhh` case is another ambient `ANTHROPIC_BASE_URL`/token export), so both are covered.
