### PR TITLE
Honor settings.json model in Claude routing

### DIFF
--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -8,7 +8,7 @@
 // Cache is warmed at startup so getActiveProviderEnv() is synchronous —
 // hot-path request handlers can call it without awaiting disk I/O.
 
-import { promises as fs, mkdirSync, existsSync, symlinkSync, lstatSync, rmSync } from 'node:fs';
+import { promises as fs, readFileSync, mkdirSync, existsSync, symlinkSync, lstatSync, rmSync } from 'node:fs';
 import { randomUUID, createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
@@ -83,8 +83,26 @@ export type PublicSettings = {
 };
 
 const CONFIG_PATH = path.join(HOME, '.claude', 'macaron-config.json');
+const CLAUDE_SETTINGS_PATH = path.join(HOME, '.claude', 'settings.json');
 
 let cache: Settings | null = null;
+
+// The SDK normally resolves this from settings.json itself. Custom-provider
+// runs use an isolated CLAUDE_CONFIG_DIR for auth, though, so the SDK cannot
+// see the user's model setting there. Read only this field synchronously on
+// the request path so edits made through the Settings page take effect on the
+// next turn without another server restart. Invalid or missing files mean the
+// same thing as an unset model and fall back to the normal env/SDK behavior.
+function readClaudeSettingsModel(): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    const model = (parsed as { model?: unknown }).model;
+    return typeof model === 'string' && model.trim() ? model.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 // Launch override: a pasted `mcc` env block (ANTHROPIC_BASE_URL) or `--model`
 // (ANTHROPIC_MODEL) at boot is a "run against these params now" intent that
@@ -495,8 +513,10 @@ export function getActiveProviderEnv(): {
     // Pass-through: inherit process.env unchanged (ANTHROPIC_BASE_URL /
     // ANTHROPIC_AUTH_TOKEN the user exported in their shell). Honor an
     // ambient ANTHROPIC_MODEL too so `mcc --model X` (which sets it) picks
-    // the launch model, matching `claude --model X`.
-    return { model: process.env.ANTHROPIC_MODEL || undefined, env: null };
+    // the launch model, matching `claude --model X`. When no launch override
+    // exists, make the user-scope settings.json model explicit instead of
+    // letting the SDK silently choose its own (currently Opus) default.
+    return { model: process.env.ANTHROPIC_MODEL || readClaudeSettingsModel(), env: null };
   }
   const p = s.customProviders.find((x) => x.id === s.activeProviderId);
   if (!p) return { model: undefined, env: null };
@@ -519,6 +539,10 @@ export function getActiveProviderEnv(): {
     ANTHROPIC_AUTH_TOKEN: p.apiKey,
     ANTHROPIC_API_KEY: p.apiKey,
   };
-  if (p.model) env.ANTHROPIC_MODEL = p.model;
-  return { model: p.model || undefined, env };
+  // A provider's explicit model remains authoritative for that endpoint. An
+  // older/partially configured provider can still follow settings.json rather
+  // than falling through to the SDK's built-in Opus default.
+  const model = p.model || readClaudeSettingsModel();
+  if (model) env.ANTHROPIC_MODEL = model;
+  return { model: model || undefined, env };
 }

--- a/server/test/provider-env-precedence.test.ts
+++ b/server/test/provider-env-precedence.test.ts
@@ -2,7 +2,7 @@ import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 // Isolate HOME before importing settings-store: CONFIG_PATH is captured at
 // module load from ~/.claude/macaron-config.json, so a temp HOME keeps these
@@ -50,6 +50,43 @@ test('System launch with no ambient model yields undefined', async () => {
   assert.equal(env, null);
 });
 
+test('System launch follows the model in user settings.json', async () => {
+  const settingsPath = path.join(process.env.HOME!, '.claude', 'settings.json');
+  writeFileSync(settingsPath, JSON.stringify({ model: 'macaron-settings-model' }));
+  try {
+    await boot({});
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, 'macaron-settings-model');
+    assert.equal(env, null);
+  } finally {
+    rmSync(settingsPath, { force: true });
+  }
+});
+
+test('an explicit launch model still takes precedence over settings.json', async () => {
+  const settingsPath = path.join(process.env.HOME!, '.claude', 'settings.json');
+  writeFileSync(settingsPath, JSON.stringify({ model: 'settings-model' }));
+  try {
+    await boot({ model: 'launch-model' });
+    assert.equal(store.getActiveProviderEnv().model, 'launch-model');
+  } finally {
+    rmSync(settingsPath, { force: true });
+  }
+});
+
+test('invalid settings.json does not break provider resolution', async () => {
+  const settingsPath = path.join(process.env.HOME!, '.claude', 'settings.json');
+  writeFileSync(settingsPath, '{not-json');
+  try {
+    await boot({});
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, undefined);
+    assert.equal(env, null);
+  } finally {
+    rmSync(settingsPath, { force: true });
+  }
+});
+
 test('active custom provider builds a relay env override', async () => {
   await boot({});
   await seedCustomActive();
@@ -57,6 +94,28 @@ test('active custom provider builds a relay env override', async () => {
   assert.equal(model, 'stored-model');
   assert.ok(env);
   assert.match(env!.ANTHROPIC_BASE_URL, /\/relay\/anthropic\//);
+});
+
+test('custom provider without a model follows user settings.json', async () => {
+  const settingsPath = path.join(process.env.HOME!, '.claude', 'settings.json');
+  writeFileSync(settingsPath, JSON.stringify({ model: 'macaron-settings-model' }));
+  try {
+    await boot({});
+    const p = await store.addProvider({
+      name: 'Stored without model',
+      endpoint: 'https://api.example.com/v1',
+      model: '',
+      apiKey: 'sk-test',
+    });
+    await store.setActiveProvider(p.id);
+
+    const { model, env } = store.getActiveProviderEnv();
+    assert.equal(model, 'macaron-settings-model');
+    assert.ok(env);
+    assert.equal(env!.ANTHROPIC_MODEL, 'macaron-settings-model');
+  } finally {
+    rmSync(settingsPath, { force: true });
+  }
 });
 
 test('base-URL launch overrides a stale persisted custom provider (route + UI agree)', async () => {


### PR DESCRIPTION
## Summary

- Read the user-scope `~/.claude/settings.json` model when no explicit launch/provider model is available.
- Preserve explicit `ANTHROPIC_MODEL` and provider model precedence.
- Treat missing or malformed settings JSON as an unset model and add regression coverage.

## Verification

- `provider-env-precedence.test.ts` (17/17 passing)
- Targeted TypeScript check for `server/src/lib/settings-store.ts`

Closes [MAC-9902](https://multica.macaron.xin/issues/655bc1eb-e301-47ed-aff6-a11b9500c172 "看看这个问题")
