### PR TITLE
avoid stale Claude session runtimes

### DIFF
--- a/server/src/lib/session-store.ts
+++ b/server/src/lib/session-store.ts
@@ -488,7 +488,7 @@ export async function resolveSessionCwd(project: string, sid: string): Promise<s
   const target = `${sid}.jsonl`;
   try {
     const primary = await readSessionSummary(path.join(CLAUDE_PROJECTS, project, target));
-    if (primary?.cwd) return primary.cwd;
+    if (primary?.cwd && (await fs.stat(primary.cwd)).isDirectory()) return primary.cwd;
   } catch { /* fall through to cross-project scan */ }
   try {
     const projectDirs = await fs.readdir(CLAUDE_PROJECTS);
@@ -496,11 +496,15 @@ export async function resolveSessionCwd(project: string, sid: string): Promise<s
       if (dir === project) continue; // already tried
       try {
         const meta = await readSessionSummary(path.join(CLAUDE_PROJECTS, dir, target));
-        if (meta?.cwd) return meta.cwd;
+        if (meta?.cwd && (await fs.stat(meta.cwd)).isDirectory()) return meta.cwd;
       } catch { /* keep looking */ }
     }
   } catch { /* CLAUDE_PROJECTS unreadable — fall through */ }
-  return decodeClaudeProjectName(project) || HOME || '/tmp';
+  const projectCwd = await resolveProjectCwd(project);
+  try {
+    if (projectCwd && (await fs.stat(projectCwd)).isDirectory()) return projectCwd;
+  } catch { /* stale project cwd — use a guaranteed live directory */ }
+  return HOME || '/tmp';
 }
 
 // Resolve a claude project name to its working directory. Prefer the cwd

--- a/server/test/session-store.test.ts
+++ b/server/test/session-store.test.ts
@@ -13,7 +13,7 @@ process.env.HOME = tmpHome;
 process.env.USERPROFILE = tmpHome;
 
 const { CLAUDE_PROJECTS } = await import('../src/config.js');
-const { readSessionMessages, resolveProjectCwd, searchProjectFiles } = await import('../src/lib/session-store.js');
+const { readSessionMessages, resolveProjectCwd, resolveSessionCwd, searchProjectFiles } = await import('../src/lib/session-store.js');
 
 const PROJECT = 'mcc-test';
 const projectDir = path.join(CLAUDE_PROJECTS, PROJECT);
@@ -98,6 +98,12 @@ test('project cwd resolution prefers a live session and otherwise uses the trust
   assert.equal(await resolveProjectCwd(cwdProject, registryCwd), liveCwd);
   await fs.rm(liveCwd, { recursive: true, force: true });
   assert.equal(await resolveProjectCwd(cwdProject, registryCwd), registryCwd);
+});
+
+test('session cwd resolution falls back when the recorded worktree was removed', async () => {
+  const staleCwd = path.join(tmpHome, 'removed-session-worktree');
+  await writeSession('stale-cwd', [{ type: 'user', cwd: staleCwd, message: { role: 'user', content: 'stale' } }]);
+  assert.equal(await resolveSessionCwd(PROJECT, 'stale-cwd'), tmpHome);
 });
 
 test('mention search skips a stale session cwd and uses the live project root', async () => {

--- a/start.sh
+++ b/start.sh
@@ -32,7 +32,7 @@ SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIR="$SRC_DIR"
 _needs_mirror=0
 case "$SRC_DIR" in
-  *"/.codex/plugins/cache/"*|*"/.claude/plugins/cache/"*|*"/.kimi-code/plugins/"*) _needs_mirror=1 ;;
+  *"/plugins/cache/"*|*"/.kimi-code/plugins/"*) _needs_mirror=1 ;;
 esac
 if [ "$_needs_mirror" = 1 ]; then
   # Version key: pull from package.json so parallel major bumps get


### PR DESCRIPTION
## Summary

- recognize plugin caches under custom Claude config directories and mirror them into the stable Macaron runtime
- reject deleted session working directories before spawning the Agent SDK binary
- fall back to a live project directory or home and cover stale worktrees with a regression test

Anthropic's official TypeScript SDK documentation says `@anthropic-ai/claude-agent-sdk` already bundles the matching native Claude Code binary as an optional platform dependency; a separately installed binary via `pathToClaudeCodeExecutable` is only needed when optional dependencies are skipped or the platform is unsupported. Macaron therefore keeps the official bundled-binary flow rather than downloading or selecting binaries itself.

## Verification

- `pnpm --filter @macaron/server test` (106 passed)
- `pnpm --filter @macaron/shared build && pnpm --filter @macaron/server typecheck`
- `bash -n start.sh`

Closes [MAC-9898](https://multica.macaron.xin/issues/cc22400a-3690-4afb-b16c-90f7bfa49a21 "这是个什么错误，客户反馈的")