### PR TITLE
publish npm releases with trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,10 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The ancestry guard needs origin/main and its history on tag checkouts.
           fetch-depth: 0
           persist-credentials: false
       - name: Verify release source
-        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main || { echo "::error::Release commit must already be on main"; exit 1; }
       - uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
         with:
           version: 12.3.4
@@ -34,12 +35,11 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.4.2
-      # Trusted publishing requires npm >= 11.5.1; do not rely on Node's bundled version.
+      # Pin npm for reproducible publish behavior; Trusted Publishing requires >= 11.5.1.
       - run: npm install --global npm@11.19.1
       - name: Verify release version
         id: package
@@ -62,8 +62,9 @@ jobs:
         env:
           MACARON_PACKAGE_SOURCE: ${{ runner.temp }}/macaron-artifacts-${{ steps.package.outputs.version }}.tgz
       # Publish the exact tested tarball. npm obtains an OIDC token from GitHub;
-      # no NPM_TOKEN or NODE_AUTH_TOKEN secret is needed.
+      # publishConfig supplies registry/access, so no token-based npmrc is needed.
+      # Keep the default tag so npm rejects publishing an older version to latest.
       - name: Publish release
-        run: npm publish "$RUNNER_TEMP/macaron-artifacts-$PACKAGE_VERSION.tgz" --access public --tag latest
+        run: npm publish "$RUNNER_TEMP/macaron-artifacts-$PACKAGE_VERSION.tgz"
         env:
           PACKAGE_VERSION: ${{ steps.package.outputs.version }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,69 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'mindverse-ltd/macaron-artifacts'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify release source
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
+        with:
+          version: 12.3.4
+          install: false
+          cache: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.4.2
+      # Trusted publishing requires npm >= 11.5.1; do not rely on Node's bundled version.
+      - run: npm install --global npm@11.19.1
+      - name: Verify release version
+        id: package
+        run: |
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import { appendFileSync, readFileSync } from 'node:fs';
+          const { version } = JSON.parse(readFileSync('package.json', 'utf8'));
+          assert.match(version, /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/, 'Only stable versions publish to latest');
+          assert.equal(process.env.GITHUB_REF_NAME, `v${version}`, 'The release tag must match package.json');
+          appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+          NODE
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test
+      - name: Pack release
+        run: npm pack --pack-destination "$RUNNER_TEMP"
+      - name: Test release package
+        run: pnpm test:package
+        env:
+          MACARON_PACKAGE_SOURCE: ${{ runner.temp }}/macaron-artifacts-${{ steps.package.outputs.version }}.tgz
+      # Publish the exact tested tarball. npm obtains an OIDC token from GitHub;
+      # no NPM_TOKEN or NODE_AUTH_TOKEN secret is needed.
+      - name: Publish release
+        run: npm publish "$RUNNER_TEMP/macaron-artifacts-$PACKAGE_VERSION.tgz" --access public --tag latest
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,6 +32,6 @@ jobs:
       # devDependency, so this executes the lockfile-pinned binary from
       # node_modules/.bin. The mandatory package test above installs and boots
       # the same single-package layout in an empty consumer directory.
-      # Force long-form URLs because compact URLs require npm repository metadata;
-      # these are only published through pkg.pr.new, and --bin shows a CLI command.
-      - run: pnpm exec pkg-pr-new publish --no-compact --bin .
+      # Compact URLs use npm repository metadata, falling back to long-form URLs
+      # until the first npm release. --bin shows a CLI command.
+      - run: pnpm exec pkg-pr-new publish --bin .

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "macaron-artifacts",
   "version": "0.1.0",
   "description": "One local WebUI for coding harnesses and streaming UI4A artifacts.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mindverse-ltd/macaron-artifacts.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @macaron/artifacts dev",

--- a/site/content/docs/architecture/packaging.mdx
+++ b/site/content/docs/architecture/packaging.mdx
@@ -31,7 +31,7 @@ A new harness implements `HarnessAdapter` and registers its capabilities. It doe
 
 ## npm releases
 
-`.github/workflows/npm-publish.yml` publishes stable `v*` tags using npm Trusted Publishing. The tag must match the root `package.json` version, for example `v0.1.0` for `0.1.0`, and point to a commit already on `main`. The workflow runs type checks and tests, builds a tarball, installs and starts that tarball in isolation, then publishes the same file to npm's `latest` tag with provenance. Releases run serially without cancelling an active publish; prerelease versions are rejected.
+`.github/workflows/npm-publish.yml` publishes stable `v*` tags using npm Trusted Publishing. The tag must match the root `package.json` version and point to a commit already on `main`. The workflow runs type checks and tests, builds a tarball, installs and starts that tarball in isolation, then publishes the same file to npm's `latest` tag with provenance. Releases run serially without cancelling an active publish; prerelease versions are rejected.
 
 Before the first automated release:
 
@@ -55,7 +55,7 @@ npm publish "$release_dir/macaron-artifacts-$release_version.tgz"
 
 Subsequent releases need only a new root package version committed to `main` and the matching `v<version>` tag pushed to GitHub. Each version can be published once; do not rerun a successful publish for that version. No npm token secret is required. GitHub-hosted runners and npm 11.5.1 or newer are required for Trusted Publishing. The workflow has read-only Git permissions and publishes the tagged commit without creating another commit or tag during the run.
 
-For example, after manually publishing `0.1.0`, bump the root package to `0.1.1` on `main` before pushing `v0.1.1` for the first automated release. Leave `--tag` unset so npm's default-tag check prevents an older version from replacing `latest`.
+After the initial manual package publication, bump the root package to the next stable version on `main` before pushing its matching `v<version>` tag for the first automated release. Leave `--tag` unset so npm's default-tag check prevents an older version from replacing `latest`.
 
 ## Release and updates
 

--- a/site/content/docs/architecture/packaging.mdx
+++ b/site/content/docs/architecture/packaging.mdx
@@ -49,11 +49,13 @@ release_dir="$(mktemp -d)"
 npm pack --pack-destination "$release_dir"
 release_version="$(node -p 'require("./package.json").version')"
 MACARON_PACKAGE_SOURCE="$release_dir/macaron-artifacts-$release_version.tgz" pnpm test:package
-npm publish "$release_dir/macaron-artifacts-$release_version.tgz" --access public --tag latest
+npm publish "$release_dir/macaron-artifacts-$release_version.tgz"
 )
 ```
 
 Subsequent releases need only a new root package version committed to `main` and the matching `v<version>` tag pushed to GitHub. Each version can be published once; do not rerun a successful publish for that version. No npm token secret is required. GitHub-hosted runners and npm 11.5.1 or newer are required for Trusted Publishing. The workflow has read-only Git permissions and publishes the tagged commit without creating another commit or tag during the run.
+
+For example, after manually publishing `0.1.0`, bump the root package to `0.1.1` on `main` before pushing `v0.1.1` for the first automated release. Leave `--tag` unset so npm's default-tag check prevents an older version from replacing `latest`.
 
 ## Release and updates
 

--- a/site/content/docs/architecture/packaging.mdx
+++ b/site/content/docs/architecture/packaging.mdx
@@ -29,6 +29,40 @@ Use a SHA from a successful package preview build. The launcher serves UI and AP
 
 A new harness implements `HarnessAdapter` and registers its capabilities. It does not add another package, launcher, SPA, sidebar, or Canvas path.
 
+## npm releases
+
+`.github/workflows/npm-publish.yml` publishes stable `v*` tags using npm Trusted Publishing. The tag must match the root `package.json` version, for example `v0.1.0` for `0.1.0`, and point to a commit already on `main`. The workflow runs type checks and tests, builds a tarball, installs and starts that tarball in isolation, then publishes the same file to npm's `latest` tag with provenance. Releases run serially without cancelling an active publish; prerelease versions are rejected.
+
+Before the first automated release:
+
+1. Run `npm login --registry=https://registry.npmjs.org` and complete browser authentication.
+2. From the repository root, run the commands below to publish the tested tarball. This first manual release creates the npm package so its publisher can be configured.
+3. In the npm package settings, add a GitHub Actions trusted publisher with organization `mindverse-ltd`, repository `macaron-artifacts`, workflow filename `npm-publish.yml`, and allowed action `npm publish`. Leave the environment name empty; this workflow does not use a GitHub environment.
+
+```sh
+(
+set -eu
+pnpm install --frozen-lockfile
+pnpm typecheck
+pnpm test
+release_dir="$(mktemp -d)"
+npm pack --pack-destination "$release_dir"
+release_version="$(node -p 'require("./package.json").version')"
+MACARON_PACKAGE_SOURCE="$release_dir/macaron-artifacts-$release_version.tgz" pnpm test:package
+npm publish "$release_dir/macaron-artifacts-$release_version.tgz" --access public --tag latest
+)
+```
+
+Subsequent releases need only a new root package version committed to `main` and the matching `v<version>` tag pushed to GitHub. Each version can be published once; do not rerun a successful publish for that version. No npm token secret is required. GitHub-hosted runners and npm 11.5.1 or newer are required for Trusted Publishing. The workflow has read-only Git permissions and publishes the tagged commit without creating another commit or tag during the run.
+
 ## Release and updates
 
 `.github/workflows/pkg-pr-new.yml` publishes the root package for each preview commit. Install a newer successful preview URL to update the application; conversation data remains in `MACARON_DATA_DIR`.
+
+`.github/workflows/pkg-pr-new.yml` builds and publishes only the repository root:
+
+```sh
+pnpm exec pkg-pr-new publish --bin .
+```
+
+After the first npm release exposes the package's `repository` metadata, pkg.pr.new can also use `https://pkg.pr.new/macaron-artifacts@<sha>`. It falls back to the full URL while that metadata is unavailable; full URLs remain valid afterward.


### PR DESCRIPTION
Add npm releases for `macaron-artifacts` using GitHub Actions Trusted Publishing. Stable `v*` tags must match `package.json` and point to a commit on `main`. The workflow runs type checks and tests, packs the application, installs and starts that tarball in isolation, then publishes the same file with automatic provenance. Leave the npm tag implicit so npm rejects an older stable version instead of moving `latest` backward.

Use GitHub-hosted runners, pinned Actions and package tools, serialized releases, and read-only Git permissions. The package's `publishConfig` supplies registry/access without a token-based npmrc. Add repository/license metadata, document bootstrap and release steps, and let pkg.pr.new select compact URLs once npm metadata is available, with its existing full-URL fallback.

Validation:

- Typecheck; 105 application tests passed, 1 optional OpenCode live test skipped.
- Release tarball installed in an empty consumer directory, started successfully, and served all four harnesses and 25 client assets intact.
- `npm publish --dry-run`, actionlint, six version/tag guard cases, and bootstrap failure-stop check passed.
- Local registry dry-run confirmed npm rejects publishing 0.1.0 over 0.2.0 with the default tag; explicit `--tag latest` bypassed that protection. Source ancestry fixtures accept a main commit and reject an unmerged commit with a clear error.

> [!NOTE]
> No npm version has been published. The first release requires npm login, followed by a Trusted Publisher binding for `mindverse-ltd/macaron-artifacts`, workflow `npm-publish.yml`, allowed action `npm publish`, and no environment name. After manually publishing 0.1.0, use a new version such as 0.1.1 for the first automated release. OIDC publication remains to be verified after that binding.