### PR TITLE
Point `pkg.pr.new` install links at `mindverse-ltd/macaron-artifacts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ In a Kimi Code session, install from the GitHub URL, then reload to activate:
 Three independent packages, each self-contained (its own prebuilt server + web bundles) — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Install one, get only that one. Launch any of them in one command, no plugin install needed:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
 `npx` works the same way — bin name = package name for all three:
 
 ```bash
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
 Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://github.com/MindLab-Research/macaron-artifacts/commits/main)). All three accept `--host` / `--port`; run with `--help` for the full list.
@@ -82,7 +82,7 @@ Replace `<sha>` with a commit on `main` (see the [pkg.pr.new builds](https://git
 ```bash
 export ANTHROPIC_BASE_URL='https://mint.macaron.im'
 export ANTHROPIC_AUTH_TOKEN='sk-...'
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha> --model Macaron-V1-Venti
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha> --model Macaron-V1-Venti
 ```
 
 Verify:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,17 +42,17 @@ Three independent packages, each shipping its own prebuilt server + web assets:
 Install none of them; run whichever you want directly:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 ```
 
 `npx` works the same — all three packages have `bin` name == package name:
 
 ```bash
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
 Replace `<sha>` with any commit on `main`. Each launcher just boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run with `--help` for the full flag list.

--- a/mcx/README.md
+++ b/mcx/README.md
@@ -5,7 +5,7 @@ Launcher for the **Macaron Codex WebUI** (ChatGPT-style chat over the Codex SDK)
 Self-contained — ships its own prebuilt server + web bundles, installs nothing from `mcc`. Run without installing:
 
 ```bash
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex → http://localhost:7979
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex → http://localhost:7979
 ```
 
 Accepts `--host` / `--port`; run with `--help` for the full list.

--- a/mkx/README.md
+++ b/mkx/README.md
@@ -5,9 +5,9 @@ Launcher for the **Macaron Kimi Code WebUI** (ChatGPT-style chat over the Kimi C
 Self-contained — ships its own prebuilt server + web bundles, installs nothing from `mcc`. Run without installing:
 
 ```bash
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi → http://localhost:7980
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi → http://localhost:7980
 # or
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>
 ```
 
 Sessions are discovered from `~/.kimi-code/sessions/` (honors `KIMI_CODE_HOME`); provider settings persist to `~/.kimi-code/macaron-kimi-config.json`.

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -55,9 +55,9 @@ export function meta({}: Route.MetaArgs) {
 }
 
 // pkg.pr.new ships prebuilt tarballs per commit; __COMMIT_SHA__ is injected at build time (falls back to `<sha>`).
-const PKG = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@${__COMMIT_SHA__}`;
-const PKG_MCX = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@${__COMMIT_SHA__}`;
-const PKG_MKX = `https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@${__COMMIT_SHA__}`;
+const PKG = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@${__COMMIT_SHA__}`;
+const PKG_MCX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@${__COMMIT_SHA__}`;
+const PKG_MKX = `https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@${__COMMIT_SHA__}`;
 
 export default function Home() {
   return (

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -43,13 +43,13 @@ Then open it in a session with `/macaron:macaron`.
 The published tarball ships the prebuilt server + web bundles as three independent packages — `mcc` (Claude WebUI, port `7878`), `mcx` (Codex WebUI, port `7979`), and `mkx` (Kimi WebUI, port `7980`). Launch any of them in one command:
 
 ```bash
-bunx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
-bunx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
-bunx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
+bunx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>   # Claude → http://localhost:7878
+bunx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>   # Codex  → http://localhost:7979
+bunx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>   # Kimi   → http://localhost:7980
 
-npx mcc@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
-npx mcx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
-npx mkx@https://pkg.pr.new/MindLab-Research/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
+npx mcc@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcc@<sha>    # Claude → http://localhost:7878
+npx mcx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mcx@<sha>    # Codex  → http://localhost:7979
+npx mkx@https://pkg.pr.new/mindverse-ltd/macaron-artifacts/mkx@<sha>    # Kimi   → http://localhost:7980
 ```
 
 The commands are pinned to this build's commit; swap in any other commit on `main` to pull that build. Each launcher boots the same server with `MACARON_ENGINE` set (`codex` / `kimi`; unset = Claude) and its own default port. All bins accept `--host` / `--port`; run `--help` for all flags.


### PR DESCRIPTION
The repo lives at `mindverse-ltd/macaron-artifacts`, but every `bunx` / `npx` install snippet still pointed at `pkg.pr.new/MindLab-Research/macaron-artifacts` — the tarballs are published under the new org, so those commands 404.

Rewrites **only** the self-referencing `pkg.pr.new` paths. Deliberately untouched:

- `pkg.pr.new/MindLab-Research/macaron-genui-demo/*` (`partial-react`, `partial-tsx`, `@genui/diagnostics`, `@genui/cli`) — that repo really is under MindLab-Research.
- `github.com/MindLab-Research/macaron-artifacts` plugin-marketplace / issue / install-script URLs — separate concern, left as is per the issue scope.

Verified against commit f1e98af:

| URL | before | after |
| --- | --- | --- |
| `…/macaron-artifacts/mcc@f1e98af` | 404 | 200 (14 MB tarball) |
| `…/macaron-artifacts/mcx@f1e98af` | 404 | 200 |
| `…/macaron-artifacts/mkx@f1e98af` | 404 | 200 |

`site/app/routes/home.tsx` builds its links from the same template with `__COMMIT_SHA__` injected at build time, so the rendered homepage commands follow automatically.
