### PR TITLE
keep unsent drafts with their sessions

### DIFF
--- a/artifacts/src/web/chat/store.test.ts
+++ b/artifacts/src/web/chat/store.test.ts
@@ -8,6 +8,17 @@ const session = (id: string): Session => ({ id, harness: 'claude-code', cwd: '/w
 const tick = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('persistent session chat connections', () => {
+  test('drafts belong to sessions and keystrokes do not publish the workspace snapshot', () => {
+    const store = new WorkspaceStore(), snapshot = store.getSnapshot();
+    let firstUpdates = 0, secondUpdates = 0;
+    const unsubscribe = store.subscribeDraft('first', () => firstUpdates++);
+    store.subscribeDraft('second', () => secondUpdates++);
+    store.setDraft('first', 'Unsent in A'); store.setDraft('second', 'Unsent in B');
+    expect(store.draft('first')).toBe('Unsent in A'); expect(store.draft('second')).toBe('Unsent in B');
+    expect(firstUpdates).toBe(1); expect(secondUpdates).toBe(1); expect(store.getSnapshot()).toBe(snapshot);
+    store.setDraft('first', ''); expect(store.draft('second')).toBe('Unsent in B');
+    unsubscribe(); store.setDraft('first', 'New draft'); expect(firstUpdates).toBe(2);
+  });
   for (const failure of ['network', 400, 409] as const) test(`a rejected ${failure} submission preserves its prompt and retries the same message only on demand`, async () => {
     const first = session('first');
     const requests: { id: string; messages: Session['messages'] }[] = [];

--- a/artifacts/src/web/chat/store.ts
+++ b/artifacts/src/web/chat/store.ts
@@ -27,6 +27,8 @@ export class WorkspaceStore {
   private files = new Map<string, Map<string, Artifact>>();
   private liveRevisions = new Map<string, Map<string, number>>();
   private queues = new Map<string, QueueItem[]>();
+  private drafts = new Map<string, string>();
+  private draftListeners = new Map<string, Set<() => void>>();
   private inflight = new Set<string>();
   private metadata = new Map<string, AbortController>();
   private turns = new Map<string, number>();
@@ -43,6 +45,14 @@ export class WorkspaceStore {
   chat = (id: string) => this.chats.get(id);
   artifacts = (id: string) => [...(this.files.get(id)?.values() ?? [])];
   queue = (id: string) => this.queues.get(id) ?? [];
+  draft = (id: string) => this.drafts.get(id) ?? '';
+  subscribeDraft = (id: string, listener: () => void) => { let listeners = this.draftListeners.get(id); if (!listeners) this.draftListeners.set(id, listeners = new Set()); listeners.add(listener); return () => { listeners.delete(listener); if (!listeners.size) this.draftListeners.delete(id); }; };
+  setDraft = (id: string, text: string) => {
+    if (this.draft(id) === text) return;
+    text ? this.drafts.set(id, text) : this.drafts.delete(id);
+    // Keystrokes only notify this composer; streaming history and the application shell need not render again.
+    for (const listener of this.draftListeners.get(id) ?? []) listener();
+  };
   selectedArtifact = (id: string) => this.selectedArtifacts.get(id);
 
   initialize = () => this.initialization ??= this.loadInitial();
@@ -153,7 +163,7 @@ export class WorkspaceStore {
   };
   remove = async (id: string) => {
     await api(`/api/sessions/${id}`, { method: 'DELETE' });
-    this.cancelMetadata(id); this.turns.delete(id);
+    this.cancelMetadata(id); this.turns.delete(id); this.setDraft(id, '');
     this.chats.delete(id); this.files.delete(id); this.liveRevisions.delete(id); this.queues.delete(id); this.selectedArtifacts.delete(id); this.dismissed.delete(id);
     const sessions = this.snapshot.sessions.filter(session => session.id !== id);
     this.publish({ sessions, activeId: this.snapshot.activeId === id ? sessions[0]?.id ?? null : this.snapshot.activeId });

--- a/artifacts/src/web/components/chat/Composer.tsx
+++ b/artifacts/src/web/components/chat/Composer.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { useInputHistory } from './useInputHistory';
 import { Icon } from '../Icon';
 
-export function Composer({ disabled, busy, onSend, onStop }: { disabled: boolean; busy: boolean; onSend: (text: string) => void; onStop: () => void }) {
-  const [text, setText] = useState('');
+export function Composer({ text, setText, disabled, busy, onSend, onStop }: { text: string; setText: (text: string) => void; disabled: boolean; busy: boolean; onSend: (text: string) => void; onStop: () => void }) {
   const helpId = useId();
   const area = useRef<HTMLTextAreaElement>(null);
   const history = useInputHistory(text, setText, area);

--- a/artifacts/src/web/components/chat/Conversation.tsx
+++ b/artifacts/src/web/components/chat/Conversation.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useSyncExternalStore } from 'react';
 import { useChat, type Chat } from '@ai-sdk/react';
 import type { ChatMessage, SessionSummary } from '../../../shared/types';
 import type { WorkspaceStore } from '../../chat/store';
@@ -32,8 +32,14 @@ export function Conversation({ instance, session, store }: { instance: Chat<Chat
       {queued.length ? <div className="mb-2 flex flex-col gap-1 rounded-xl border border-border p-2">{queued.map(item => <div key={item.id} className="flex items-center gap-2 text-xs text-muted"><span className="shrink-0">排队中</span><span className="min-w-0 flex-1 truncate">{item.text}</span><button type="button" title="移除排队消息" aria-label="移除排队消息" onClick={() => store.dropQueued(session.id, item.id)} className="interactive grid size-7 place-items-center rounded-md hover:bg-surface-3"><Icon name="x" className="size-3.5" /></button></div>)}</div> : null}
       {suggestions.length ? <div className="mb-2 flex flex-wrap gap-2">{suggestions.map(item => <Button key={item} variant="ghost" size="sm" onClick={() => send(item)} className="suggestion h-auto max-w-full rounded-full border border-border py-1.5 text-left font-normal whitespace-normal break-words">{item}</Button>)}</div> : null}
     </div></div>
-    <Composer disabled={false} busy={streaming} onSend={send} onStop={() => void store.stop(session.id).catch(store.fail)} />
+    <SessionComposer store={store} sessionId={session.id} busy={streaming} onSend={send} />
   </div>;
+}
+
+function SessionComposer({ store, sessionId, busy, onSend }: { store: WorkspaceStore; sessionId: string; busy: boolean; onSend: (text: string) => void }) {
+  const subscribe = useCallback((listener: () => void) => store.subscribeDraft(sessionId, listener), [store, sessionId]);
+  const text = useSyncExternalStore(subscribe, () => store.draft(sessionId));
+  return <Composer text={text} setText={value => store.setDraft(sessionId, value)} disabled={false} busy={busy} onSend={onSend} onStop={() => void store.stop(sessionId).catch(store.fail)} />;
 }
 
 const Message = memo(function Message({ message, streaming, sessionId, cwd, onSend, onArtifact, onApprove }: { message: ChatMessage; streaming: boolean; sessionId: string; cwd: string; onSend: (text: string) => void; onArtifact: (path: string) => void; onApprove: (id: string, approved: boolean) => Promise<unknown> }) {


### PR DESCRIPTION
Switching conversations currently unmounts the composer and discards its input. Keep drafts in the session store with a dedicated subscription, so returning to a conversation restores its text without rerendering the application on every keystroke.

Validation: session isolation and subscription tests pass; typecheck passes; production browser confirms A → B → A restores the unsent draft.

Stacked on `fix/canvas-tool-paths`; this diff contains only draft persistence.