### PR TITLE
DirPicker: editable path bar for paste-to-navigate

### DIFF
--- a/web/src/components/DirPicker.tsx
+++ b/web/src/components/DirPicker.tsx
@@ -7,6 +7,7 @@ import { api, type DirListing } from '../lib/api';
 // confirm-backdrop/dialog shell so it inherits the app's modal styling.
 export function DirPicker({ onPick, onClose }: { onPick: (cwd: string) => void; onClose: () => void }) {
   const [listing, setListing] = useState<DirListing | null>(null);
+  const [draft, setDraft] = useState(''); // editable address bar text; synced to the resolved path on every successful browse
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
 
@@ -16,7 +17,7 @@ export function DirPicker({ onPick, onClose }: { onPick: (cwd: string) => void; 
     setListing(null);
     api
       .listDirs(path)
-      .then((d) => setListing(d))
+      .then((d) => { setListing(d); setDraft(d.path); })
       .catch((e) => setError((e as Error).message))
       .finally(() => setLoading(false));
   }, []);
@@ -37,7 +38,16 @@ export function DirPicker({ onPick, onClose }: { onPick: (cwd: string) => void; 
     <div className="confirm-backdrop" onClick={onClose}>
       <div className="confirm-dialog dir-picker" role="dialog" aria-modal="true" aria-label="Choose a folder" onClick={(e) => e.stopPropagation()}>
         <div className="confirm-title">Choose a folder</div>
-        <div className="dir-picker-path" title={cur}>{cur || '…'}</div>
+        <input
+          className="dir-picker-path"
+          value={draft}
+          placeholder="…"
+          title="Paste or type a path, then press Enter"
+          spellCheck={false}
+          aria-label="Folder path"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && draft.trim()) browse(draft.trim()); }}
+        />
         <div className="dir-picker-list">
           {listing?.parent && (
             <button type="button" className="dir-picker-row dir-picker-up" onClick={() => browse(listing.parent!)}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3404,6 +3404,7 @@ textarea:focus, select:focus, input:focus {
 /* ---------- directory picker ---------- */
 .dir-picker { min-width: 420px; max-width: 560px; }
 .dir-picker-path {
+  width: 100%;
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--muted);
@@ -3412,12 +3413,8 @@ textarea:focus, select:focus, input:focus {
   border-radius: 8px;
   padding: 7px 10px;
   margin-bottom: 10px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  direction: rtl; /* keep the tail (deepest folder) visible when truncated */
-  text-align: left;
 }
+.dir-picker-path:focus { color: var(--text); outline: 1px solid var(--accent); border-color: var(--accent); }
 .dir-picker-list {
   height: 300px;
   overflow-y: auto;


### PR DESCRIPTION
## What

The **Choose a folder** dialog (`DirPicker`) showed the current path in a read-only bar, so the only way to reach a deep directory was clicking through folders one by one. The bar is now an editable input: paste or type a path, press Enter, and the picker navigates straight there.

## Changes

- `web/src/components/DirPicker.tsx` — the `.dir-picker-path` div becomes an `<input>` fed by a `draft` state that syncs to the resolved path on every successful browse; Enter browses the typed/pasted value (IME-composition guarded, matching the `NewProjectModal` convention).
- `web/src/styles.css` — drops the div-only truncation tricks (`direction: rtl` ellipsis, etc., which don't apply to inputs), adds `width: 100%` and an accent focus ring.

No server change needed: `GET /api/fs/dirs` already trims, expands `~`, resolves relative paths, and degrades to an empty listing for nonexistent/unreadable paths instead of erroring.

## Verification (browser, production build)

- Paste absolute path → Enter → listing navigates; input syncs to the normalized path; **Use this folder** picks it into the New Project modal's Location.
- `~/projects/gamma` → expands against home correctly.
- Nonexistent path → "No sub-folders here." with the draft preserved for correction (no crash, no 500).
- `tsc` on the web package shows no new errors (the two `macaron-vendor` module-resolution errors predate this change).
