### PR TITLE
Relax custom provider endpoint handling

### DIFF
--- a/server/src/lib/anthropic-endpoint.test.ts
+++ b/server/src/lib/anthropic-endpoint.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { anthropicMessagesUrl } from './anthropic-endpoint.js';
+
+const cases = [
+  ['https://api.example.com', 'https://api.example.com/messages'],
+  ['https://api.example.com/', 'https://api.example.com/messages'],
+  ['https://api.example.com/v1', 'https://api.example.com/v1/messages'],
+  ['https://api.example.com/v1/', 'https://api.example.com/v1/messages'],
+  ['https://api.example.com/v1///', 'https://api.example.com/v1/messages'],
+  ['https://gateway.example.com/anthropic', 'https://gateway.example.com/anthropic/messages'],
+] as const;
+
+for (const [endpoint, expected] of cases) {
+  test(`builds the messages URL from ${endpoint}`, () => {
+    assert.equal(anthropicMessagesUrl(endpoint), expected);
+  });
+}

--- a/server/src/lib/anthropic-endpoint.ts
+++ b/server/src/lib/anthropic-endpoint.ts
@@ -1,0 +1,3 @@
+export function anthropicMessagesUrl(endpoint: string): string {
+  return `${endpoint.replace(/\/+$/, '')}/messages`;
+}

--- a/server/src/routes/relay.ts
+++ b/server/src/routes/relay.ts
@@ -9,7 +9,7 @@
 // We sit in front of the provider:
 //   GET /v1/models             → synthesize list from active provider config
 //   GET /v1/models/<name>      → synthesize a Model object for <name>
-//   POST /v1/messages          → forward to provider.endpoint verbatim,
+//   POST /v1/messages          → append /messages to the provider endpoint,
 //                                streaming the response back byte-by-byte
 //   * everything else          → return an empty {ok:true} 200 so probes
 //                                don't fail (best-effort — most CLI probes
@@ -20,6 +20,7 @@
 // provider is a custom one.
 
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { anthropicMessagesUrl } from '../lib/anthropic-endpoint.js';
 import { readSettings } from '../lib/settings-store.js';
 
 async function findProvider(id: string) {
@@ -116,7 +117,7 @@ export async function registerRelayRoutes(app: FastifyInstance): Promise<void> {
         }
       }
 
-      const upstreamUrl = `${p.endpoint.replace(/\/$/, '')}/messages`;
+      const upstreamUrl = anthropicMessagesUrl(p.endpoint);
       // Forward select client headers (streaming, anthropic-beta, etc.).
       const fwdHeaders: Record<string, string> = {
         'content-type': 'application/json',

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import { anthropicMessagesUrl } from '../lib/anthropic-endpoint.js';
 import {
   deleteSession,
   duplicateSession,
@@ -260,8 +261,7 @@ export async function registerSessionRoutes(app: FastifyInstance, options: Sessi
           'One paragraph, no more than 250 words.',
       });
 
-      const endpoint = provider.endpoint.replace(/\/+$/, '');
-      const url = endpoint.endsWith('/v1') ? `${endpoint}/messages` : `${endpoint}/v1/messages`;
+      const url = anthropicMessagesUrl(provider.endpoint);
       let apiRes: Response;
       try {
         apiRes = await fetch(url, {

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -640,12 +640,12 @@ function ProviderForm({
           id="p-endpoint"
           className="settings-input"
           value={draft.endpoint}
-          placeholder="https://…/v1"
+          placeholder="https://api.example.com/v1"
           spellCheck={false}
           autoCapitalize="off"
           onChange={(e) => onChange({ endpoint: e.target.value })}
         />
-        <p className="settings-hint">Must expose <code>/v1/messages</code>. Claude Code SDK will POST to it.</p>
+        <p className="settings-hint">Requests are sent to <code>Endpoint/messages</code>.</p>
       </div>
       <div className="settings-field">
         <label htmlFor="p-model">Model</label>


### PR DESCRIPTION
## Summary

- preserve the custom provider endpoint exactly as configured
- strip trailing slashes and append only `/messages` for relay and compact requests
- clarify the Settings hint and cover root, `/v1`, custom-path, and trailing-slash inputs

## Verification

- `pnpm --dir server exec node --import tsx --test src/lib/anthropic-endpoint.test.ts` (6/6)
- `pnpm --filter @macaron/server typecheck`
- `pnpm --filter @macaron/web build`
- `git diff --check`

> [!NOTE]
> The full server suite reaches the new tests successfully, then its existing package-isolation cases fail because the packed `server/dist` is missing `config.js`. Web typecheck remains blocked by existing vendored Bun/type-path errors; the production build passes.