### PR TITLE
Adopt the `ANTHROPIC_BASE_URL` contract for provider endpoints, and stop relaying a stale `content-encoding`

### DIFF
--- a/server/src/lib/anthropic-endpoint.test.ts
+++ b/server/src/lib/anthropic-endpoint.test.ts
@@ -3,12 +3,13 @@ import test from 'node:test';
 import { anthropicMessagesUrl } from './anthropic-endpoint.js';
 
 const cases = [
-  ['https://api.example.com', 'https://api.example.com/messages'],
-  ['https://api.example.com/', 'https://api.example.com/messages'],
+  ['https://api.example.com', 'https://api.example.com/v1/messages'],
+  ['https://api.example.com/', 'https://api.example.com/v1/messages'],
+  ['  https://api.example.com  ', 'https://api.example.com/v1/messages'],
   ['https://api.example.com/v1', 'https://api.example.com/v1/messages'],
   ['https://api.example.com/v1/', 'https://api.example.com/v1/messages'],
   ['https://api.example.com/v1///', 'https://api.example.com/v1/messages'],
-  ['https://gateway.example.com/anthropic', 'https://gateway.example.com/anthropic/messages'],
+  ['https://gateway.example.com/anthropic', 'https://gateway.example.com/anthropic/v1/messages'],
 ] as const;
 
 for (const [endpoint, expected] of cases) {

--- a/server/src/lib/anthropic-endpoint.ts
+++ b/server/src/lib/anthropic-endpoint.ts
@@ -1,3 +1,14 @@
+// Canonical provider endpoint = the Anthropic *base* URL, WITHOUT `/v1` —
+// same contract as ANTHROPIC_BASE_URL, where the SDK appends `/v1/messages`.
+// Users paste both forms (env snippets ship the bare host, docs pages often
+// show `.../v1`), so we strip a trailing `/v1` on the way in and add it back
+// when building a request URL. Without this, a bare host hits `/messages`,
+// which on an SPA-fronted gateway returns the index.html with HTTP 200 and
+// the CLI reports "empty or malformed response".
+export function normalizeAnthropicBase(endpoint: string): string {
+  return endpoint.trim().replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
 export function anthropicMessagesUrl(endpoint: string): string {
-  return `${endpoint.replace(/\/+$/, '')}/messages`;
+  return `${normalizeAnthropicBase(endpoint)}/v1/messages`;
 }

--- a/server/src/lib/provider-probe.test.ts
+++ b/server/src/lib/provider-probe.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import { probeProvider } from './provider-probe.js';
+
+// Boots a throwaway HTTP server that answers whatever the case needs, so the
+// probe's classification logic is exercised without touching a real provider.
+async function withServer(
+  handler: http.RequestListener,
+  run: (base: string) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer(handler);
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address() as { port: number };
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+test('reports ok on a well-formed message response', async () => {
+  await withServer(
+    (req, res) => {
+      assert.equal(req.url, '/v1/messages');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'message', model: 'test-model', content: [] }));
+    },
+    async (base) => {
+      const r = await probeProvider({ endpoint: base, model: 'test-model', apiKey: 'k' });
+      assert.equal(r.ok, true);
+      assert.equal(r.url, `${base}/v1/messages`);
+      assert.match(r.detail!, /test-model/);
+    },
+  );
+});
+
+test('flags an SPA index.html served with HTTP 200', async () => {
+  await withServer(
+    (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<!doctype html><html></html>');
+    },
+    async (base) => {
+      const r = await probeProvider({ endpoint: base, model: 'm', apiKey: 'k' });
+      assert.equal(r.ok, false);
+      assert.match(r.detail!, /web page/);
+    },
+  );
+});
+
+test('names an auth failure', async () => {
+  await withServer(
+    (_req, res) => {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'nope' }));
+    },
+    async (base) => {
+      const r = await probeProvider({ endpoint: base, model: 'm', apiKey: 'bad' });
+      assert.equal(r.ok, false);
+      assert.equal(r.status, 401);
+      assert.match(r.detail!, /API key rejected/);
+    },
+  );
+});
+
+test('surfaces an unreachable endpoint', async () => {
+  const r = await probeProvider({ endpoint: 'http://127.0.0.1:1', model: 'm', apiKey: 'k' });
+  assert.equal(r.ok, false);
+  assert.match(r.detail!, /could not reach/);
+});

--- a/server/src/lib/provider-probe.ts
+++ b/server/src/lib/provider-probe.ts
@@ -1,0 +1,91 @@
+// One-shot connectivity probe for a provider's endpoint/model/key, run from
+// the Settings form before the user commits the row. Deliberately minimal:
+// a non-streaming 1-token completion is the cheapest call that exercises the
+// full path (DNS → TLS → auth → model routing) end to end.
+//
+// The failure we most want to name is the silent one: an SPA-fronted gateway
+// answers an unknown path with its index.html and HTTP 200, so the CLI later
+// reports a useless "empty or malformed response". Sniffing the body for HTML
+// turns that into "this looks like a web page, check the endpoint".
+
+import { anthropicMessagesUrl } from './anthropic-endpoint.js';
+
+export type ProviderProbe = {
+  ok: boolean;
+  url: string;
+  status?: number;
+  latencyMs: number;
+  detail?: string;
+};
+
+const TIMEOUT_MS = 20_000;
+
+export async function probeProvider(input: {
+  endpoint: string;
+  model: string;
+  apiKey: string;
+}): Promise<ProviderProbe> {
+  const url = anthropicMessagesUrl(input.endpoint);
+  const started = Date.now();
+  const done = (r: Omit<ProviderProbe, 'url' | 'latencyMs'>): ProviderProbe => ({
+    ...r,
+    url,
+    latencyMs: Date.now() - started,
+  });
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${input.apiKey}`,
+        'x-api-key': input.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: input.model,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+  } catch (e) {
+    const err = e as Error;
+    const timedOut = err.name === 'TimeoutError' || err.name === 'AbortError';
+    return done({
+      ok: false,
+      detail: timedOut ? `no response within ${TIMEOUT_MS / 1000}s` : `could not reach the endpoint — ${err.message}`,
+    });
+  }
+
+  const text = await res.text().catch(() => '');
+  if (!res.ok) {
+    const hint = res.status === 401 || res.status === 403 ? 'API key rejected' : res.status === 404 ? 'endpoint not found' : `HTTP ${res.status}`;
+    return done({ ok: false, status: res.status, detail: `${hint} — ${firstLine(text)}` });
+  }
+  if (/^\s*</.test(text)) {
+    return done({
+      ok: false,
+      status: res.status,
+      detail: 'the endpoint answered with a web page, not an API response — check the URL',
+    });
+  }
+  let json: { type?: string; model?: string; error?: { message?: string } } | null = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return done({ ok: false, status: res.status, detail: `unreadable response — ${firstLine(text)}` });
+  }
+  if (json?.type === 'error') {
+    return done({ ok: false, status: res.status, detail: json.error?.message || 'provider returned an error' });
+  }
+  if (json?.type !== 'message') {
+    return done({ ok: false, status: res.status, detail: `unexpected response shape — ${firstLine(text)}` });
+  }
+  return done({ ok: true, status: res.status, detail: `replied as ${json.model || input.model}` });
+}
+
+function firstLine(body: string): string {
+  return body.replace(/\s+/g, ' ').trim().slice(0, 200) || '(empty body)';
+}

--- a/server/src/lib/settings-store.ts
+++ b/server/src/lib/settings-store.ts
@@ -13,6 +13,7 @@ import { randomUUID, createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { HOME, HOST, PORT, MACARON_API_BASE, MACARON_API_KEY, MACARON_MODEL } from '../config.js';
+import { normalizeAnthropicBase } from './anthropic-endpoint.js';
 
 // The built-in pass-through provider. Never touches the SDK subprocess env —
 // it inherits process.env unchanged. Whatever ANTHROPIC_BASE_URL /
@@ -211,7 +212,7 @@ function sanitizeProvider(p: CustomProvider): CustomProvider {
   return {
     id: String(p.id || randomUUID()),
     name: String(p.name || '').trim() || 'Unnamed provider',
-    endpoint: String(p.endpoint || '').trim(),
+    endpoint: normalizeAnthropicBase(String(p.endpoint || '')),
     model: String(p.model || '').trim(),
     apiKey: String(p.apiKey || ''),
   };
@@ -373,7 +374,7 @@ export async function seedProviderFromEnv(): Promise<
   if (/^(1|true|yes)$/i.test(process.env.MACARON_DISABLE_ENV_PROVIDER_SEED || '')) {
     return { seeded: false, reason: 'disabled' };
   }
-  const endpoint = (process.env.MACARON_PROVIDER_ENDPOINT || process.env.ANTHROPIC_BASE_URL || '').trim();
+  const endpoint = normalizeAnthropicBase(process.env.MACARON_PROVIDER_ENDPOINT || process.env.ANTHROPIC_BASE_URL || '');
   const token = (process.env.MACARON_PROVIDER_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN || process.env.ANTHROPIC_API_KEY || '').trim();
   if (!endpoint || !token) return { seeded: false, reason: 'missing-env' };
   const model = (process.env.MACARON_PROVIDER_MODEL || process.env.ANTHROPIC_MODEL || 'macaron-v1-venti').trim();

--- a/server/src/routes/relay.ts
+++ b/server/src/routes/relay.ts
@@ -148,7 +148,10 @@ export async function registerRelayRoutes(app: FastifyInstance): Promise<void> {
       const rawHeaders: Record<string, string> = {};
       upstream.headers.forEach((v, k) => {
         const lk = k.toLowerCase();
-        if (lk === 'content-length' || lk === 'transfer-encoding' || lk === 'connection') return;
+        // `fetch` already decoded the body, so passing the upstream
+        // content-encoding through makes the CLI try to brotli/gzip-decode
+        // plaintext SSE — it then stalls forever with a decompression error.
+        if (lk === 'content-length' || lk === 'content-encoding' || lk === 'transfer-encoding' || lk === 'connection') return;
         rawHeaders[k] = v;
       });
       reply.raw.writeHead(upstream.status, rawHeaders);
@@ -178,7 +181,7 @@ export async function registerRelayRoutes(app: FastifyInstance): Promise<void> {
   // permissions, telemetry). Return a bland 200 so probes don't kill the
   // session. Provider-specific POSTs that need real behavior will still
   // fail visibly if they matter; startup checks won't.
-  const stub = async (req: FastifyRequest, reply: FastifyReply) => {
+  const stub = async (_req: FastifyRequest, reply: FastifyReply) => {
     return reply.send({});
   };
   app.get('/relay/anthropic/:providerId/v1/*', stub);

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from 'fastify';
+import { probeProvider } from '../lib/provider-probe.js';
 import {
+  readSettings,
   readPublicSettings,
   addProvider,
   updateProvider,
@@ -13,6 +15,7 @@ import {
 type AddBody = { name?: string; endpoint?: string; model?: string; apiKey?: string };
 type UpdateBody = { name?: string; endpoint?: string; model?: string; apiKey?: string };
 type ActiveBody = { providerId?: string };
+type TestBody = { id?: string; endpoint?: string; model?: string; apiKey?: string };
 type PermissionModeBody = { mode?: DefaultPermissionMode };
 type FollowupsBody = { enabled?: boolean };
 
@@ -61,6 +64,23 @@ export async function registerSettingsRoutes(app: FastifyInstance): Promise<void
       }
     },
   );
+
+  // Smoke test a provider draft before it's saved. `id` lets the form probe an
+  // existing row whose key the client never sees ("leave blank to keep").
+  app.post<{ Body: TestBody }>('/api/settings/providers/test', async (req, reply) => {
+    const b = req.body || {};
+    const endpoint = String(b.endpoint || '').trim();
+    const model = String(b.model || '').trim();
+    let apiKey = String(b.apiKey || '');
+    if (!endpoint) return reply.status(400).send({ error: 'endpoint required' });
+    if (!model) return reply.status(400).send({ error: 'model required' });
+    if (!apiKey && b.id) {
+      const s = await readSettings();
+      apiKey = s.customProviders.find((p) => p.id === b.id)?.apiKey || '';
+    }
+    if (!apiKey) return reply.status(400).send({ error: 'API key required' });
+    return await probeProvider({ endpoint, model, apiKey });
+  });
 
   app.delete<{ Params: { id: string } }>(
     '/api/settings/providers/:id',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -152,6 +152,14 @@ export type ProviderInput = {
   apiKey?: string;
 };
 
+export type ProviderProbe = {
+  ok: boolean;
+  url: string;
+  status?: number;
+  latencyMs: number;
+  detail?: string;
+};
+
 export type AgentInput = {
   name: string;
   description: string;
@@ -211,6 +219,12 @@ export const api = {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
+    }),
+  testProvider: (input: Partial<ProviderInput> & { id?: string }) =>
+    req<ProviderProbe>('/api/settings/providers/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
     }),
   deleteProvider: (id: string) =>
     req<PublicSettings>(`/api/settings/providers/${encodeURIComponent(id)}`, {

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { api, type PublicSettings, type PublicCustomProvider, type ProviderInput, type TunnelProvider, type TunnelState, type ConfigFileMeta, type DefaultPermissionMode } from '../lib/api';
+import { api, type PublicSettings, type PublicCustomProvider, type ProviderInput, type ProviderProbe, type TunnelProvider, type TunnelState, type ConfigFileMeta, type DefaultPermissionMode } from '../lib/api';
 import { useToast } from '../components/Toast';
 import { useConfirm } from '../components/Confirm';
 import { useTheme, setTheme, type Theme } from '../lib/theme';
@@ -353,6 +353,7 @@ export function Settings() {
               </h3>
               <ProviderForm
                 draft={editing.draft}
+                providerId={editing.id}
                 existingConfigured={editing.existingConfigured}
                 isNew={editing.id === null}
                 onChange={(patch) =>
@@ -612,16 +613,47 @@ export function RemoteAccess() {
 
 function ProviderForm({
   draft,
+  providerId,
   existingConfigured,
   isNew,
   onChange,
 }: {
   draft: ProviderInput;
+  providerId: string | null;
   existingConfigured: boolean;
   isNew: boolean;
   onChange: (patch: Partial<ProviderInput>) => void;
 }) {
   const [showKey, setShowKey] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [probe, setProbe] = useState<ProviderProbe | null>(null);
+  // Any edit invalidates the previous verdict — a stale green tick next to a
+  // freshly-changed endpoint is worse than no tick at all.
+  const edit = (patch: Partial<ProviderInput>) => {
+    setProbe(null);
+    onChange(patch);
+  };
+  const runTest = async () => {
+    setTesting(true);
+    setProbe(null);
+    try {
+      setProbe(
+        await api.testProvider({
+          id: providerId || undefined,
+          endpoint: draft.endpoint.trim(),
+          model: draft.model.trim(),
+          apiKey: (draft.apiKey || '').trim(),
+        }),
+      );
+    } catch (e) {
+      setProbe({ ok: false, url: '', latencyMs: 0, detail: (e as Error).message });
+    } finally {
+      setTesting(false);
+    }
+  };
+  const canTest =
+    Boolean(draft.endpoint.trim() && draft.model.trim()) &&
+    Boolean((draft.apiKey || '').trim() || existingConfigured);
   return (
     <>
       <div className="settings-field">
@@ -631,7 +663,7 @@ function ProviderForm({
           className="settings-input"
           value={draft.name}
           placeholder="e.g. Macaron, OpenRouter, My server"
-          onChange={(e) => onChange({ name: e.target.value })}
+          onChange={(e) => edit({ name: e.target.value })}
         />
       </div>
       <div className="settings-field">
@@ -640,12 +672,12 @@ function ProviderForm({
           id="p-endpoint"
           className="settings-input"
           value={draft.endpoint}
-          placeholder="https://api.example.com/v1"
+          placeholder="https://api.example.com"
           spellCheck={false}
           autoCapitalize="off"
-          onChange={(e) => onChange({ endpoint: e.target.value })}
+          onChange={(e) => edit({ endpoint: e.target.value })}
         />
-        <p className="settings-hint">Requests are sent to <code>Endpoint/messages</code>.</p>
+        <p className="settings-hint">Base URL only — requests go to <code>Endpoint/v1/messages</code>. A trailing <code>/v1</code> is fine, we strip it.</p>
       </div>
       <div className="settings-field">
         <label htmlFor="p-model">Model</label>
@@ -654,7 +686,7 @@ function ProviderForm({
           className="settings-input"
           value={draft.model}
           placeholder="e.g. provider-model-id"
-          onChange={(e) => onChange({ model: e.target.value })}
+          onChange={(e) => edit({ model: e.target.value })}
         />
       </div>
       <div className="settings-field">
@@ -668,7 +700,7 @@ function ProviderForm({
             placeholder={existingConfigured ? '••••••••  (saved — leave blank to keep)' : 'Paste your API key'}
             autoComplete="off"
             spellCheck={false}
-            onChange={(e) => onChange({ apiKey: e.target.value })}
+            onChange={(e) => edit({ apiKey: e.target.value })}
           />
           <button
             type="button"
@@ -686,6 +718,19 @@ function ProviderForm({
         ) : (
           <p className="settings-hint">No key on file yet.</p>
         )}
+      </div>
+      <div className="settings-field">
+        <div className="settings-input-row">
+          <button type="button" className="ghost small" onClick={runTest} disabled={testing || !canTest}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </button>
+          {probe && (
+            <span className={`settings-hint ${probe.ok ? 'ok' : 'bad'}`}>
+              {probe.ok ? `✓ ${probe.detail} (${(probe.latencyMs / 1000).toFixed(1)}s)` : `✕ ${probe.detail}`}
+            </span>
+          )}
+        </div>
+        <p className="settings-hint">Sends one 1-token message to check the endpoint, key and model.</p>
       </div>
     </>
   );


### PR DESCRIPTION
## What & why

Two bugs surfaced while driving a custom provider from the WebUI, plus the check that would have caught both at configure time.

### 1. The endpoint had to end in `/v1` — but nothing said so

#183 settled on "send to `Endpoint/messages`, verbatim". That silently requires the user to type the `/v1` themselves, and the env-seeded path (`seedProviderFromEnv`) reads `ANTHROPIC_BASE_URL`, whose whole convention is that the *SDK* appends `/v1/messages`. So a perfectly valid `ANTHROPIC_BASE_URL=https://mintcn.macaron.xin` got turned into a request for `/messages`:

```
POST https://mintcn.macaron.xin/messages    → 200  <!doctype html> …
POST https://mintcn.macaron.xin/v1/messages → 200  event: message_start …
```

The gateway is SPA-fronted, so the unknown path returns `index.html` with **HTTP 200** — and the CLI reports `API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request`, which points nowhere near the actual cause.

This PR adopts the `ANTHROPIC_BASE_URL` contract wholesale: **the stored endpoint is the bare base, no `/v1`**, and `anthropicMessagesUrl` appends `/v1/messages`. A pasted trailing `/v1` is stripped at the ingest chokepoint (`sanitizeProvider`), which every write path — add, update, env-seed — already flows through, so existing configs normalise themselves on next load. `seedProviderFromEnv` normalises before hashing its deterministic id too, so the same gateway with and without `/v1` can't produce two rows.

### 2. The relay handed back `content-encoding: br` on an already-decoded body

`fetch` transparently decodes the upstream response, but https://github.com/mindverse-ltd/macaron-artifacts/blob/535f7e37fc6fcfcf2ffff8d80bc332c340866ce0/server/src/routes/relay.ts#L148-L153 mirrored every upstream header except `content-length` — so the CLI was told to brotli-decode plaintext SSE:

```
$ ANTHROPIC_BASE_URL=…/relay/anthropic/<id> claude -p "say hi"
Decompression error: BrotliDecompressionError
Hi! 👋 How can I help you today?
```

`claude -p` limps through it; the WebUI's streaming consumer just waits forever for a frame that never parses. **This is the "手动配置的 provider 一直转圈不返回" symptom** — unrelated to the `/v1` bug above, which is why fixing one didn't fix the other.

> [!NOTE]
> The two bugs are independent but present identically to a user ("I configured a provider and it doesn't work"), which is what motivated the third change.

### 3. `Test connection` in the provider form

`POST /api/settings/providers/test` sends one `max_tokens: 1` non-streaming message and classifies the outcome. Passing `id` with a blank key probes the saved credential, matching the form's existing "leave blank to keep" semantics.

| condition | reported as |
| --- | --- |
| working | `✓ replied as macaron-v1-coding-venti (1.9s)` |
| 401 / 403 | `✕ API key rejected — {"code":"INVALID_API_KEY"…}` |
| 404 / other non-2xx | `✕ endpoint not found` / `✕ HTTP 503 — <upstream body>` |
| **HTML behind a 200** | `✕ the endpoint answered with a web page, not an API response — check the URL` |
| DNS / connect failure | `✕ could not reach the endpoint — fetch failed` |
| no reply in 20s | `✕ no response within 20s` |

Row four is bug 1, named at the moment you fill the form instead of hours later as a generic streaming error. Any keystroke in the form clears the last verdict — a stale green tick beside a freshly-edited endpoint is worse than no tick.

The endpoint hint now reads *"Base URL only — requests go to `Endpoint/v1/messages`. A trailing `/v1` is fine, we strip it."*

## Verification

Against the real gateway, through the relay:

- bare host and `…/v1/` both resolve to `https://mintcn.macaron.xin/v1/messages` and stream
- `claude -p` end-to-end through the relay — clean, no `BrotliDecompressionError`, response headers no longer carry `content-encoding`
- all seven probe classifications exercised over HTTP, including the saved-key-by-`id` path

Automated:

- `pnpm --dir server exec node --import tsx --test src/lib/*.test.ts` → **61/61** (7 endpoint cases, 4 new probe cases against a stub HTTP server)
- `pnpm --filter @macaron/server typecheck`, `build:server`
- full server suite: 118 pass / 3 fail — the same three `engine-sdk-isolation` packing cases that fail on `main` untouched (missing `server/dist/config.js` in the packed tarball), see the note on #183

Web `tsc -b` reports only the pre-existing `src/macaron-vendor/**` errors; nothing under `src/views` or `src/lib`.
