### PR TITLE
retry failed agent turns in place

### DIFF
--- a/artifacts/src/server/conversations.ts
+++ b/artifacts/src/server/conversations.ts
@@ -17,7 +17,7 @@ export class ActiveConversation {
   private mainSettled = false;
   latest?: ChatMessage;
   readonly done: Promise<void>;
-  constructor(private store: SessionStore, readonly session: Session, private adapter: HarnessAdapter, private instructions: string, prompt: string, private metadata: MetadataTasks) {
+  constructor(private store: SessionStore, readonly session: Session, private adapter: HarnessAdapter, private instructions: string, prompt: string, private metadata: MetadataTasks, private retry = false) {
     this.done = this.execute(prompt);
   }
   stream(): ReadableStream<ChatChunk> {
@@ -68,11 +68,12 @@ export class ActiveConversation {
           emit({ type: 'data-approval', id: request.id, data: { ...request, resolved: true } });
           return approved;
         };
-        writer.write({ type: 'start', messageId: crypto.randomUUID() });
+        const previousAssistant = this.retry ? session.messages.findLast(message => message.role === 'assistant') : undefined;
+        writer.write({ type: 'start', messageId: previousAssistant?.id ?? crypto.randomUUID() });
         writer.write({ type: 'start-step' });
         try {
           await artifacts.start();
-          const turn = { nativeId: session.nativeId, cwd: session.cwd, prompt, model: session.model, instructions: this.instructions, signal: this.controller.signal, onNativeSession: (id: string) => {
+          const turn = { nativeId: session.nativeId, cwd: session.cwd, prompt, retry: this.retry, model: session.model, instructions: this.instructions, signal: this.controller.signal, onNativeSession: (id: string) => {
             if (session.nativeId === id) return;
             session.nativeId = id;
             // First output waits for this durable identity checkpoint. A recovered partial
@@ -116,7 +117,13 @@ export class ActiveConversation {
       const settled = await Promise.allSettled([broadcastTask, snapshotTask]);
       for (const result of settled) if (result.status === 'rejected') failure ??= result.reason;
       disk.end(); await diskDone;
-      if (this.latest) session.messages = [...before, this.latest];
+      if (this.latest) {
+        const previousAssistant = this.retry ? before.findLast(message => message.role === 'assistant') : undefined;
+        if (previousAssistant && this.latest.role === 'assistant' && this.latest.id === previousAssistant.id) {
+          const index = before.lastIndexOf(previousAssistant);
+          session.messages = [...before.slice(0, index), { ...this.latest, parts: [...previousAssistant.parts, ...this.latest.parts] }];
+        } else session.messages = [...before, this.latest];
+      }
       session.status = failure || diskError ? 'error' : 'idle';
       session.error = diskError?.message || (failure instanceof Error ? failure.message : failure ? String(failure) : undefined);
       session.updatedAt = Date.now();

--- a/artifacts/src/server/conversations.ts
+++ b/artifacts/src/server/conversations.ts
@@ -73,7 +73,7 @@ export class ActiveConversation {
         writer.write({ type: 'start-step' });
         try {
           await artifacts.start();
-          const turn = { nativeId: session.nativeId, cwd: session.cwd, prompt, retry: this.retry, model: session.model, instructions: this.instructions, signal: this.controller.signal, onNativeSession: (id: string) => {
+          const turn = { nativeId: session.nativeId, cwd: session.cwd, prompt, messageId: session.messages.findLast(message => message.role === 'user')?.id, retry: this.retry, model: session.model, instructions: this.instructions, signal: this.controller.signal, onNativeSession: (id: string) => {
             if (session.nativeId === id) return;
             session.nativeId = id;
             // First output waits for this durable identity checkpoint. A recovered partial

--- a/artifacts/src/server/harnesses/claude.ts
+++ b/artifacts/src/server/harnesses/claude.ts
@@ -106,10 +106,11 @@ export class ClaudeEventMapper {
 
 export function claudeOptions(turn: HarnessTurn, abortController: AbortController): Options {
   return {
-    cwd: turn.cwd, ...(turn.nativeId ? { resume: turn.nativeId } : {}), ...(turn.model ? { model: turn.model } : {}), abortController,
+    cwd: turn.cwd, ...(turn.nativeId && !turn.retry ? { resume: turn.nativeId } : {}), ...(turn.model ? { model: turn.model } : {}), abortController,
     ...(process.env.MACARON_CLAUDE_PATH ? { pathToClaudeCodeExecutable: process.env.MACARON_CLAUDE_PATH } : {}),
     systemPrompt: { type: 'preset', preset: 'claude_code', append: turn.instructions }, includePartialMessages: true, permissionMode: 'default',
     ...(turn.enrichment ? { forkSession: true, persistSession: false, maxTurns: 1 } : {}),
+    ...(turn.retry ? { continue: true } : {}),
     // Always register the same callbacks, including for forks. Removing tools or interactive callbacks changes the cached prompt prefix.
     hooks: { PreToolUse: [{ hooks: [async () => turn.enrichment ? { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: 'Metadata generation cannot execute tools' } } : {}] }] },
     canUseTool: async (tool, input, context) => {

--- a/artifacts/src/server/harnesses/codex.ts
+++ b/artifacts/src/server/harnesses/codex.ts
@@ -81,7 +81,7 @@ export async function* runCodexConnection(turn: HarnessTurn, connection: CodexCo
     if (!turn.enrichment) turn.onNativeSession(nativeId);
     if (turn.signal.aborted) throw abortError();
     streaming = true;
-    const response = await connection.request('turn/start', { threadId: nativeId, input: [{ type: 'text', text: turn.prompt, text_elements: [] }] });
+    const response = await connection.request('turn/start', { threadId: nativeId, input: turn.retry ? [] : [{ type: 'text', text: turn.prompt, text_elements: [] }] });
     nativeTurnId ||= string(record(response.turn).id);
     if (nativeTurnId) turnAvailable();
     await done;

--- a/artifacts/src/server/harnesses/events.test.ts
+++ b/artifacts/src/server/harnesses/events.test.ts
@@ -72,6 +72,11 @@ describe('Claude native deltas', () => {
     const gate = await hook({ hook_event_name: 'PreToolUse', session_id: 'fork', transcript_path: '', cwd: '/tmp', tool_name: 'Write', tool_input: {}, tool_use_id: 't1' }, 't1', { signal: new AbortController().signal });
     expect(gate).toMatchObject({ hookSpecificOutput: { permissionDecision: 'deny' } });
   });
+  test('uses Claude native continuation for a failed-turn retry', () => {
+    const options = claudeOptions(turn({ nativeId: 'main', retry: true }), new AbortController());
+    expect(options.continue).toBe(true);
+    expect(options.resume).toBeUndefined();
+  });
 });
 
 describe('Codex native deltas', () => {
@@ -136,6 +141,11 @@ describe('Codex turn lifecycle', () => {
     expect(connection.calls.map((call) => call.method)).toEqual(['initialize', 'initialized', 'thread/resume', 'turn/start']);
     expect(chunks.filter((chunk) => chunk.type === 'text-delta').map((chunk) => chunk.delta)).toEqual(['fresh']);
     expect(ids).toEqual(['native']); expect(connection.closed).toBe(true);
+  });
+  test('starts a failed-turn retry with Codex native empty input', async () => {
+    const connection = new ReplayConnection();
+    for await (const _chunk of runCodexConnection(turn({ nativeId: 'native', retry: true }), connection)) { /* Drain the actual adapter. */ }
+    expect(connection.calls.find(call => call.method === 'turn/start')?.params).toMatchObject({ threadId: 'native', input: [] });
   });
 
   test('an ephemeral metadata fork cannot overwrite the durable native id', async () => {

--- a/artifacts/src/server/harnesses/opencode-server.ts
+++ b/artifacts/src/server/harnesses/opencode-server.ts
@@ -16,6 +16,7 @@ export interface OpenCodeConnection {
   blockTools(id: string): Promise<void>;
   events(signal: AbortSignal): AsyncIterable<unknown>;
   prompt(id: string, prompt: OpenCodePrompt, signal: AbortSignal): Promise<void>;
+  retry(id: string, text: string, signal: AbortSignal): Promise<void>;
   replyPermission(id: string, approved: boolean, signal: AbortSignal): Promise<void>;
   rejectQuestion(id: string, signal: AbortSignal): Promise<void>;
   abort(id: string, signal: AbortSignal): Promise<void>;
@@ -114,6 +115,7 @@ export async function startOpenCode(cwd: string, signal: AbortSignal): Promise<O
         yield* result.stream;
       },
       async prompt(sessionID, prompt, signal) { await client.session.promptAsync({ sessionID, ...prompt }, options(signal)); },
+      async retry(sessionID, text, signal) { await client.v2.session.prompt({ sessionID, prompt: { text }, resume: true }, options(signal)); },
       async replyPermission(requestID, approved, signal) { await client.permission.reply({ requestID, reply: approved ? 'once' : 'reject' }, options(signal)); },
       async rejectQuestion(requestID, signal) { await client.question.reject({ requestID }, options(signal)); },
       async abort(sessionID, signal) { await client.session.abort({ sessionID }, options(signal)); },

--- a/artifacts/src/server/harnesses/opencode-server.ts
+++ b/artifacts/src/server/harnesses/opencode-server.ts
@@ -16,7 +16,7 @@ export interface OpenCodeConnection {
   blockTools(id: string): Promise<void>;
   events(signal: AbortSignal): AsyncIterable<unknown>;
   prompt(id: string, prompt: OpenCodePrompt, signal: AbortSignal): Promise<void>;
-  retry(id: string, text: string, signal: AbortSignal): Promise<void>;
+  retry(id: string, messageID: string | undefined, text: string, signal: AbortSignal): Promise<void>;
   replyPermission(id: string, approved: boolean, signal: AbortSignal): Promise<void>;
   rejectQuestion(id: string, signal: AbortSignal): Promise<void>;
   abort(id: string, signal: AbortSignal): Promise<void>;
@@ -115,7 +115,7 @@ export async function startOpenCode(cwd: string, signal: AbortSignal): Promise<O
         yield* result.stream;
       },
       async prompt(sessionID, prompt, signal) { await client.session.promptAsync({ sessionID, ...prompt }, options(signal)); },
-      async retry(sessionID, text, signal) { await client.v2.session.prompt({ sessionID, prompt: { text }, resume: true }, options(signal)); },
+      async retry(sessionID, messageID, text, signal) { await client.v2.session.prompt({ sessionID, id: messageID, prompt: { text }, resume: true }, options(signal)); },
       async replyPermission(requestID, approved, signal) { await client.permission.reply({ requestID, reply: approved ? 'once' : 'reject' }, options(signal)); },
       async rejectQuestion(requestID, signal) { await client.question.reject({ requestID }, options(signal)); },
       async abort(sessionID, signal) { await client.session.abort({ sessionID }, options(signal)); },

--- a/artifacts/src/server/harnesses/opencode.test.ts
+++ b/artifacts/src/server/harnesses/opencode.test.ts
@@ -66,7 +66,7 @@ class FakeConnection implements OpenCodeConnection {
     finally { signal.removeEventListener('abort', stop); }
   }
   async prompt(id: string, prompt: OpenCodePrompt) { this.calls.push({ method: 'prompt', value: { id, prompt } }); this.onPrompt(id); }
-  async retry(id: string, text: string) { this.calls.push({ method: 'retry', value: { id, text } }); this.onPrompt(id); }
+  async retry(id: string, messageID: string | undefined, text: string) { this.calls.push({ method: 'retry', value: { id, messageID, text } }); this.onPrompt(id); }
   async replyPermission(id: string, approved: boolean) { this.calls.push({ method: 'reply', value: { id, approved } }); this.emit('native', 'session.idle'); }
   async rejectQuestion(id: string) { this.calls.push({ method: 'question-reject', value: id }); this.emit('native', 'session.idle'); }
   async abort(id: string) { this.calls.push({ method: 'abort', value: id }); this.queue.end(); }
@@ -87,9 +87,9 @@ describe('OpenCode lifecycle', () => {
   });
   test('uses the native V2 resume operation for failed-turn retry', async () => {
     const connection = new FakeConnection();
-    await collect(makeTurn({ nativeId: 'native', retry: true }), connection);
+    await collect(makeTurn({ nativeId: 'native', retry: true, messageId: 'user' }), connection);
     expect(connection.calls.map(call => call.method)).toEqual(['get', 'retry', 'close']);
-    expect(connection.calls[1]?.value).toEqual({ id: 'native', text: 'hello' });
+    expect(connection.calls[1]?.value).toEqual({ id: 'native', messageID: 'user', text: 'hello' });
   });
   test('forks the complete history, guards execution before prompt and deletes only the fork', async () => {
     const connection = new FakeConnection(), nativeIDs: string[] = [];

--- a/artifacts/src/server/harnesses/opencode.test.ts
+++ b/artifacts/src/server/harnesses/opencode.test.ts
@@ -66,6 +66,7 @@ class FakeConnection implements OpenCodeConnection {
     finally { signal.removeEventListener('abort', stop); }
   }
   async prompt(id: string, prompt: OpenCodePrompt) { this.calls.push({ method: 'prompt', value: { id, prompt } }); this.onPrompt(id); }
+  async retry(id: string, text: string) { this.calls.push({ method: 'retry', value: { id, text } }); this.onPrompt(id); }
   async replyPermission(id: string, approved: boolean) { this.calls.push({ method: 'reply', value: { id, approved } }); this.emit('native', 'session.idle'); }
   async rejectQuestion(id: string) { this.calls.push({ method: 'question-reject', value: id }); this.emit('native', 'session.idle'); }
   async abort(id: string) { this.calls.push({ method: 'abort', value: id }); this.queue.end(); }
@@ -83,6 +84,12 @@ describe('OpenCode lifecycle', () => {
     expect(chunks.map(chunk => chunk.type)).toEqual(['text-start', 'text-delta', 'text-end']);
     expect(connection.calls.map(call => call.method)).toEqual(['get', 'prompt', 'close']);
     expect(connection.calls[1]?.value).toMatchObject({ id: 'native', prompt: { system: 'stable instructions', agent: 'build', model: { providerID: 'provider', modelID: 'model' }, variant: 'high' } });
+  });
+  test('uses the native V2 resume operation for failed-turn retry', async () => {
+    const connection = new FakeConnection();
+    await collect(makeTurn({ nativeId: 'native', retry: true }), connection);
+    expect(connection.calls.map(call => call.method)).toEqual(['get', 'retry', 'close']);
+    expect(connection.calls[1]?.value).toEqual({ id: 'native', text: 'hello' });
   });
   test('forks the complete history, guards execution before prompt and deletes only the fork', async () => {
     const connection = new FakeConnection(), nativeIDs: string[] = [];

--- a/artifacts/src/server/harnesses/opencode.ts
+++ b/artifacts/src/server/harnesses/opencode.ts
@@ -77,7 +77,7 @@ export async function* runOpenCodeConnection(turn: HarnessTurn, connection: Open
     const selectedModel = turn.model ? openCodeModel(turn.model) : original?.model ? { providerID: original.model.providerID, modelID: original.model.id } : undefined;
     const prompt: OpenCodePrompt = { system: turn.instructions, parts: [{ type: 'text', text: turn.prompt }], ...(selectedModel ? { model: selectedModel } : {}), ...(original?.agent ? { agent: original.agent } : {}), ...(original?.model?.variant ? { variant: original.model.variant } : {}) };
     started = true;
-    if (turn.retry) await connection.retry(nativeID, turn.prompt, signal); else await connection.prompt(nativeID, prompt, signal);
+    if (turn.retry) await connection.retry(nativeID, turn.messageId, turn.prompt, signal); else await connection.prompt(nativeID, prompt, signal);
     await abortable(done, signal);
   })();
   void producer.then(() => queue.end(), fail);

--- a/artifacts/src/server/harnesses/opencode.ts
+++ b/artifacts/src/server/harnesses/opencode.ts
@@ -77,7 +77,7 @@ export async function* runOpenCodeConnection(turn: HarnessTurn, connection: Open
     const selectedModel = turn.model ? openCodeModel(turn.model) : original?.model ? { providerID: original.model.providerID, modelID: original.model.id } : undefined;
     const prompt: OpenCodePrompt = { system: turn.instructions, parts: [{ type: 'text', text: turn.prompt }], ...(selectedModel ? { model: selectedModel } : {}), ...(original?.agent ? { agent: original.agent } : {}), ...(original?.model?.variant ? { variant: original.model.variant } : {}) };
     started = true;
-    await connection.prompt(nativeID, prompt, signal);
+    if (turn.retry) await connection.retry(nativeID, turn.prompt, signal); else await connection.prompt(nativeID, prompt, signal);
     await abortable(done, signal);
   })();
   void producer.then(() => queue.end(), fail);

--- a/artifacts/src/server/harnesses/pi.ts
+++ b/artifacts/src/server/harnesses/pi.ts
@@ -155,7 +155,7 @@ export async function* runPiSession(turn: HarnessTurn, create = createPiSession)
     }
     task = (async () => {
       try {
-        await session.prompt(turn.prompt);
+        if (turn.retry) await session.agent.continue(); else await session.prompt(turn.prompt);
         await session.waitForIdle();
         if (signal.aborted) throw abortError();
         const assistant = session.messages.findLast(message => message.role === 'assistant');

--- a/artifacts/src/server/harnesses/types.ts
+++ b/artifacts/src/server/harnesses/types.ts
@@ -4,6 +4,7 @@ export interface HarnessTurn {
   nativeId?: string;
   cwd: string;
   prompt: string;
+  messageId?: string;
   /** Resume the failed native turn without adding another user message. */
   retry?: boolean;
   model?: string;

--- a/artifacts/src/server/harnesses/types.ts
+++ b/artifacts/src/server/harnesses/types.ts
@@ -4,6 +4,8 @@ export interface HarnessTurn {
   nativeId?: string;
   cwd: string;
   prompt: string;
+  /** Resume the failed native turn without adding another user message. */
+  retry?: boolean;
   model?: string;
   instructions: string;
   signal: AbortSignal;

--- a/artifacts/src/server/index.ts
+++ b/artifacts/src/server/index.ts
@@ -94,18 +94,21 @@ export async function createArtifactsServer(options: { directory: string; instru
         const user = messages.findLast(message => message.role === 'user');
         const prompt = user?.parts?.filter(part => part.type === 'text').map(part => part.text).join('\n').trim();
         if (!user || !prompt) return json(res, { error: 'A user message is required.' }, 400);
-        if (session.messages.some(message => message.id === user.id)) return json(res, { error: 'This message was already submitted.' }, 409);
+        const retry = session.status === 'error' && session.messages.some(message => message.id === user.id);
+        if (session.messages.some(message => message.id === user.id) && !retry) return json(res, { error: 'This message was already submitted.' }, 409);
         // Claim before the first await. Two simultaneous POSTs must never both
         // append a user message and start native turns for the same session.
         claims.add(session.id); void metadata.cancel(session.id);
         const previous = { ...session, messages: [...session.messages], suggestions: [...session.suggestions] };
         let run: ActiveConversation;
         try {
-          session.messages.push({ id: user.id || crypto.randomUUID(), role: 'user', parts: [{ type: 'text', text: prompt }] });
-          if (session.messages.length === 1) session.title = prompt.slice(0, 60);
+          if (!retry) {
+            session.messages.push({ id: user.id || crypto.randomUUID(), role: 'user', parts: [{ type: 'text', text: prompt }] });
+            if (session.messages.length === 1) session.title = prompt.slice(0, 60);
+          }
           session.status = 'running'; session.error = undefined; session.suggestions = []; session.updatedAt = Date.now();
           await store.save(session);
-          run = new ActiveConversation(store, session, adapter, options.instructions, prompt, metadata); active.set(session.id, run);
+          run = new ActiveConversation(store, session, adapter, options.instructions, prompt, metadata, retry); active.set(session.id, run);
         } catch (error) { Object.assign(session, previous); throw error; }
         finally { claims.delete(session.id); }
         void run.done.finally(() => { if (active.get(session.id) === run) active.delete(session.id); }).catch(error => { console.error('Session persistence failed:', error); });

--- a/artifacts/src/server/server.test.ts
+++ b/artifacts/src/server/server.test.ts
@@ -84,6 +84,7 @@ test('retries a failed native turn in place without adding a continuation messag
   expect((await post('/api/chat', { id: session.id, messages: failed.messages })).ok).toBe(true);
   const recovered = await (await fetch(`${base}/api/sessions/${session.id}`)).json() as Session;
   expect(turns.map(turn => turn.retry)).toEqual([false, true]);
+  expect(turns[1]?.messageId).toBe('retry-user');
   expect(recovered.messages.filter(message => message.role === 'user')).toHaveLength(1);
   expect(recovered.messages.filter(message => message.role === 'assistant')).toHaveLength(1);
 });

--- a/artifacts/src/server/server.test.ts
+++ b/artifacts/src/server/server.test.ts
@@ -66,6 +66,28 @@ test('enrichment keeps bootstrap and native session but does not overwrite its i
   expect(saved.messages[1].parts.find(part => part.type === 'text')?.text).toBe('Answer');
 });
 
+test('retries a failed native turn in place without adding a continuation message', async () => {
+  const turns: HarnessTurn[] = []; let attempts = 0;
+  const { post, session, base } = await setup(async function* (turn) {
+    turns.push(turn);
+    yield { type: 'text-start', id: 'answer' };
+    yield { type: 'text-delta', id: 'answer', delta: attempts === 0 ? 'partial' : 'resumed' };
+    if (attempts++ === 0) throw new Error('temporary failure');
+    yield { type: 'text-end', id: 'answer' };
+  });
+  const original = message('retry-user', 'Keep this request');
+  expect((await post('/api/chat', { id: session.id, messages: [original] })).ok).toBe(true);
+  while (true) { const current = await (await fetch(`${base}/api/sessions/${session.id}`)).json() as Session; if (!current.status || current.status === 'error') break; await new Promise(resolve => setTimeout(resolve, 0)); }
+  const failed = await (await fetch(`${base}/api/sessions/${session.id}`)).json() as Session;
+  expect(failed.status).toBe('error');
+  expect(failed.messages.filter(message => message.role === 'user')).toHaveLength(1);
+  expect((await post('/api/chat', { id: session.id, messages: failed.messages })).ok).toBe(true);
+  const recovered = await (await fetch(`${base}/api/sessions/${session.id}`)).json() as Session;
+  expect(turns.map(turn => turn.retry)).toEqual([false, true]);
+  expect(recovered.messages.filter(message => message.role === 'user')).toHaveLength(1);
+  expect(recovered.messages.filter(message => message.role === 'assistant')).toHaveLength(1);
+});
+
 test('a missing adapter rejects a restored session before changing its durable history', async () => {
   const { app, post, session } = await setup(async function* () { throw new Error('Unavailable adapter must not run'); });
   session.harness = 'pi'; await app.store.save(session);

--- a/artifacts/src/web/chat/store.ts
+++ b/artifacts/src/web/chat/store.ts
@@ -215,7 +215,7 @@ export class WorkspaceStore {
         chat.clearError(); await chat.resumeStream(); await this.refresh(id, turn, true);
       } else {
         chat.messages = remote.messages; chat.clearError();
-        if (remote.status === 'error') { this.update(id, { status: 'running', suggestions: [], error: undefined }); await chat.sendMessage({ text: '继续。' }); }
+        if (remote.status === 'error') { this.update(id, { status: 'running', suggestions: [], error: undefined }); await chat.sendMessage(); }
         else { const { messages: _messages, ...summary } = remote; this.update(id, summary); void this.subscribeMetadata(id); }
       }
     } catch (error) { if (this.turns.get(id) === turn) this.fail(error); }


### PR DESCRIPTION
## Problem

Retrying a failed turn appended a synthetic "继续。" user message instead of recovering the failed turn.

## Changes

- Retry the existing user message without adding a new transcript entry.
- Reuse the failed assistant message ID and merge resumed parts into the existing record.
- Route retry through native Claude, Codex, OpenCode, and pi continuation APIs.
- Keep ordinary duplicate message submissions rejected.
- Add server and adapter regression coverage.

## Validation

- pnpm --filter @macaron/artifacts test (109 passed, 1 skipped)
- pnpm --filter @macaron/artifacts typecheck
- pnpm --filter @macaron/artifacts build
- git diff --check