### PR TITLE
fix new session action in workspace menu

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   focusCanvasSid,
   subscribeCanvas,
   removeCanvasSid,
+  addDraftSid,
 } from '../lib/canvas';
 import { subscribeSystemEvents } from '../lib/systemEvents';
 
@@ -173,7 +174,12 @@ export function Sidebar({ onNavigate }: {
         {
           icon: <Plus size={14} aria-hidden="true" />,
           label: 'New Session',
-          onClick: () => navigate(`/w/${encodeURIComponent(w.project)}`),
+          onClick: () => {
+            // Navigation alone does not open a composer in an existing workspace.
+            addDraftSid(w.project);
+            navigate(`/w/${encodeURIComponent(w.project)}`);
+            onNavigate?.();
+          },
         },
         {
           icon: <Clipboard size={14} aria-hidden="true" />,


### PR DESCRIPTION
Clicking **New Session** in a workspace's `···` menu only navigated to the workspace, so it never opened a composer. Reuse `addDraftSid` to add and focus the draft before navigating, and close the mobile navigation drawer. Repeated clicks reuse the existing draft and preserve its text.

Closes #174.

Validation:
- All 97 web tests pass; the production web build passes.
- Chromium smoke on the real UI with fixture workspaces: reproduced the original no-op, then verified same-workspace creation, cross-workspace creation, repeated clicks, and mobile drawer dismissal.
- The fixture includes a Windows-style workspace path; native Windows execution was not tested.
- Typecheck reports the same 79 existing errors before and after the change, with identical output.