### PR TITLE
document existing v0 source launch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ Inside Codex, ask it to open the Macaron WebUI. The Codex-side default port is `
 
 Inside Kimi Code, run `/macaron:macaron`. The Kimi-side default port is `7980`.
 
+### Source Checkout
+
+With Node 22+ and pnpm 12 (`npm install -g pnpm@latest`), run from the repo root:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm start                                      # Claude, port 7878
+MACARON_ENGINE=codex MACARON_PORT=7979 pnpm start # Codex
+MACARON_ENGINE=kimi MACARON_PORT=7980 pnpm start  # Kimi
+```
+
+Run one start command per terminal and stop it with Ctrl-C. These commands use exported environment variables; plain `pnpm start` does not load `.env`. The plugin commands continue to use `start.sh`, including its `.env` loading, cache mirroring, and install/build checks.
+
 ### Views
 
 | View          | What it does |


### PR DESCRIPTION
Document the existing source-checkout install, build, and start commands for all three v0 engines. Explicitly state that plain `pnpm start` does not load `.env`; plugin commands continue to use `start.sh` and its existing safeguards.

README only, 14 added lines. Verified the commands against the current package scripts and engine configuration; `git diff --check` passes.

Independent preparation split from #195; no runtime or default-entry changes.