### PR TITLE
feat: export rendered GenUI as standalone HTML

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,7 @@ import { registerCodexRoutes } from './routes/codex.js';
 import { registerKimiRoutes } from './routes/kimi.js';
 import { registerGitRoutes } from './routes/git.js';
 import { registerShareRoutes } from './routes/share.js';
+import { registerGenuiExportRoutes } from './routes/genui-export.js';
 import { registerSearchRoutes } from './routes/search.js';
 import { isSearchEnabled, syncAll } from './lib/search-index.js';
 import { registerAgentRoutes } from './routes/agents.js';
@@ -167,6 +168,7 @@ await app.register(async (instance) => {
   }
   await registerGitRoutes(instance);
   await registerShareRoutes(instance);
+  await registerGenuiExportRoutes(instance);
   await registerSearchRoutes(instance);
   await registerAgentRoutes(instance);
   await registerScheduleRoutes(instance);

--- a/server/src/routes/genui-export.ts
+++ b/server/src/routes/genui-export.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from 'fastify';
+
+// Building a fully self-contained HTML export means running the same Vite +
+// UnoCSS pipeline the official artifacts site uses to render GenUI — a heavy
+// dependency the shipped server bundle deliberately doesn't carry. So we proxy
+// the official builder (same code path the reference macaron-genui-demo export
+// uses), which SSRs the widget and inlines the display-time importmap shims +
+// UnoCSS CSS into one standalone file. The endpoint has no CORS, hence this
+// same-origin server hop rather than a direct browser fetch.
+const EXPORT_ENDPOINT = process.env.MACARON_GENUI_EXPORT_ENDPOINT || 'https://genui.macaron.im/api/genui-html';
+
+type ExportBody = { code?: string };
+
+export async function registerGenuiExportRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Body: ExportBody }>('/api/genui/export-html', async (req, reply) => {
+    const code = String(req.body?.code || '').trim();
+    if (!code) return reply.status(400).send({ error: 'code required' });
+    let upstream: Response;
+    try {
+      upstream = await fetch(EXPORT_ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code, ssr: true }),
+      });
+    } catch (e) {
+      return reply.status(502).send({ error: `export builder unreachable: ${(e as Error).message}` });
+    }
+    if (!upstream.ok) return reply.status(502).send({ error: `export builder failed (${upstream.status})` });
+    const html = await upstream.text();
+    return reply
+      .header('content-type', 'text/html; charset=utf-8')
+      .header('content-disposition', 'attachment; filename="macaron-genui.html"')
+      .send(html);
+  });
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1678,6 +1678,9 @@ textarea:focus, select:focus, input:focus {
 }
 .ti-genui-codebtn {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   border: none;
   background: transparent;
   color: var(--muted);

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -823,7 +823,7 @@ function GenuiItem({ it, superseded = false }: { it: Extract<Item, { kind: 'genu
         <div className="ti-genui-head">
           <span className="ti-genui-prompt" />
           <button className="ti-genui-codebtn" onClick={onExport} disabled={exporting} title="Export this UI as a standalone HTML file">
-            <Download size={12} aria-hidden="true" style={{ verticalAlign: '-1px', marginRight: 4 }} />
+            <Download size={12} aria-hidden="true" />
             {exporting ? 'Exporting…' : 'Export HTML'}
           </button>
         </div>

--- a/web/src/views/Session.tsx
+++ b/web/src/views/Session.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarkdownCode, MarkdownCodeStreamingProvider, MarkdownPre, loadShikiStreamCodeBlock } from '../components/MarkdownCode';
-import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Bot, Check, ChevronDown, ChevronRight, Circle, CircleDot, ClipboardList, Download, GitBranch, GitFork, Info, Lock, MessageCircle, MoreHorizontal, Paperclip, Plus, RefreshCw, Square, Undo2, X } from 'lucide-react';
 import { useReplay } from '../components/ReplayControls';
 import { sessionToMarkdown } from '@macaron/shared';
 import {
@@ -42,6 +42,7 @@ import {
   easeTowards,
 } from '../lib/thinkingVerbs';
 import { useToast } from '../components/Toast';
+import { authedFetch } from '../lib/auth';
 import { useConfirm } from '../components/Confirm';
 import { useFileMention } from '../components/MentionPopup';
 import { StatusBar, type PermissionMode } from '../components/StatusBar';
@@ -782,6 +783,8 @@ function GenuiItem({ it, superseded = false }: { it: Extract<Item, { kind: 'genu
   // the widget — keep showing the last good frame until fresh code compiles.
   const [lastGoodCode, setLastGoodCode] = useState('');
   const [hasRendered, setHasRendered] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const toast = useToast();
 
   const onRendered = useCallback((rendered: string) => {
     setLastGoodCode(rendered);
@@ -793,10 +796,38 @@ function GenuiItem({ it, superseded = false }: { it: Extract<Item, { kind: 'genu
   const onError = useCallback(() => { /* swallow */ }, []);
 
   const displayCode = code || lastGoodCode;
+  const onExport = useCallback(async () => {
+    if (exporting || !displayCode) return;
+    setExporting(true);
+    try {
+      const resp = await authedFetch('/api/genui/export-html', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code: displayCode }),
+      });
+      if (!resp.ok) throw new Error(`export failed (${resp.status})`);
+      const html = await resp.text();
+      downloadTextFile('macaron-genui.html', html, 'text/html');
+    } catch (e) {
+      toast(`HTML export failed: ${(e as Error).message}`);
+    } finally {
+      setExporting(false);
+    }
+  }, [displayCode, exporting, toast]);
+
   if (!displayCode) return null;
 
   return (
     <div className="ti-genui" data-item-id={it.id}>
+      {hasRendered && !streaming && (
+        <div className="ti-genui-head">
+          <span className="ti-genui-prompt" />
+          <button className="ti-genui-codebtn" onClick={onExport} disabled={exporting} title="Export this UI as a standalone HTML file">
+            <Download size={12} aria-hidden="true" style={{ verticalAlign: '-1px', marginRight: 4 }} />
+            {exporting ? 'Exporting…' : 'Export HTML'}
+          </button>
+        </div>
+      )}
       <div
         data-genui-render-state={hasRendered ? 'ready' : 'pending'}
         aria-hidden={!hasRendered}


### PR DESCRIPTION
## What

Adds an **Export HTML** button to each rendered GenUI item in the Claude chat view. Clicking it downloads a fully self-contained `.html` file that reproduces the widget standalone — opens directly from `file://` with no network dependency.

## How

- `web/src/views/Session.tsx` — `GenuiItem` gains an export button (shown once the widget has rendered and is not streaming). It POSTs the current display code to a same-origin route and triggers a Blob download via the existing `downloadTextFile` helper.
- `server/src/routes/genui-export.ts` — new `POST /api/genui/export-html` route. It proxies the official builder (`https://genui.macaron.im/api/genui-html`, overridable via `MACARON_GENUI_EXPORT_ENDPOINT`), which SSRs the widget and inlines the display-time importmap shims + UnoCSS-generated CSS into one file.

Proxying keeps the heavy Vite + UnoCSS export pipeline out of the shipped server bundle (which carries only `server/dist`) — the same SSR path the reference `macaron-genui-demo` export uses. The official endpoint has no CORS, so a same-origin server hop is required rather than a direct browser fetch.

## Verification

- `pnpm --filter @macaron/server build` and `pnpm --filter @macaron/web build` both pass. (The web `typecheck` has 71 pre-existing `@/components/ui/*` alias errors in vendored `macaron-vendor/`, unrelated to this change and unaffected — the Vite build resolves the alias fine.)
- End-to-end against the built server: `POST /api/genui/export-html` returns `text/html`, 201 KB, **zero** external `<script src=>` and **zero** `esm.sh` references.
- The exported file opens standalone in headless chromium and renders correctly with UnoCSS utilities applied (verified `text-blue-600 font-bold p-6` on a test widget).
