### PR TITLE
normalize tool paths before opening a canvas

### DIFF
--- a/artifacts/src/server/artifacts.ts
+++ b/artifacts/src/server/artifacts.ts
@@ -3,9 +3,10 @@ import { lstat, mkdir, readFile, realpath, readdir, stat, writeFile } from 'node
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { parse } from 'partial-json';
 import type { Artifact, ChatChunk } from '../shared/types.js';
+import { isArtifactEntry } from '../shared/artifact-path.js';
+export { isArtifactEntry } from '../shared/artifact-path.js';
 
 const MAX_BYTES = 2 * 1024 * 1024;
-export const isArtifactEntry = (path: string) => /^\.artifacts\/(?:canvases\/)?[^/]+\.(?:ui4a\.)?tsx$/.test(path);
 export function ui4aPath(cwd: string, path: string) {
   const target = resolve(cwd, path), rel = relative(resolve(cwd), target);
   if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`) || !rel.startsWith(`.artifacts${sep}`)) throw new Error('Files must be inside this workspace’s .artifacts directory.');

--- a/artifacts/src/shared/artifact-path.test.ts
+++ b/artifacts/src/shared/artifact-path.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { artifactEntryPath } from './artifact-path';
+
+test('tool paths resolve to the artifact stream identity within their own workspace', () => {
+  const path = '.artifacts/canvases/demo.ui4a.tsx';
+  for (const input of [path, `./${path}`, `/workspace/${path}`, `/workspace/.artifacts/canvases/../canvases/demo.ui4a.tsx`]) expect(artifactEntryPath(input, '/workspace')).toBe(path);
+  expect(artifactEntryPath('C:\\workspace\\.artifacts\\canvases\\demo.ui4a.tsx', 'C:\\workspace')).toBe(path);
+  expect(artifactEntryPath('/.artifacts/demo.tsx', '/')).toBe('.artifacts/demo.tsx');
+  for (const input of ['/workspace-other/' + path, '/other/' + path, '../' + path, '.artifacts/../outside.tsx', '.artifacts/canvases/demo/Counter.tsx', '.artifacts/state.json']) expect(artifactEntryPath(input, '/workspace')).toBeUndefined();
+});

--- a/artifacts/src/shared/artifact-path.ts
+++ b/artifacts/src/shared/artifact-path.ts
@@ -1,0 +1,18 @@
+export const isArtifactEntry = (path: string) => /^\.artifacts\/(?:canvases\/)?[^/]+\.(?:ui4a\.)?tsx$/.test(path);
+
+/** Tool inputs use native paths; browser selections use the workspace-relative keys from the artifact stream. */
+export function artifactEntryPath(path: string, cwd: string): string | undefined {
+  const normalize = (value: string) => {
+    const parts: string[] = [];
+    for (const part of value.replaceAll('\\', '/').split('/')) {
+      if (part === '.') continue;
+      if (part === '..') { if (!parts.length || parts.at(-1) === '') return undefined; parts.pop(); }
+      else if (part || !parts.length) parts.push(part);
+    }
+    return parts.join('/').replace(/\/$/, '');
+  };
+  const base = normalize(cwd), native = normalize(path);
+  if (base === undefined || native === undefined) return;
+  const relative = /^(?:\/|[a-z]:\/)/i.test(native) ? native.startsWith(`${base}/`) ? native.slice(base.length + 1) : undefined : native;
+  return relative && isArtifactEntry(relative) ? relative : undefined;
+}

--- a/artifacts/src/web/chat/store.ts
+++ b/artifacts/src/web/chat/store.ts
@@ -2,6 +2,7 @@ import { Chat } from '@ai-sdk/react';
 import { DefaultChatTransport, type DataUIPart } from 'ai';
 import type { Artifact, ChatMessage, HarnessId, HarnessInfo, MessageData, Session, SessionSummary } from '../../shared/types';
 import { consumeMetadata } from './metadata';
+import { artifactEntryPath } from '../../shared/artifact-path';
 
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, { ...init, headers: { 'content-type': 'application/json', ...init?.headers } });
@@ -240,6 +241,6 @@ export class WorkspaceStore {
     void this.drain(id);
   };
   approve = (id: string, approvalId: string, approved: boolean) => api(`/api/sessions/${id}/approvals/${encodeURIComponent(approvalId)}`, { method: 'POST', body: JSON.stringify({ approved }) });
-  openArtifact = (id: string, path: string) => { this.selectedArtifacts.set(id, path); this.dismissed.delete(id); this.publish(); };
+  openArtifact = (id: string, path: string) => { const session = this.snapshot.sessions.find(session => session.id === id), entry = session && artifactEntryPath(path, session.cwd); if (!entry) return; this.selectedArtifacts.set(id, entry); this.dismissed.delete(id); this.publish(); };
   closeArtifact = (id: string) => { const path = this.selectedArtifacts.get(id); if (path) this.dismissed.set(id, path); this.selectedArtifacts.delete(id); this.publish(); };
 }

--- a/artifacts/src/web/components/chat/Conversation.tsx
+++ b/artifacts/src/web/components/chat/Conversation.tsx
@@ -23,7 +23,7 @@ export function Conversation({ instance, session, store }: { instance: Chat<Chat
   const queued = store.queue(session.id);
   return <div className="@container relative flex h-full min-w-0 flex-1 flex-col">
     <div ref={viewport} data-chat-column className="min-h-0 flex-1 overflow-y-auto"><div ref={content} className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
-      {chat.messages.map(message => <Message key={message.id} message={message} streaming={streaming && message.id === last?.id} sessionId={session.id} onSend={send} onArtifact={openArtifact} onApprove={approve} />)}
+      {chat.messages.map(message => <Message key={message.id} message={message} streaming={streaming && message.id === last?.id} cwd={session.cwd} sessionId={session.id} onSend={send} onArtifact={openArtifact} onApprove={approve} />)}
       {chat.status === 'submitted' ? <p className="flex items-center gap-2 text-xs text-muted" role="status"><span className="size-1.5 animate-pulse rounded-full bg-accent" />正在连接…</p> : null}
       {chat.error || session.status === 'error' ? <div role="alert" className="flex items-center gap-3 rounded-xl border border-danger/40 px-3 py-2 text-xs text-danger"><span className="min-w-0 flex-1 break-words">{chat.error?.message ?? session.error ?? '这轮没有跑完'}</span><Button size="sm" variant="ghost" onClick={() => void store.retry(session.id)}>重试</Button></div> : null}
     </div></div>
@@ -36,7 +36,7 @@ export function Conversation({ instance, session, store }: { instance: Chat<Chat
   </div>;
 }
 
-const Message = memo(function Message({ message, streaming, sessionId, onSend, onArtifact, onApprove }: { message: ChatMessage; streaming: boolean; sessionId: string; onSend: (text: string) => void; onArtifact: (path: string) => void; onApprove: (id: string, approved: boolean) => Promise<unknown> }) {
+const Message = memo(function Message({ message, streaming, sessionId, cwd, onSend, onArtifact, onApprove }: { message: ChatMessage; streaming: boolean; sessionId: string; cwd: string; onSend: (text: string) => void; onArtifact: (path: string) => void; onApprove: (id: string, approved: boolean) => Promise<unknown> }) {
   // The server forwards one part per output delta; the joined text exists only here.
   const outputs = new Map<string, string>();
   const firstDelta = new Map<string, number>();
@@ -53,7 +53,7 @@ const Message = memo(function Message({ message, streaming, sessionId, onSend, o
     {message.parts.map((part, index) => {
       if (part.type === 'text') return <MessageBody key={index} text={part.text} messageId={`${message.id}:${index}`} streaming={streaming} sessionId={sessionId} onSend={onSend} allowUi={message.role === 'assistant'} />;
       if (part.type === 'reasoning') return <details key={index} className="overflow-clip rounded-lg border border-border text-xs text-muted"><summary className="cursor-pointer px-3 py-2 select-none">思考过程</summary><Collapsible className="border-t border-border"><p className="px-3 py-2 leading-relaxed whitespace-pre-wrap">{part.text}</p></Collapsible></details>;
-      if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') return <ToolCall key={index} part={part} commandOutput={'toolCallId' in part ? outputs.get(part.toolCallId) : undefined} onArtifact={onArtifact} />;
+      if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') return <ToolCall key={index} cwd={cwd} part={part} commandOutput={'toolCallId' in part ? outputs.get(part.toolCallId) : undefined} onArtifact={onArtifact} />;
       if (part.type === 'data-approval') return <ApprovalCard key={part.data.id} approval={part.data} onDecide={approved => onApprove(part.data.id, approved)} />;
       // An orphan command stream renders once, at its first delta, carrying the joined output.
       if (part.type === 'data-command') return !toolIds.has(part.data.toolCallId) && firstDelta.get(part.data.toolCallId) === index ? <ToolCall key={index} part={{ type: 'tool-command', state: streaming ? 'input-available' : 'output-available', output: outputs.get(part.data.toolCallId) }} onArtifact={onArtifact} /> : null;

--- a/artifacts/src/web/components/chat/ToolCall.tsx
+++ b/artifacts/src/web/components/chat/ToolCall.tsx
@@ -3,9 +3,10 @@ import { CodeBlock } from '../code/CodeBlock';
 import { Collapsible } from '../code/Collapsible';
 import { Icon } from '../Icon';
 import { toolOutput } from './tool-output';
+import { artifactEntryPath } from '../../../shared/artifact-path';
 
 type Tool = { type: string; toolName?: string; state?: string; input?: unknown; output?: unknown; errorText?: string; toolCallId?: string };
-export const ToolCall = memo(function ToolCall({ part, commandOutput, onArtifact }: { part: Tool; commandOutput?: string; onArtifact: (path: string) => void }) {
+export const ToolCall = memo(function ToolCall({ part, commandOutput, cwd = '', onArtifact }: { part: Tool; commandOutput?: string; cwd?: string; onArtifact: (path: string) => void }) {
   const name = part.toolName ?? part.type.replace(/^tool-/, '');
   const input = part.input as Record<string, unknown> | undefined;
   const file = input?.file_path ?? input?.path ?? input?.filePath ?? input?.filename;
@@ -14,6 +15,6 @@ export const ToolCall = memo(function ToolCall({ part, commandOutput, onArtifact
   const working = part.state === 'input-streaming' || part.state === 'input-available';
   const source = typeof input?.content === 'string' ? input.content : typeof command === 'string' ? command : input ? JSON.stringify(input, null, 2) : '';
   const output = toolOutput(part, commandOutput);
-  const canvas = typeof file === 'string' && file.includes('.artifacts/') && file.endsWith('.tsx');
+  const canvas = typeof file === 'string' ? artifactEntryPath(file, cwd) : undefined;
   return <details className="overflow-clip rounded-lg border border-border text-xs" open={working || undefined}><summary className="interactive sticky top-0 z-20 flex cursor-pointer list-none items-center gap-2 bg-surface px-3 py-2 text-muted hover:text-fg">{working ? <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-accent" /> : <Icon name={part.state === 'output-error' ? 'x' : 'check'} className="size-3.5 shrink-0" />}<span className="shrink-0 font-medium">{name}</span><span className="min-w-0 flex-1 truncate">{hint}</span></summary>{source ? <Collapsible className="border-t border-border"><CodeBlock code={source} lang={typeof input?.content === 'string' ? 'tsx' : typeof command === 'string' ? 'bash' : 'json'} /></Collapsible> : null}{output ? <Collapsible className="border-t border-border"><CodeBlock code={output} lang="text" /></Collapsible> : null}{part.errorText ? <p className="px-3 py-2 whitespace-pre-wrap text-danger">{part.errorText}</p> : null}{canvas ? <button type="button" onClick={() => onArtifact(file as string)} className="interactive m-2 rounded-md px-2 py-1 text-muted hover:bg-surface-3">在 Canvas 中打开</button> : null}</details>;
 });


### PR DESCRIPTION
Tool calls commonly return absolute file paths, while the Canvas list uses workspace-relative keys. Normalize both through one shared entry contract so clicking “Open in Canvas” opens the file immediately; exclude helper modules and paths outside the session workspace.

Validation: focused path tests cover POSIX, Windows, relative paths and escapes; typecheck passes; production browser confirms the absolute-path tool card opens its Canvas.