### PR TITLE
Add a backend registry with per-tab credentials

### DIFF
--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -42,8 +42,13 @@ export function isApiBaseKnown(): boolean {
   // that REFUSES to answer. Without the API, no hosted binding could ever have been
   // written, so same-origin is provably the target rather than a guess. A present
   // sessionStorage that throws IS a guess, and that is what we refuse to make.
-  if (typeof sessionStorage === 'undefined') return true;
-  try { sessionStorage.getItem(KEY); return true; } catch { return false; }
+  if (typeof sessionStorage === 'undefined') { cached = ''; return true; }
+  // Use getApiBase for the probe so a successful read becomes the exact cached
+  // value used by the ensuing request. Probing and then reading again creates a
+  // TOCTOU window where the probe succeeds, the second read throws, and routing
+  // silently falls back to the hosting origin.
+  getApiBase();
+  return cached !== null;
 }
 
 // Test-only: drop the module cache so the next read hits storage, simulating a
@@ -66,8 +71,7 @@ export function clearApiBase(): void {
 // path; annotating the fetch with targetAddressSpace lets the browser skip the
 // mixed-content pre-check (see server CORS + LNA headers). Best-effort: only
 // loopback literals/names get flagged, everything else is left to normal rules.
-export function isLoopbackBase(): boolean {
-  const b = getApiBase();
+export function isLoopbackBase(b = getApiBase()): boolean {
   if (!b) return false;
   try {
     const h = new URL(b).hostname.replace(/\.$/, '').toLowerCase();
@@ -77,8 +81,7 @@ export function isLoopbackBase(): boolean {
 
 // Retarget an /api or /relay path at the configured server. Absolute URLs and
 // non-API paths pass through untouched.
-export function resolveApiUrl(input: string): string {
-  const base = getApiBase();
+export function resolveApiUrl(input: string, base = getApiBase()): string {
   if (!base) return input;
   if (!input.startsWith('/api') && !input.startsWith('/relay')) return input;
   return base + input;

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -26,9 +26,30 @@ function normalize(raw: string): string {
 
 export function getApiBase(): string {
   if (cached !== null) return cached;
-  try { cached = sessionStorage.getItem(KEY) || ''; } catch { cached = ''; }
+  try { cached = sessionStorage.getItem(KEY) || ''; } catch { return ''; }
   return cached;
 }
+
+// Whether the target is actually KNOWN. A sessionStorage read that throws is not
+// "same-origin" — it's "we can't tell". getApiBase() returns '' in that case (its
+// callers all want a string), so routing a request on that answer would send a
+// hosted tab's call to the local origin instead of the server it is bound to.
+// authedFetch gates on this and fails closed rather than guessing. We do NOT
+// cache the failure: a later successful read resolves the real base.
+export function isApiBaseKnown(): boolean {
+  if (cached !== null) return true;
+  // No storage API at all (SSR / a non-browser host) is not the same as a storage
+  // that REFUSES to answer. Without the API, no hosted binding could ever have been
+  // written, so same-origin is provably the target rather than a guess. A present
+  // sessionStorage that throws IS a guess, and that is what we refuse to make.
+  if (typeof sessionStorage === 'undefined') return true;
+  try { sessionStorage.getItem(KEY); return true; } catch { return false; }
+}
+
+// Test-only: drop the module cache so the next read hits storage, simulating a
+// fresh page load. clearApiBase() can't stand in for this — clearing the base is
+// a real state ('' = same-origin), not the absence of a known state.
+export function __resetCacheForTests(): void { cached = null; }
 
 export function setApiBase(origin: string): void {
   const clean = normalize(origin);

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -4,7 +4,7 @@
 // the browser EventSource), so a single Authorization header covers plain
 // requests and streaming reads alike — no cookie / query-token escape hatch.
 
-import { getApiBase, isLoopbackBase, resolveApiUrl, setApiBase, clearApiBase } from './apiBase';
+import { getApiBase, isApiBaseKnown, isLoopbackBase, resolveApiUrl, setApiBase, clearApiBase } from './apiBase';
 
 // The token is keyed by the server origin it was minted for, so a token bound to
 // server A can never be sent to server B. It lives in sessionStorage — per browser
@@ -34,6 +34,13 @@ export function clearToken(): void {
 // fetch wrapper that injects the token and re-gates the UI on 401 (expired /
 // wrong token). Every call site that hits our own server uses this.
 export async function authedFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  // Fail closed on an unknown target. If the base can't be read we do NOT fall
+  // back to same-origin: a hosted tab bound to a remote server would then send
+  // the request — and its Authorization header — to the docs origin instead.
+  // Only /api and /relay are at risk; everything else is same-origin by design.
+  if (!isApiBaseKnown() && (input.startsWith('/api') || input.startsWith('/relay'))) {
+    throw new Error('macaron: cannot determine the API target (storage unreadable) — refusing to send the request');
+  }
   const headers = new Headers(init.headers);
   const t = getToken();
   if (t) headers.set('Authorization', `Bearer ${t}`);

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -13,14 +13,18 @@ import { getApiBase, isApiBaseKnown, isLoopbackBase, resolveApiUrl, setApiBase, 
 // one. Same-origin (empty base) keeps the historical bare key. See the two-realm
 // and same-server dual-tab regressions.
 const KEY = 'macaron_auth_token';
-function tokenKey(): string { const b = getApiBase(); return b ? `${KEY}::${b}` : KEY; }
+function tokenKey(base = getApiBase()): string { return base ? `${KEY}::${base}` : KEY; }
+
+function readToken(base: string): string {
+  try { return sessionStorage.getItem(tokenKey(base)) || ''; } catch { return ''; }
+}
 
 // sessionStorage key the docs connect page WRITES and we READ once on load.
 // Must stay identical to HANDOFF_KEY in site/app/lib/hosted-target.ts.
 const HANDOFF_KEY = 'macaron_connect_handoff';
 
 export function getToken(): string {
-  try { return sessionStorage.getItem(tokenKey()) || ''; } catch { return ''; }
+  return readToken(getApiBase());
 }
 
 export function setToken(token: string): void {
@@ -41,21 +45,34 @@ export async function authedFetch(input: string, init: RequestInit = {}): Promis
   if (!isApiBaseKnown() && (input.startsWith('/api') || input.startsWith('/relay'))) {
     throw new Error('macaron: cannot determine the API target (storage unreadable) — refusing to send the request');
   }
+  // Capture one immutable {target, token} pair for the whole request. Besides
+  // keeping routing atomic, this lets a late 401 clear the credential that was
+  // actually rejected instead of whichever backend happens to be active then.
+  const base = getApiBase();
   const headers = new Headers(init.headers);
-  const t = getToken();
+  const t = readToken(base);
   if (t) headers.set('Authorization', `Bearer ${t}`);
-  const url = resolveApiUrl(input);
+  const url = resolveApiUrl(input, base);
   const extra: RequestInit = {};
   // Cross-origin hosted mode: the browser needs credentials mode explicit, and
   // loopback targets want the LNA hint so Chrome skips the mixed-content check.
-  if (getApiBase()) {
+  if (base) {
     extra.mode = 'cors';
-    if (isLoopbackBase()) (extra as { targetAddressSpace?: string }).targetAddressSpace = 'loopback';
+    if (isLoopbackBase(base)) (extra as { targetAddressSpace?: string }).targetAddressSpace = 'loopback';
   }
   const resp = await fetch(url, { ...init, ...extra, headers });
   if (resp.status === 401) {
-    clearToken();
-    window.dispatchEvent(new Event('macaron:auth-required'));
+    const key = tokenKey(base);
+    let requestTokenIsCurrent = true;
+    try {
+      requestTokenIsCurrent = (sessionStorage.getItem(key) || '') === t;
+      if (requestTokenIsCurrent) sessionStorage.removeItem(key);
+    } catch { /* storage unavailable: the 401 is still authoritative */ }
+    // A response from an inactive backend (or from a token already replaced by
+    // a newer login) must not re-arm the current backend's auth gate.
+    if (requestTokenIsCurrent && getApiBase() === base) {
+      window.dispatchEvent(new Event('macaron:auth-required'));
+    }
   }
   return resp;
 }

--- a/web/src/lib/backends.ts
+++ b/web/src/lib/backends.ts
@@ -1,0 +1,94 @@
+// The list of headless macaron servers this browser knows about. A "backend" is
+// one such server; picking which one to drive is a pure client concern (like VS
+// Code's remote picker) — the servers are stateless and don't know about each other.
+//
+// WHAT LIVES WHERE is the whole design:
+//
+//   localStorage  — the registry: {id, label, baseUrl}. Non-sensitive, and SHARED
+//                   across tabs on purpose: your list of servers is the same list
+//                   in every tab, and editing it in one tab should show up in the next.
+//   sessionStorage — which backend is ACTIVE (this is apiBase) and its TOKEN (keyed
+//                   by origin in auth.ts). Both are per-tab, so two tabs can drive
+//                   two different servers, and two tabs on the SAME server keep
+//                   their own credentials instead of clobbering each other.
+//
+// No token ever enters this module or localStorage. That is not an incidental
+// detail — it's what lets the registry be a plain shared list with no
+// cross-tab compare-and-swap, no migration tombstones, and no recovery state
+// machine. Credential lifetime is already solved per-tab in auth.ts/apiBase.ts.
+
+import { clearApiBase, getApiBase, setApiBase } from './apiBase';
+
+export type Backend = {
+  id: string;
+  label: string;
+  // '' means same-origin — the built-in local default, served by the server it
+  // talks to. Otherwise an absolute origin like https://box.example.com.
+  baseUrl: string;
+};
+
+export const LOCAL_BACKEND_ID = 'local';
+
+const BACKENDS_KEY = 'macaron_backends';
+
+function localDefault(): Backend {
+  return { id: LOCAL_BACKEND_ID, label: 'Local', baseUrl: '' };
+}
+
+// Normalize one stored entry, rejecting anything malformed. A hand-edited or
+// corrupted registry must not crash the app or produce a `baseUrl` that later
+// throws inside URL parsing — a bad entry is simply dropped.
+function normalize(raw: unknown): Backend | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const { id, label, baseUrl } = raw as Record<string, unknown>;
+  if (typeof id !== 'string' || !id) return null;
+  if (typeof label !== 'string' || typeof baseUrl !== 'string') return null;
+  if (baseUrl) {
+    // Must be an origin, no path — same rule setApiBase enforces, checked here
+    // so a stored value can't smuggle in a reroute that only fails at use time.
+    try { const u = new URL(baseUrl); if (u.origin !== baseUrl) return null; } catch { return null; }
+  }
+  return { id, label, baseUrl };
+}
+
+// Read the registry. A read that throws (private mode) is indistinguishable from
+// an empty one for our purposes: either way we have no user-defined servers to
+// offer, and the built-in local default still works. Unlike a token, losing the
+// list is not a security event — it's a cosmetic one.
+export function loadBackends(): Backend[] {
+  let parsed: unknown = null;
+  try { parsed = JSON.parse(localStorage.getItem(BACKENDS_KEY) || 'null'); } catch { parsed = null; }
+  const stored = Array.isArray(parsed) ? parsed.map(normalize).filter((b): b is Backend => !!b) : [];
+  // The local default is synthetic and always present, so it is never stored and
+  // never duplicated by a stored entry claiming its id.
+  const rest = stored.filter((b) => b.id !== LOCAL_BACKEND_ID);
+  const seen = new Set<string>();
+  return [localDefault(), ...rest.filter((b) => !seen.has(b.id) && seen.add(b.id))];
+}
+
+// Persist the registry, minus the synthetic local default. Best-effort: a failed
+// write (quota / private mode) loses a label edit, not a credential.
+export function saveBackends(list: Backend[]): void {
+  const stored = list.filter((b) => b.id !== LOCAL_BACKEND_ID).map(({ id, label, baseUrl }) => ({ id, label, baseUrl }));
+  try { localStorage.setItem(BACKENDS_KEY, JSON.stringify(stored)); } catch { /* private mode / quota */ }
+}
+
+// Which backend this TAB is driving. Derived from apiBase (sessionStorage) rather
+// than stored separately, so there is exactly one source of truth for where
+// requests go — a second copy could disagree with the one authedFetch actually uses.
+export function getActiveBackend(): Backend {
+  const base = getApiBase();
+  if (!base) return localDefault();
+  return loadBackends().find((b) => b.baseUrl === base) || { id: base, label: base, baseUrl: base };
+}
+
+// Point THIS TAB at a backend. Switching clears nothing: the previous backend's
+// token stays under its own origin key, so switching away and back does not
+// require logging in again, and the new backend's token is whatever was minted
+// for its origin.
+export function activateBackend(id: string): void {
+  const target = loadBackends().find((b) => b.id === id);
+  if (!target) return;
+  if (target.baseUrl) setApiBase(target.baseUrl);
+  else clearApiBase();
+}

--- a/web/test/backends.test.ts
+++ b/web/test/backends.test.ts
@@ -6,11 +6,17 @@ import assert from 'node:assert/strict';
 // modules are imported after the shims are installed.
 class MemStorage {
   private m = new Map<string, string>();
+  private getCount = 0;
   fail = false;
-  getItem(k: string) { if (this.fail) throw new Error('SecurityError'); return this.m.has(k) ? this.m.get(k)! : null; }
+  failAfterSuccessfulGets: number | null = null;
+  getItem(k: string) {
+    if (this.fail || (this.failAfterSuccessfulGets !== null && this.getCount >= this.failAfterSuccessfulGets)) throw new Error('SecurityError');
+    this.getCount++;
+    return this.m.has(k) ? this.m.get(k)! : null;
+  }
   setItem(k: string, v: string) { if (this.fail) throw new Error('SecurityError'); this.m.set(k, v); }
   removeItem(k: string) { if (this.fail) throw new Error('SecurityError'); this.m.delete(k); }
-  clear() { this.m.clear(); }
+  clear() { this.m.clear(); this.getCount = 0; this.failAfterSuccessfulGets = null; }
 }
 const local = new MemStorage();
 const session = new MemStorage();
@@ -20,6 +26,8 @@ const session = new MemStorage();
 const { setApiBase, clearApiBase, getApiBase, __resetCacheForTests } = await import('../src/lib/apiBase');
 const { loadBackends, saveBackends, getActiveBackend, activateBackend, LOCAL_BACKEND_ID } = await import('../src/lib/backends');
 const { authedFetch, getToken, setToken } = await import('../src/lib/auth');
+
+if (typeof window === 'undefined') (globalThis as unknown as { window: EventTarget }).window = new EventTarget();
 
 beforeEach(() => {
   local.clear(); session.clear();
@@ -126,13 +134,24 @@ test('an unwritable registry loses the edit but does not throw', () => {
   assert.doesNotThrow(() => saveBackends([BOX]));
 });
 
-test('FAIL-CLOSED: an unreadable api base refuses to send an /api request', async () => {
+test('FAIL-CLOSED: an unreadable api base refuses to send /api and /relay requests', async () => {
   session.setItem('macaron_api_base', BOX.baseUrl);
   __resetCacheForTests();       // fresh page load: the base is not yet cached
   session.fail = true;
   // Without the guard this would resolve to a same-origin '/api/...' fetch,
   // sending a request meant for the remote server to the hosting origin.
   await assert.rejects(() => authedFetch('/api/workspaces'), /cannot determine the API target/);
+  await assert.rejects(() => authedFetch('/relay/session'), /cannot determine the API target/);
+});
+
+test('routing reuses the guard read if storage fails immediately afterward', async () => {
+  session.setItem('macaron_api_base', BOX.baseUrl);
+  __resetCacheForTests();
+  session.failAfterSuccessfulGets = 1;
+  let seen = '';
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (u: string) => { seen = u; return new Response('{}'); }) as never;
+  await authedFetch('/api/x');
+  assert.equal(seen, `${BOX.baseUrl}/api/x`, 'a second target read must not fall back to the hosting origin');
 });
 
 test('a readable api base still routes normally after a transient failure', async () => {
@@ -146,4 +165,29 @@ test('a readable api base still routes normally after a transient failure', asyn
   (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (u: string) => { seen = u; return new Response('{}'); }) as never;
   await authedFetch('/api/x');
   assert.equal(seen, `${BOX.baseUrl}/api/x`);
+});
+
+test('a late 401 only clears the backend and token used by that request', async () => {
+  const OTHER = { id: 'other', label: 'Other', baseUrl: 'https://other.example.com' };
+  saveBackends([...loadBackends(), BOX, OTHER]);
+  activateBackend('box');
+  setToken('TOKEN_BOX');
+
+  let finish!: (response: Response) => void;
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = (() => new Promise<Response>((resolve) => { finish = resolve; })) as never;
+  let authRequired = 0;
+  const onAuthRequired = () => { authRequired++; };
+  window.addEventListener('macaron:auth-required', onAuthRequired);
+  const pending = authedFetch('/api/x');
+
+  activateBackend('other');
+  setToken('TOKEN_OTHER');
+  finish(new Response('{}', { status: 401 }));
+  await pending;
+
+  assert.equal(getToken(), 'TOKEN_OTHER', 'the current backend token must survive an old request');
+  assert.equal(authRequired, 0, 'an inactive backend must not re-arm the current backend auth gate');
+  activateBackend('box');
+  assert.equal(getToken(), '', 'the rejected request token must be cleared from its own backend');
+  window.removeEventListener('macaron:auth-required', onAuthRequired);
 });

--- a/web/test/backends.test.ts
+++ b/web/test/backends.test.ts
@@ -1,0 +1,149 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// jsdom-free storage shims. `fail` makes every operation throw, standing in for
+// private mode / a disabled-storage profile. apiBase caches on read, so the
+// modules are imported after the shims are installed.
+class MemStorage {
+  private m = new Map<string, string>();
+  fail = false;
+  getItem(k: string) { if (this.fail) throw new Error('SecurityError'); return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string) { if (this.fail) throw new Error('SecurityError'); this.m.set(k, v); }
+  removeItem(k: string) { if (this.fail) throw new Error('SecurityError'); this.m.delete(k); }
+  clear() { this.m.clear(); }
+}
+const local = new MemStorage();
+const session = new MemStorage();
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = local;
+(globalThis as unknown as { sessionStorage: MemStorage }).sessionStorage = session;
+
+const { setApiBase, clearApiBase, getApiBase, __resetCacheForTests } = await import('../src/lib/apiBase');
+const { loadBackends, saveBackends, getActiveBackend, activateBackend, LOCAL_BACKEND_ID } = await import('../src/lib/backends');
+const { authedFetch, getToken, setToken } = await import('../src/lib/auth');
+
+beforeEach(() => {
+  local.clear(); session.clear();
+  local.fail = false; session.fail = false;
+  clearApiBase();
+});
+
+const BOX: { id: string; label: string; baseUrl: string } = { id: 'box', label: 'Box', baseUrl: 'https://box.example.com' };
+
+// --- registry: the shared, non-sensitive part ---
+
+test('a fresh profile has exactly the built-in local backend', () => {
+  const list = loadBackends();
+  assert.deepEqual(list, [{ id: LOCAL_BACKEND_ID, label: 'Local', baseUrl: '' }]);
+});
+
+test('saved backends round-trip and keep the local default first', () => {
+  saveBackends([...loadBackends(), BOX]);
+  const list = loadBackends();
+  assert.equal(list.length, 2);
+  assert.equal(list[0].id, LOCAL_BACKEND_ID);
+  assert.deepEqual(list[1], BOX);
+});
+
+test('the registry NEVER contains a token, even if one is handed to it', () => {
+  saveBackends([...loadBackends(), { ...BOX, token: 'SECRET' } as never]);
+  const raw = local.getItem('macaron_backends')!;
+  assert.ok(!raw.includes('SECRET'), `token leaked into localStorage: ${raw}`);
+  assert.deepEqual(loadBackends()[1], BOX);
+});
+
+test('the synthetic local default is not persisted and cannot be duplicated', () => {
+  saveBackends([{ id: LOCAL_BACKEND_ID, label: 'Impostor', baseUrl: 'https://evil.test' }, BOX]);
+  assert.equal(local.getItem('macaron_backends'), JSON.stringify([BOX]));
+  const list = loadBackends();
+  assert.equal(list.filter((b) => b.id === LOCAL_BACKEND_ID).length, 1);
+  assert.equal(list[0].baseUrl, ''); // the real local default, not the stored impostor
+});
+
+test('malformed entries are dropped instead of crashing or rerouting', () => {
+  local.setItem('macaron_backends', JSON.stringify([null, {}, { id: 'a' }, { id: 'b', label: 'B', baseUrl: 'https://ok.test/deep/path' }, BOX]));
+  assert.deepEqual(loadBackends(), [{ id: LOCAL_BACKEND_ID, label: 'Local', baseUrl: '' }, BOX]);
+});
+
+test('a corrupt registry degrades to the local default', () => {
+  local.setItem('macaron_backends', '{not json');
+  assert.deepEqual(loadBackends(), [{ id: LOCAL_BACKEND_ID, label: 'Local', baseUrl: '' }]);
+});
+
+// --- per-tab activation ---
+
+test('activating a backend retargets this tab; local reverts to same-origin', () => {
+  saveBackends([...loadBackends(), BOX]);
+  activateBackend('box');
+  assert.equal(getApiBase(), BOX.baseUrl);
+  assert.equal(getActiveBackend().id, 'box');
+  activateBackend(LOCAL_BACKEND_ID);
+  assert.equal(getApiBase(), '');
+  assert.equal(getActiveBackend().id, LOCAL_BACKEND_ID);
+});
+
+test('the active backend is per-tab: it is never written to shared localStorage', () => {
+  saveBackends([...loadBackends(), BOX]);
+  activateBackend('box');
+  const shared = local.getItem('macaron_backends')!;
+  assert.ok(!shared.includes('active'), `active target leaked into localStorage: ${shared}`);
+  assert.equal(session.getItem('macaron_api_base'), BOX.baseUrl);
+});
+
+// --- tab isolation: the reason tokens stay in sessionStorage ---
+
+test('two tabs on the SAME backend keep their own token', () => {
+  saveBackends([...loadBackends(), BOX]);
+  activateBackend('box');
+  setToken('TOKEN_TAB_A');
+  // A second tab shares localStorage (the registry) but not sessionStorage.
+  assert.equal(local.getItem(`macaron_auth_token::${BOX.baseUrl}`), null);
+  assert.equal(session.getItem(`macaron_auth_token::${BOX.baseUrl}`), 'TOKEN_TAB_A');
+});
+
+test('switching backends and back does not leak or lose either token', () => {
+  const OTHER = { id: 'other', label: 'Other', baseUrl: 'https://other.example.com' };
+  saveBackends([...loadBackends(), BOX, OTHER]);
+  activateBackend('box');
+  setToken('TOKEN_BOX');
+  activateBackend('other');
+  assert.equal(getToken(), '', 'box token must not be readable while other is active');
+  setToken('TOKEN_OTHER');
+  activateBackend('box');
+  assert.equal(getToken(), 'TOKEN_BOX', 'switching back must not require logging in again');
+  activateBackend('other');
+  assert.equal(getToken(), 'TOKEN_OTHER');
+});
+
+// --- storage exceptions ---
+
+test('an unreadable registry still yields a working local backend', () => {
+  local.fail = true;
+  assert.deepEqual(loadBackends(), [{ id: LOCAL_BACKEND_ID, label: 'Local', baseUrl: '' }]);
+});
+
+test('an unwritable registry loses the edit but does not throw', () => {
+  local.fail = true;
+  assert.doesNotThrow(() => saveBackends([BOX]));
+});
+
+test('FAIL-CLOSED: an unreadable api base refuses to send an /api request', async () => {
+  session.setItem('macaron_api_base', BOX.baseUrl);
+  __resetCacheForTests();       // fresh page load: the base is not yet cached
+  session.fail = true;
+  // Without the guard this would resolve to a same-origin '/api/...' fetch,
+  // sending a request meant for the remote server to the hosting origin.
+  await assert.rejects(() => authedFetch('/api/workspaces'), /cannot determine the API target/);
+});
+
+test('a readable api base still routes normally after a transient failure', async () => {
+  session.setItem('macaron_api_base', BOX.baseUrl);
+  __resetCacheForTests();
+  session.fail = true;
+  await assert.rejects(() => authedFetch('/api/x'));
+  session.fail = false;         // storage recovers — the failure must not be cached
+  __resetCacheForTests();
+  let seen = '';
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (u: string) => { seen = u; return new Response('{}'); }) as never;
+  await authedFetch('/api/x');
+  assert.equal(seen, `${BOX.baseUrl}/api/x`);
+});


### PR DESCRIPTION
## What & why

Reopens the multi-backend split ([MAC-8578](https://multica.macaron.xin/issues/dbe39a11-91be-4755-9c9f-3a644dcf0056 "评估 macaron-claude-code hosted 版方案")) from #146, rebuilt on `main`'s credential model instead of against it.

A "backend" is one headless macaron server the UI can drive. #146 kept the whole registry — **tokens included** — in `localStorage`, which reverted the per-tab isolation [`5ad2c37`](https://github.com/mindverse-ltd/macaron-artifacts/commit/5ad2c3743b80b0e99fa90da829efc4184bee5c72) had just landed. This PR keeps credentials exactly where `main` put them.

## What lives where

| | storage | shared across tabs? |
| :-- | :-- | :-- |
| registry — `{id, label, baseUrl}` | `localStorage` | **yes, on purpose** — your server list is the same list in every tab |
| active target (`apiBase`) | `sessionStorage` | no — two tabs can drive two servers |
| token (`macaron_auth_token::<origin>`) | `sessionStorage` | no — two tabs on the *same* server keep their own |

No token enters `backends.ts` or `localStorage`. That isn't incidental — it's what lets the registry be a plain shared list. Because credential lifetime is already solved per-tab in `auth.ts`/`apiBase.ts`, none of #146's migration tombstones, intent queue or cross-tab CAS recovery machinery is needed: `backends.ts` is **94 lines instead of 642**, and the four blockers from that PR's last review round don't have a place to occur.

`saveBackends()` strips any extra field it's handed, so a token can't reach shared storage even by mistake — asserted by a test.

## Routing now fails closed

https://github.com/mindverse-ltd/macaron-artifacts/blob/f88916c24704e40d2a1f035a5a1e7ff69213a03d/web/src/lib/apiBase.ts#L27-L31

`getApiBase()` previously cached `''` when the read *threw*, making "storage refused to answer" indistinguishable from "same-origin". A hosted tab bound to a remote server would then send the request — and its `Authorization` header — to the docs origin. This was #146's cold-routing blocker, and it exists on `main` today.

`isApiBaseKnown()` separates the two, and `authedFetch` refuses to send `/api` / `/relay` on an unknown target rather than guessing. A missing storage API (SSR / non-browser host) is *not* unknown: no hosted binding could ever have been written, so same-origin is provable there. The failure isn't cached — a later successful read resolves the real base.

## Out of scope

Switcher UI and health probing, as before. This is the data model plus the routing guard.

## Tests

14 new tests in `web/test/backends.test.ts` covering the registry (round-trip, the synthetic local default, malformed/corrupt input, token-leak), per-tab activation, tab isolation (switch away and back loses neither token), and storage exceptions including the fail-closed path and recovery after a transient failure.

- `pnpm --filter @macaron/web test` — **94/94** (80 pre-existing + 14 new)
- `pnpm build:web` — passes
- `typecheck` — **0 new errors**; the 78 reported are the pre-existing `src/macaron-vendor/` baseline, verified identical to `main`
- the fail-closed guard was mutation-tested: stubbing the check out makes exactly that test fail, so it's load-bearing rather than decorative

Closes #146.
