### PR TITLE
preserve canvas dependency modules across revisions

### DIFF
--- a/artifacts/src/web/ui4a/Ui4aSurface.tsx
+++ b/artifacts/src/web/ui4a/Ui4aSurface.tsx
@@ -50,6 +50,9 @@ export function Ui4aSurface({ source, streaming, scope, sessionId, filename, rev
     let disposed = false;
     setPainted(false);
     let renderer: GenUIRenderer | null = null;
+    let surfaceDelivery: SurfaceDelivery | null = null;
+    let compilingSource: string | undefined, readySource: string | undefined;
+    const compiler = createTsxCompiler();
     const modules = createSurfaceModules(sessionId, scope, (text) => send(text));
     const imports = createSurfaceImports(modules.imports, modules.readFile);
     const surfaceStyles = createSurfaceStyles(target);
@@ -57,21 +60,26 @@ export function Ui4aSurface({ source, streaming, scope, sessionId, filename, rev
     void surfaceStyles.update(latest.current.source, latest.current.streaming);
     void GenUIRenderer.create(target, {
       filename, importmap: { imports: modules.imports }, preserveStateOnUpdate: true, flushMode: "immediate",
-      callbacks: { onError: (error) => { if (!disposed) report(error); }, onRendered: () => { if (!disposed) setPainted(true); } },
+      compiler: { compile: (code, options) => { compilingSource = code; surfaceDelivery?.compiling(code); return compiler.compile(code, options); } },
+      callbacks: {
+        onReady: (_component, _url, code) => { readySource = code; if (code !== undefined) surfaceDelivery?.ready(code); },
+        onError: (error, phase) => { if (!disposed) { surfaceDelivery?.failed(phase === "render" ? readySource : compilingSource, phase); report(error); } },
+        onRendered: (_component, _code, serial) => { if (!disposed) { surfaceDelivery?.rendered(serial); setPainted(true); } },
+      },
     }).then((created) => {
       if (disposed) { created.detach(); return; }
       renderer = created;
-      delivery.current = new SurfaceDelivery(created, imports.resolve, (error) => report(error));
+      surfaceDelivery = new SurfaceDelivery(created, imports.resolve, (error) => report(error));
+      delivery.current = surfaceDelivery;
       delivery.current.update(latest.current);
     }).catch((error) => { if (!disposed) report(error); });
     return () => {
       disposed = true;
-      delivery.current?.dispose();
       delivery.current = null;
       styles.current = null;
       surfaceStyles.dispose();
       // The nested React root must finish its parent's commit before unmounting; then no generated callback can read a released bridge.
-      queueMicrotask(() => { renderer?.detach(); imports.dispose(); modules.dispose(); });
+      queueMicrotask(() => { renderer?.detach(); surfaceDelivery?.dispose(); imports.dispose(); modules.dispose(); });
     };
   }, [sessionId, scope, filename]);
 

--- a/artifacts/src/web/ui4a/delivery.ts
+++ b/artifacts/src/web/ui4a/delivery.ts
@@ -2,23 +2,23 @@ import type { RendererImportMap } from "partial-react/import-map";
 import { importSignature, type ImportRequest, type PreparedImports } from "./imports";
 
 export type SurfaceFrame = ImportRequest & { streaming: boolean };
-export type RendererPort = { pushCode: (delta: string) => void; render: (source: string) => void; finish: (source: string) => void; clear: (options?: { preserveVisualState: boolean }) => void; setImportMap: (map: RendererImportMap) => unknown };
+export type RendererPort = { pushCode: (delta: string, serial?: number) => void; render: (source: string, serial?: number) => void; finish: (source: string, serial?: number) => void; clear: (options?: { preserveVisualState: boolean }) => void; setImportMap: (map: RendererImportMap) => unknown };
 
-export function deliverFrame(renderer: RendererPort, frame: SurfaceFrame, previous: { source: string; streaming: boolean } | null, force = false): boolean {
+export function deliverFrame(renderer: RendererPort, frame: SurfaceFrame, previous: { source: string; streaming: boolean } | null, force = false, serial?: number): boolean {
   if (!frame.streaming) {
     // Always finish a streaming buffer, even when its bytes did not change: final syntax errors and render context must settle.
-    if (previous?.streaming) renderer.finish(frame.source);
-    else if (force || frame.source !== previous?.source) renderer.render(frame.source);
+    if (previous?.streaming) renderer.finish(frame.source, serial);
+    else if (force || frame.source !== previous?.source) renderer.render(frame.source, serial);
     else return false;
     return true;
   }
   if (!force && previous && frame.source.startsWith(previous.source)) {
     const delta = frame.source.slice(previous.source.length);
     if (!delta) return false;
-    renderer.pushCode(delta);
+    renderer.pushCode(delta, serial);
   } else {
     if (previous) renderer.clear({ preserveVisualState: true });
-    renderer.pushCode(frame.source);
+    renderer.pushCode(frame.source, serial);
   }
   return true;
 }
@@ -32,6 +32,12 @@ export class SurfaceDelivery {
   private epoch = 0;
   private disposed = false;
   private resolutionError: Error | null = null;
+  private abort?: AbortController;
+  private serial = 0;
+  private committedSerial = 0;
+  private committed: PreparedImports | null = null;
+  private leases = new Set<PreparedImports>();
+  private submissions = new Map<number, { imports: PreparedImports; source: string; stage: "pending" | "compiling" | "ready" }>();
 
   constructor(private renderer: RendererPort, private resolve: (request: ImportRequest) => Promise<PreparedImports>, private onError: (error: Error) => void) {}
 
@@ -40,6 +46,7 @@ export class SurfaceDelivery {
     this.latest = frame;
     if (!frame.source.trim()) {
       this.epoch++;
+      this.abort?.abort();
       this.signature = null;
       this.prepared = null;
       this.delivered = null;
@@ -55,9 +62,12 @@ export class SurfaceDelivery {
     this.signature = signature;
     this.prepared = null;
     this.resolutionError = null;
+    this.abort?.abort();
+    this.abort = new AbortController();
     const epoch = ++this.epoch;
-    void this.resolve(frame).then((prepared) => {
-      if (this.disposed || epoch !== this.epoch) return;
+    void this.resolve({ ...frame, signal: this.abort.signal }).then((prepared) => {
+      if (this.disposed || epoch !== this.epoch) { prepared.release?.(); return; }
+      this.leases.add(prepared);
       this.prepared = prepared;
       this.renderer.setImportMap(prepared.importMap);
       this.deliver(true);
@@ -71,8 +81,48 @@ export class SurfaceDelivery {
   private deliver(force = false) {
     if (!this.latest || !this.prepared) return;
     const frame = { ...this.latest, source: this.prepared.rewrite(this.latest.source) };
-    if (deliverFrame(this.renderer, frame, this.delivered, force)) this.delivered = frame;
+    const serial = ++this.serial;
+    this.submissions.set(serial, { imports: this.prepared, source: frame.source, stage: "pending" });
+    if (deliverFrame(this.renderer, frame, this.delivered, force, serial)) {
+      this.delivered = frame;
+      // The renderer compiles single-flight and coalesces queued frames. Only the latest unstarted frame can run.
+      for (const [id, submission] of this.submissions) if (id < serial && submission.stage === "pending") this.submissions.delete(id);
+    } else this.submissions.delete(serial);
+    this.collect();
   }
 
-  dispose() { this.disposed = true; this.epoch++; }
+  compiling(source: string) {
+    for (const [id, submission] of this.submissions) {
+      if (submission.stage === "compiling") this.submissions.delete(id);
+      else if (submission.stage === "pending" && submission.source === source) submission.stage = "compiling";
+    }
+    this.collect();
+  }
+
+  ready(source: string) { for (const submission of this.submissions.values()) if (submission.stage === "compiling" && submission.source === source) submission.stage = "ready"; }
+
+  rendered(serial?: number) {
+    if (serial === undefined || serial <= this.committedSerial) return; // A last-good rollback has no request serial.
+    const submission = this.submissions.get(serial);
+    if (!submission) return;
+    this.committed = submission.imports;
+    this.committedSerial = serial;
+    for (const id of this.submissions.keys()) if (id <= serial) this.submissions.delete(id);
+    this.collect();
+  }
+
+  failed(source: string | undefined, phase: "transform" | "compile" | "render") {
+    const stage = phase === "render" ? "ready" : "compiling";
+    const failed = [...this.submissions].findLast(([, submission]) => submission.stage === stage && submission.source === source);
+    if (failed) for (const id of this.submissions.keys()) if (id <= failed[0]) this.submissions.delete(id);
+    this.collect();
+  }
+
+  private collect() {
+    const live = new Set([this.prepared, this.committed, ...[...this.submissions.values()].map((submission) => submission.imports)]);
+    for (const imports of this.leases) if (!live.has(imports)) { imports.release?.(); this.leases.delete(imports); }
+  }
+
+  /** Detach the renderer first: its last-good component can still call a lazy relative import until unmounted. */
+  dispose() { this.disposed = true; this.epoch++; this.abort?.abort(); for (const imports of this.leases) imports.release?.(); this.leases.clear(); this.submissions.clear(); }
 }

--- a/artifacts/src/web/ui4a/imports.test.ts
+++ b/artifacts/src/web/ui4a/imports.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "bun:test";
+import { createSurfaceImports } from "./imports";
+import { SurfaceDelivery, type RendererPort } from "./delivery";
+
+const filename = ".artifacts/canvases/main.tsx";
+const source = 'import Counter from "./counter.tsx"; export default Counter;';
+const tick = () => Promise.resolve();
+const deferred = <T,>() => { let resolve!: (value: T) => void; const promise = new Promise<T>((done) => { resolve = done; }); return { promise, resolve }; };
+function fixture(initial: Record<string, string>) {
+  const files = { ...initial }, compiled: string[] = [], created: string[] = [], revoked: string[] = [];
+  const imports = createSurfaceImports({}, async (path) => {
+    if (!(path in files)) throw Object.assign(new Error("missing file"), { status: 404 });
+    return files[path]!;
+  }, {
+    fallback: { kind: "fallback", resolve: () => ({ imports: {} }) },
+    compiler: { compile: async (code) => { if (code.includes("SYNTAX_ERROR")) throw new Error("invalid module"); compiled.push(code); return { code, source: code, changed: true }; } },
+    createModuleUrl: () => { const url = `blob:module-${created.length}`; created.push(url); return url; }, revokeModuleUrl: (url) => { revoked.push(url); },
+  });
+  return { files, compiled, created, revoked, imports };
+}
+
+test("100 unchanged revisions retain the same imported component identity without new Blob URLs", async () => {
+  const { imports, compiled, created, revoked } = fixture({ ".artifacts/canvases/counter.tsx": "export default function Counter() {}" });
+  let current = await imports.resolve({ source, filename, revision: 0 });
+  const rewritten = current.rewrite(source);
+  for (let revision = 1; revision <= 100; revision++) {
+    const next = await imports.resolve({ source, filename, revision });
+    expect(next.rewrite(source)).toBe(rewritten);
+    current.release!(); current = next;
+  }
+  expect(compiled).toHaveLength(1);
+  expect(created).toHaveLength(1);
+  expect(revoked).toHaveLength(0);
+  current.release!(); current.release!(); imports.dispose();
+  expect(revoked).toEqual(created);
+});
+
+test("100 failed renders retain only the last-good and latest graphs", async () => {
+  const { imports, files, created, revoked } = fixture({ ".artifacts/canvases/counter.tsx": "export default 0;" });
+  let submitted = deferred<{ source: string; serial: number }>();
+  const renderer: RendererPort = { pushCode() {}, finish() {}, clear() {}, setImportMap() {}, render(source, serial) { submitted.resolve({ source, serial: serial! }); } };
+  const delivery = new SurfaceDelivery(renderer, imports.resolve, () => {});
+  const update = async (revision: number) => {
+    submitted = deferred();
+    delivery.update({ source, filename, revision, streaming: false });
+    const rendered = await submitted.promise;
+    delivery.compiling(rendered.source); delivery.ready(rendered.source);
+    return rendered;
+  };
+  const first = await update(0);
+  delivery.rendered(first.serial);
+  for (let revision = 1; revision <= 100; revision++) {
+    files[".artifacts/canvases/counter.tsx"] = `export default ${revision};`;
+    const failed = await update(revision);
+    delivery.failed(failed.source, "render");
+    expect(created.length - revoked.length).toBe(2);
+    expect(revoked).not.toContain(created[0]!);
+  }
+  delivery.dispose(); imports.dispose();
+  expect(new Set(revoked)).toEqual(new Set(created));
+});
+
+test("a changed leaf replaces its ancestors, while shared and unrelated modules keep their URLs", async () => {
+  const { imports, files, compiled, created, revoked } = fixture({
+    ".artifacts/canvases/counter.tsx": 'import { count } from "./data.ts"; import "./shared.ts"; export default count;',
+    ".artifacts/canvases/data.ts": "export const count = 1;",
+    ".artifacts/canvases/shared.ts": "export const shared = 1;",
+    ".artifacts/canvases/other.ts": 'import "./shared.ts";',
+  });
+  const entry = source + 'import "./other.ts";';
+  const first = await imports.resolve({ source: entry, filename });
+  files[".artifacts/canvases/data.ts"] = "export const count = 2;";
+  const second = await imports.resolve({ source: entry, filename });
+  expect(compiled).toHaveLength(6); // Four initial modules, then only the leaf and its parent.
+  expect(second.rewrite(entry)).not.toBe(first.rewrite(entry));
+  expect(revoked).toHaveLength(0); // The old graph may still be visible or importing.
+  first.release!();
+  expect(revoked).toEqual([created[0]!, created[2]!]);
+  second.release!(); imports.dispose();
+  expect(new Set(revoked)).toEqual(new Set(created));
+});
+
+test("failed graph builds release new modules and preserve a retained last-good graph", async () => {
+  const { imports, files, created, revoked } = fixture({ ".artifacts/canvases/counter.tsx": 'import "./data.ts"; export default 1;', ".artifacts/canvases/data.ts": "export default 1;" });
+  const first = await imports.resolve({ source, filename });
+  files[".artifacts/canvases/data.ts"] = "export default 2;";
+  files[".artifacts/canvases/counter.tsx"] += "SYNTAX_ERROR";
+  await expect(imports.resolve({ source, filename })).rejects.toThrow("invalid module");
+  expect(revoked).toEqual([created[2]!]);
+  files[".artifacts/canvases/data.ts"] = "export default 1;";
+  files[".artifacts/canvases/counter.tsx"] = 'import "./data.ts"; export default 1;';
+  const recovered = await imports.resolve({ source, filename });
+  expect(recovered.rewrite(source)).toBe(first.rewrite(source));
+  recovered.release!(); first.release!(); imports.dispose();
+  expect(new Set(revoked)).toEqual(new Set(created));
+});
+
+test("concurrent identical graphs share compilation and keep shared URLs until both leases release", async () => {
+  const { imports, created, revoked } = fixture({ ".artifacts/canvases/counter.tsx": "export default 1;" });
+  const [first, second] = await Promise.all([imports.resolve({ source, filename }), imports.resolve({ source, filename })]);
+  expect(created).toHaveLength(1);
+  expect(first.rewrite(source)).toBe(second.rewrite(source));
+  first.release!(); expect(revoked).toHaveLength(0);
+  second.release!(); expect(revoked).toEqual(created);
+  imports.dispose();
+});
+
+test("late stale reads cannot replace a newer cached graph", async () => {
+  const old = deferred<string>();
+  let reads = 0, urls = 0;
+  const revoked: string[] = [];
+  const imports = createSurfaceImports({}, () => ++reads === 1 ? old.promise : Promise.resolve("export default 2;"), {
+    fallback: { kind: "fallback", resolve: () => ({ imports: {} }) },
+    compiler: { compile: async (code) => ({ code, source: code, changed: true }) }, createModuleUrl: () => `blob:${urls++}`, revokeModuleUrl: (url) => { revoked.push(url); },
+  });
+  const abort = new AbortController();
+  const stale = imports.resolve({ source, filename, signal: abort.signal });
+  abort.abort();
+  const latest = await imports.resolve({ source, filename });
+  old.resolve("export default 1;");
+  await expect(stale).rejects.toThrow();
+  const repeat = await imports.resolve({ source, filename });
+  expect(repeat.rewrite(source)).toBe(latest.rewrite(source));
+  expect(urls).toBe(1);
+  expect(revoked).toHaveLength(0);
+  repeat.release!(); latest.release!(); imports.dispose();
+});
+
+test("disposal during compilation cannot create a live URL afterward", async () => {
+  const compile = deferred<{ code: string; source: string; changed: boolean }>();
+  let started = false, created = false;
+  const imports = createSurfaceImports({}, async () => "export default 1;", {
+    fallback: { kind: "fallback", resolve: () => ({ imports: {} }) },
+    compiler: { compile: () => { started = true; return compile.promise; } }, createModuleUrl: () => { created = true; return "blob:late"; },
+  });
+  const pending = imports.resolve({ source, filename });
+  while (!started) await tick();
+  imports.dispose();
+  compile.resolve({ code: "export default 1;", source: "export default 1;", changed: true });
+  await expect(pending).rejects.toThrow("closed");
+  expect(created).toBe(false);
+});

--- a/artifacts/src/web/ui4a/imports.ts
+++ b/artifacts/src/web/ui4a/imports.ts
@@ -4,15 +4,18 @@ import { createEsmShModuleResolver, transformedEsmShFallback } from "partial-rea
 import { relativeUi4aPath, ui4aPath } from "./files";
 import { ui4aModules } from "./manifest";
 
-export type PreparedImports = { importMap: RendererImportMap; rewrite: (source: string) => string };
-export type ImportRequest = { source: string; filename?: string; revision?: string | number };
+export type PreparedImports = { importMap: RendererImportMap; rewrite: (source: string) => string; release?: () => void };
+export type ImportRequest = { source: string; filename?: string; revision?: string | number; signal?: AbortSignal };
+type CachedModule = { refs: number; url?: string; pending: Promise<string> };
 const relative = (specifier: string) => specifier.startsWith("./") || specifier.startsWith("../");
 export const importSignature = ({ source, filename, revision }: ImportRequest) => JSON.stringify([filename, revision, [...extractImportSpecifiers(source)].sort()]);
 
 export function createSurfaceImports(baseImports: Record<string, string>, readFile: (path: string) => Promise<string>, options: { compiler?: TsxCompiler; fallback?: ReturnType<typeof transformedEsmShFallback>; createModuleUrl?: (code: string) => string; revokeModuleUrl?: (url: string) => void } = {}) {
   const compiler = options.compiler ?? createTsxCompiler();
   const urls = new Set<string>();
+  const cache = new Map<string, CachedModule>();
   let disposed = false;
+  const revokeModuleUrl = (url: string) => { if (urls.delete(url)) (options.revokeModuleUrl ?? URL.revokeObjectURL)(url); };
   const createModuleUrl = (code: string) => {
     if (disposed) throw new Error("UI4A surface was closed");
     const url = options.createModuleUrl?.(code) ?? URL.createObjectURL(new Blob([code], { type: "text/javascript" }));
@@ -27,44 +30,77 @@ export function createSurfaceImports(baseImports: Record<string, string>, readFi
   };
 
   return {
-    async resolve({ source, filename }: ImportRequest): Promise<PreparedImports> {
-      const modules = new Map<string, string>();
-      const loaded = new Map<string, { filename: string; source: string }>();
-      const localSpecifiers = [...extractImportSpecifiers(source)].filter(relative);
-      if (localSpecifiers.length && !filename) throw new Error("Relative imports require a .artifacts file canvas; inline UI can import React and $ui4a modules directly.");
-      const readModule = async (requested: string) => {
-        const cached = loaded.get(requested);
-        if (cached) return cached;
-        const candidates = /\.[cm]?[jt]sx?$|\.json$/.test(requested) ? [requested] : [requested, ...[".tsx", ".ts", ".jsx", ".js", "/index.tsx", "/index.ts", ".json"].map((suffix) => requested + suffix)];
-        for (const filename of candidates) {
-          try {
-            const found = { filename, source: await readFile(filename) };
-            loaded.set(requested, found);
-            return found;
-          } catch (error) { if ((error as { status?: number }).status !== 404) throw error; }
+    async resolve({ source, filename, signal }: ImportRequest): Promise<PreparedImports> {
+      const retained = new Map<string, CachedModule>();
+      const check = () => { signal?.throwIfAborted(); if (disposed) throw new Error("UI4A surface was closed"); };
+      const release = () => {
+        for (const [key, module] of retained) if (--module.refs === 0) {
+          cache.delete(key);
+          if (module.url) revokeModuleUrl(module.url);
         }
-        throw new Error(`UI4A module ${requested} was not found`);
+        retained.clear();
       };
-      const compileModule = async (requested: string, ancestors: string[]): Promise<string> => {
-        const found = await readModule(requested);
-        if (ancestors.includes(found.filename)) throw new Error(`Circular UI4A imports: ${[...ancestors, found.filename].join(" → ")}`);
-        const cached = modules.get(found.filename);
-        if (cached) return cached;
-        if (loaded.size > 128) throw new Error("UI4A canvas imports more than 128 modules");
-        const source = found.filename.endsWith(".json") ? `export default ${JSON.stringify(JSON.parse(found.source))};` : found.source;
+      check();
+      const prepare = async (): Promise<PreparedImports> => {
+        const modules = new Map<string, string>();
+        const loaded = new Map<string, { filename: string; source: string }>();
+        const localSpecifiers = [...extractImportSpecifiers(source)].filter(relative);
+        if (localSpecifiers.length && !filename) throw new Error("Relative imports require a .artifacts file canvas; inline UI can import React and $ui4a modules directly.");
+        const readModule = async (requested: string) => {
+          const cached = loaded.get(requested);
+          if (cached) return cached;
+          const candidates = /\.[cm]?[jt]sx?$|\.json$/.test(requested) ? [requested] : [requested, ...[".tsx", ".ts", ".jsx", ".js", "/index.tsx", "/index.ts", ".json"].map((suffix) => requested + suffix)];
+          for (const filename of candidates) {
+            try {
+              const found = { filename, source: await readFile(filename) };
+              check();
+              loaded.set(requested, found);
+              return found;
+            } catch (error) { if ((error as { status?: number }).status !== 404) throw error; }
+          }
+          throw new Error(`UI4A module ${requested} was not found`);
+        };
+        const compileModule = async (requested: string, ancestors: string[]): Promise<string> => {
+          const found = await readModule(requested);
+          if (ancestors.includes(found.filename)) throw new Error(`Circular UI4A imports: ${[...ancestors, found.filename].join(" → ")}`);
+          const cached = modules.get(found.filename);
+          if (cached) return cached;
+          if (loaded.size > 128) throw new Error("UI4A canvas imports more than 128 modules");
+          const source = found.filename.endsWith(".json") ? `export default ${JSON.stringify(JSON.parse(found.source))};` : found.source;
+          const rewrites: Record<string, string> = {};
+          // Resolve each branch to completion before caching it: two concurrent cyclic branches can otherwise await each other forever.
+          for (const specifier of extractImportSpecifiers(source)) if (relative(specifier)) rewrites[specifier] = await compileModule(relativeUi4aPath(specifier, found.filename), [...ancestors, found.filename]);
+          const importMap = await resolveBare(source);
+          check();
+          const rewritten = rewriteImportSpecifiers(source, rewrites);
+          // Relative URLs carry the identity of the entire dependency graph. A leaf edit invalidates its ancestors,
+          // while an unrelated revision keeps React component exports (and their local state) identical.
+          const key = JSON.stringify([found.filename, rewritten, importMap]);
+          let module = cache.get(key);
+          if (!module) {
+            const entry: CachedModule = { refs: 0, pending: compiler.compile(rewritten, { filename: found.filename, importMap }).then((result) => {
+              const url = createModuleUrl(result.code);
+              entry.url = url;
+              if (!entry.refs) revokeModuleUrl(url);
+              return url;
+            }) };
+            cache.set(key, entry);
+            module = entry;
+          }
+          if (!retained.has(key)) { module.refs++; retained.set(key, module); }
+          const url = await module.pending;
+          check();
+          modules.set(found.filename, url);
+          return url;
+        };
         const rewrites: Record<string, string> = {};
-        // Resolve each branch to completion before caching it: two concurrent cyclic branches can otherwise await each other forever.
-        for (const specifier of extractImportSpecifiers(source)) if (relative(specifier)) rewrites[specifier] = await compileModule(relativeUi4aPath(specifier, found.filename), [...ancestors, found.filename]);
+        for (const specifier of localSpecifiers) rewrites[specifier] = await compileModule(relativeUi4aPath(specifier, ui4aPath(filename!)), [filename!]);
         const importMap = await resolveBare(source);
-        const result = await compiler.compile(rewriteImportSpecifiers(source, rewrites), { filename: found.filename, importMap });
-        const url = createModuleUrl(result.code);
-        modules.set(found.filename, url);
-        return url;
+        check();
+        return { importMap, rewrite: (code) => rewriteImportSpecifiers(code, rewrites), release };
       };
-      const rewrites: Record<string, string> = {};
-      for (const specifier of localSpecifiers) rewrites[specifier] = await compileModule(relativeUi4aPath(specifier, ui4aPath(filename!)), [filename!]);
-      return { importMap: await resolveBare(source), rewrite: (code) => rewriteImportSpecifiers(code, rewrites) };
+      try { return await prepare(); } catch (error) { release(); throw error; }
     },
-    dispose() { disposed = true; for (const url of urls) (options.revokeModuleUrl ?? URL.revokeObjectURL)(url); urls.clear(); },
+    dispose() { disposed = true; for (const url of urls) revokeModuleUrl(url); cache.clear(); },
   };
 }

--- a/artifacts/src/web/ui4a/runtime.test.ts
+++ b/artifacts/src/web/ui4a/runtime.test.ts
@@ -58,6 +58,49 @@ describe("surface delivery", () => {
     expect(calls.at(-1)).toEqual(["push", 'import "b";']);
   });
 
+  test("retains importing and last-good graphs while releasing coalesced and failed revisions", async () => {
+    const released: string[] = [];
+    const submitted: { source: string; serial: number }[] = [];
+    const { renderer } = recorder();
+    renderer.render = (source, serial) => { submitted.push({ source, serial: serial! }); };
+    const delivery = new SurfaceDelivery(renderer, async ({ source }) => ({ ...prepared(), release: () => { released.push(source); } }), () => {});
+    const update = async (source: string) => { delivery.update({ source, streaming: false, revision: source }); await tick(); return submitted.at(-1)!; };
+    const first = await update("first");
+    delivery.compiling(first.source); delivery.ready(first.source); delivery.rendered(first.serial);
+    const second = await update("second");
+    delivery.compiling(second.source);
+    await update("coalesced");
+    const latest = await update("latest");
+    expect(released).toEqual(["coalesced"]);
+    delivery.ready(second.source); delivery.failed(second.source, "render");
+    expect(released).toEqual(["coalesced", "second"]);
+    delivery.compiling(latest.source); delivery.ready(latest.source); delivery.rendered(latest.serial);
+    expect(released).toEqual(["coalesced", "second", "first"]);
+    delivery.rendered(first.serial);
+    delivery.dispose();
+    expect(released).toEqual(["coalesced", "second", "first", "latest"]);
+  });
+
+  test("failed imports leave the committed graph retained and stale leases release immediately", async () => {
+    const released: string[] = [];
+    const resolves: ((value: PreparedImports) => void)[] = [];
+    let renderedSerial = 0;
+    const { renderer } = recorder();
+    renderer.render = (_source, serial) => { renderedSerial = serial!; };
+    const delivery = new SurfaceDelivery(renderer, () => new Promise((done) => { resolves.push(done); }), () => {});
+    const lease = (id: string) => ({ ...prepared(), release: () => { released.push(id); } });
+    delivery.update({ source: "first", streaming: false, revision: 1 });
+    resolves[0]!(lease("first")); await tick();
+    delivery.compiling("first"); delivery.ready("first"); delivery.rendered(renderedSerial);
+    delivery.update({ source: "obsolete", streaming: false, revision: 2 });
+    delivery.update({ source: "latest", streaming: false, revision: 3 });
+    resolves[1]!(lease("obsolete")); await tick();
+    expect(released).toEqual(["obsolete"]);
+    delivery.dispose();
+    resolves[2]!(lease("latest")); await tick();
+    expect(released).toEqual(["obsolete", "first", "latest"]);
+  });
+
   test("import errors suppressed while streaming are reported on the final frame", async () => {
     const errors: string[] = [];
     const { renderer } = recorder();


### PR DESCRIPTION
Repeated artifact revisions currently compile unchanged imports into new Blob modules, resetting their React state and retaining old URLs until the Canvas closes. Cache by canonical file content and dependency graph, and release superseded graphs through renderer lifecycle events while retaining in-flight and last-good renders.

Validation: 20 focused regression tests cover 100 unchanged revisions, changed leaves, shared dependencies, cancellation, disposal and repeated render failures; typecheck and production build pass. Browser regression confirms an imported Counter stays at 1 after an identical dependency revision instead of resetting to 0.