### PR TITLE
add hosted pairing for local agents

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -2,10 +2,10 @@ name: docs site
 
 on:
   pull_request:
-    paths: ['site/**']
+    paths: ['site/**', 'artifacts/**', 'pnpm-lock.yaml', 'package.json']
   push:
     branches: [main]
-    paths: ['site/**']
+    paths: ['site/**', 'artifacts/**', 'pnpm-lock.yaml', 'package.json']
 
 permissions:
   contents: read
@@ -13,22 +13,21 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: site
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/setup@v1
         with:
-          package-json-file: site/package.json
+          package-json-file: package.json
           install: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
+        working-directory: site
       - run: pnpm typecheck
-      # `verify` builds the site (emitting build/client/api/search) then runs the
-      # search-index tests with REQUIRE_BUILT_INDEX=1 — so the real Orama route-
-      # wiring test fails hard if the `/api/search` artifact ever stops emitting,
-      # instead of silently skipping.
+        working-directory: site
+      # `verify` builds the site (including the embedded artifacts WebUI) then runs
+      # the search-index tests with REQUIRE_BUILT_INDEX=1.
       - run: pnpm verify
+        working-directory: site

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ macaron-artifacts
 
 Replace `<sha>` with the commit from a successful [package preview build](https://github.com/mindverse-ltd/macaron-artifacts/actions/workflows/pkg-pr-new.yml). Open `http://127.0.0.1:43860`, create a conversation, and choose its harness and workspace. An empty model field uses the harness default; for OpenCode and pi, enter an optional override as `provider/model`.
 
+To connect the hosted WebUI, start the server with `macaron-artifacts --pair`. Open [artifacts.macaron.im/connect](https://artifacts.macaron.im/connect), enter the address and the one-time code printed in the terminal, and the browser will open the local WebUI. Pairing codes expire after ten minutes and are consumed once. For a server reached through SSH, forward its loopback port first: `ssh -N -L 43860:127.0.0.1:43860 user@host`, then use `http://127.0.0.1:43860` in the connect form.
+
 ```sh
 macaron-artifacts --port 43860 --data-dir /path/to/session-data
 macaron-artifacts --help
@@ -48,6 +50,8 @@ Claude Code, Codex, OpenCode, and pi are supported. Kimi Code, Hermes, and dsh a
 | --- | --- |
 | `MACARON_PORT` | UI and API port, default `43860` |
 | `MACARON_DATA_DIR` | App conversation storage, default `~/.macaron-artifacts/sessions` |
+| `MACARON_PAIR` | Enable one-time hosted WebUI pairing (`1` or `true`) |
+| `MACARON_ALLOWED_ORIGINS` | Comma-separated hosted WebUI origins, default `https://artifacts.macaron.im` when pairing is enabled |
 | `MACARON_CLAUDE_PATH` | Claude Code executable |
 | `MACARON_CODEX_PATH` | Codex executable |
 | `MACARON_OPENCODE_PATH` | OpenCode executable |
@@ -57,7 +61,7 @@ Open **Profiles** in the sidebar to configure models, reasoning effort, service 
 
 You can also inherit your CLI's configuration. For Claude gateways, that includes `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY`. Variables injected only by a shell alias do not reach a separately launched app.
 
-Workspace files remain in each conversation's selected directory. Deleting an app conversation does not delete those files. The API binds to loopback and accepts same-origin browser requests. Generated React runs in the host page; use it with trusted local code.
+Workspace files remain in each conversation's selected directory. Deleting an app conversation does not delete those files. The API always binds to loopback; normal local UI requests are same-origin, while `--pair` adds an origin-bound Bearer connection for the hosted WebUI. Generated React runs in the host page; use it with trusted local code.
 
 ## Development
 

--- a/artifacts/src/server/index.ts
+++ b/artifacts/src/server/index.ts
@@ -13,9 +13,11 @@ import { MetadataTasks } from './enrichment.js';
 import { listArtifacts, readUi4aFile, writeUi4aFile } from './artifacts.js';
 import { ProfileStore, validateProfileInput } from './profiles.js';
 import { safeError } from './harnesses/common.js';
+import { PairingManager, bearerToken, isLoopbackHost, originHost, originProtocol, type PairingGrant, type PairingOptions } from './pairing.js';
 
-export async function createArtifactsServer(options: { directory: string; instructions: string; harnesses?: Partial<Record<HarnessId, HarnessAdapter>>; profiles?: ProfileStore; webRoot?: string }) {
+export async function createArtifactsServer(options: { directory: string; instructions: string; harnesses?: Partial<Record<HarnessId, HarnessAdapter>>; profiles?: ProfileStore; webRoot?: string; pairing?: PairingOptions }) {
   const store = new SessionStore(options.directory), active = new Map<string, ActiveConversation>(), claims = new Set<string>();
+  const pairing = new PairingManager(options.pairing);
   const profiles = options.profiles ?? new ProfileStore(join(options.directory, 'profiles'));
   const deletingProfiles = new Set<string>(), bindingProfiles = new Map<string, number>();
   // Reserve bindings before resolving async native config, so deletion cannot race a new session or a profile switch.
@@ -37,13 +39,53 @@ export async function createArtifactsServer(options: { directory: string; instru
   const server = createServer(async (req, res) => {
     try {
     const url = new URL(req.url || '/', 'http://localhost'), segments = url.pathname.split('/').filter(Boolean);
+    let grant: PairingGrant | undefined, localRequest = false;
     // Native harnesses can mutate files. A local browser must not let an unrelated origin trigger them.
     if (url.pathname.startsWith('/api/')) {
-      const host = new URL(`http://${req.headers.host || 'invalid'}`).hostname;
-      if (!['127.0.0.1', 'localhost', '[::1]'].includes(host)) return json(res, { error: 'A loopback host is required.' }, 403);
-      if (req.headers.origin && new URL(req.headers.origin).host !== req.headers.host) return json(res, { error: 'Cross-origin requests are not accepted.' }, 403);
+      const requestHost = req.headers.host;
+      if (!isLoopbackHost(requestHost)) return json(res, { error: 'A loopback host is required.' }, 403);
+      const origin = req.headers.origin;
+      const originHostValue = originHost(origin);
+      if (origin && !originHostValue) return json(res, { error: 'Invalid Origin.' }, 400);
+      const crossOrigin = Boolean(origin && (originHostValue !== requestHost || originProtocol(origin) !== 'http:'));
+      localRequest = !crossOrigin;
+      if (crossOrigin && !pairing.enabled) return json(res, { error: 'Cross-origin requests are not accepted.' }, 403);
+      if (crossOrigin && !pairing.originAllowed(origin)) return json(res, { error: 'This WebUI origin is not allowed.' }, 403);
+      if (crossOrigin) {
+        res.setHeader('access-control-allow-origin', origin!); res.setHeader('access-control-expose-headers', 'x-vercel-ai-ui-message-stream'); res.setHeader('vary', 'Origin');
+        const pairingRoute = url.pathname === '/api/pair';
+        const localOnlyRoute = url.pathname === '/api/pair/code' || url.pathname.startsWith('/api/pair/connections');
+        if (localOnlyRoute) return json(res, { error: 'This endpoint is local-only.' }, 403);
+        if (req.method === 'OPTIONS') { res.writeHead(204, { 'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS', 'access-control-allow-headers': 'authorization, content-type, accept', 'access-control-expose-headers': 'x-vercel-ai-ui-message-stream', 'access-control-max-age': '600', ...(req.headers['access-control-request-private-network'] === 'true' ? { 'access-control-allow-private-network': 'true' } : {}) }); return res.end(); }
+        if (url.pathname !== '/api/health' && !pairingRoute && !(grant = pairing.authenticate(bearerToken(req.headers.authorization), origin))) return json(res, { error: 'Pairing authentication required.', authRequired: true }, 401);
+      }
     }
       if (url.pathname === '/api/health') return json(res, { ok: true });
+      if (url.pathname === '/api/pair' && req.method === 'POST') {
+        if (localRequest || !req.headers.origin) return json(res, { error: 'Pairing must be claimed from the hosted WebUI.' }, 403);
+        const input = await body(req), result = pairing.claim(typeof input.code === 'string' ? input.code : '', req.headers.origin);
+        return json(res, result);
+      }
+      if (url.pathname === '/api/pair/code' && req.method === 'POST') {
+        if (!localRequest) return json(res, { error: 'This endpoint is local-only.' }, 403);
+        return json(res, pairing.generateCode());
+      }
+      if (url.pathname === '/api/connection' && req.method === 'GET') {
+        if (!localRequest && !grant) return json(res, { error: 'Pairing authentication required.', authRequired: true }, 401);
+        return json(res, grant ? pairing.context(grant) : { id: null, name: 'Local', expiresAt: null, protocolVersion: 1 });
+      }
+      if (url.pathname === '/api/connection' && req.method === 'DELETE') {
+        if (!grant) return json(res, { error: 'Pairing authentication required.', authRequired: true }, 401);
+        pairing.revokeCurrent(grant); return json(res, { ok: true });
+      }
+      if (url.pathname === '/api/pair/connections' && req.method === 'GET') {
+        if (!localRequest) return json(res, { error: 'This endpoint is local-only.' }, 403);
+        return json(res, pairing.list());
+      }
+      if (segments[0] === 'api' && segments[1] === 'pair' && segments[2] === 'connections' && segments[3] && req.method === 'DELETE') {
+        if (!localRequest) return json(res, { error: 'This endpoint is local-only.' }, 403);
+        return json(res, { ok: pairing.revoke(decodeURIComponent(segments[3])) });
+      }
       if (url.pathname === '/api/harnesses' && req.method === 'GET') return json(res, await Promise.all(Object.values(harnesses).map(adapter => adapter.info())));
       if (segments[0] === 'api' && segments[1] === 'harnesses' && segments[3] === 'profile-options' && req.method === 'GET') {
         const harness = segments[2] as HarnessId, adapter = Object.hasOwn(harnesses, harness) ? harnesses[harness] : undefined;
@@ -115,6 +157,7 @@ export async function createArtifactsServer(options: { directory: string; instru
         }
         if (segments[3] === 'metadata' && req.method === 'GET') {
           res.writeHead(200, { 'content-type': 'text/event-stream; charset=utf-8', 'cache-control': 'no-cache, no-transform', 'x-accel-buffering': 'no' }); req.socket.setNoDelay(true);
+          if (grant) pairing.track(grant, res);
           const unsubscribe = metadata.subscribe(session, { update: recap => res.write(`data: ${JSON.stringify(recap)}\n\n`), close: () => res.end() });
           res.on('close', unsubscribe); return;
         }
@@ -134,6 +177,7 @@ export async function createArtifactsServer(options: { directory: string; instru
       if (segments[0] === 'api' && segments[1] === 'chat' && segments[3] === 'stream' && req.method === 'GET') {
         const run = active.get(segments[2]);
         if (!run) { res.writeHead(204); return res.end(); }
+        if (grant) pairing.track(grant, res);
         req.socket.setNoDelay(true);
         return await pipeUIMessageStreamToResponse({ response: res, stream: run.stream(), headers: { 'cache-control': 'no-cache, no-transform', 'x-accel-buffering': 'no' } });
       }
@@ -167,6 +211,7 @@ export async function createArtifactsServer(options: { directory: string; instru
         } catch (error) { Object.assign(session, previous); throw error; }
         finally { claims.delete(session.id); }
         void run.done.finally(() => { if (active.get(session.id) === run) active.delete(session.id); }).catch(error => { console.error('Session persistence failed:', error); });
+        if (grant) pairing.track(grant, res);
         req.socket.setNoDelay(true);
         return await pipeUIMessageStreamToResponse({ response: res, stream: run.stream(), headers: { 'cache-control': 'no-cache, no-transform', 'x-accel-buffering': 'no' } });
       }
@@ -179,14 +224,23 @@ export async function createArtifactsServer(options: { directory: string; instru
       res.writeHead(200, { 'content-type': mime[extname(file)] ?? 'application/octet-stream' }); res.end(await readFile(file));
     } catch (error) { if (!res.headersSent) json(res, { error: safeError(error) }, (error as { status?: number }).status ?? (error as { statusCode?: number }).statusCode ?? ((error as NodeJS.ErrnoException).code === 'ENOENT' ? 404 : 400)); else res.end(); }
   });
-  return { server, store, profiles, active, async close() { for (const run of active.values()) run.stop(); await Promise.allSettled([...active.values()].map(run => run.done)); await metadata.close(); server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); } };
+  return { server, store, profiles, active, pairing, async close() { for (const run of active.values()) run.stop(); await Promise.allSettled([...active.values()].map(run => run.done)); await metadata.close(); server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); } };
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   const root = resolve(dirname(fileURLToPath(import.meta.url)), import.meta.url.endsWith('/src/server/index.ts') ? '../..' : '..');
   const instructions = await readFile(join(root, 'skills/ui4a/SKILL.md'), 'utf8');
-  const app = await createArtifactsServer({ directory: process.env.MACARON_DATA_DIR || join(homedir(), '.macaron-artifacts/sessions'), instructions, webRoot: join(root, 'dist/web') });
+  const pairing = /^(1|true|yes)$/i.test(process.env.MACARON_PAIR || '') ? { enabled: true, allowedOrigins: (process.env.MACARON_ALLOWED_ORIGINS || 'https://artifacts.macaron.im').split(',').map(value => value.trim()).filter(Boolean) } : undefined;
+  const app = await createArtifactsServer({ directory: process.env.MACARON_DATA_DIR || join(homedir(), '.macaron-artifacts/sessions'), instructions, webRoot: join(root, 'dist/web'), pairing });
   const port = Number(process.env.MACARON_PORT || 43860);
-  app.server.listen(port, '127.0.0.1', () => console.log(`Macaron Artifacts: http://127.0.0.1:${port}`));
+  app.server.listen(port, '127.0.0.1', () => {
+    console.log(`Macaron Artifacts: http://127.0.0.1:${port}`);
+    if (app.pairing.enabled) {
+      console.log(`Connect: https://artifacts.macaron.im/connect?server=${encodeURIComponent(`http://127.0.0.1:${port}`)}`);
+      console.log(`Pairing code: ${app.pairing.code} (expires ${new Date(app.pairing.codeExpiry).toISOString()})`);
+      if (process.env.SSH_CONNECTION) console.log(`SSH port forward: ssh -N -L ${port}:127.0.0.1:${port} <user>@<host>`);
+      console.log(`To generate a new code locally: curl -X POST http://127.0.0.1:${port}/api/pair/code`);
+    }
+  });
   for (const signal of ['SIGINT', 'SIGTERM']) process.on(signal, () => { void app.close().then(() => process.exit()); });
 }

--- a/artifacts/src/server/pairing-server.test.ts
+++ b/artifacts/src/server/pairing-server.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createArtifactsServer } from './index.js';
+import type { HarnessAdapter } from './harnesses/types.js';
+
+const cleanups: (() => Promise<unknown>)[] = [];
+afterEach(async () => { for (const cleanup of cleanups.splice(0).reverse()) await cleanup(); });
+
+async function setup() {
+  const directory = await mkdtemp(join(tmpdir(), 'artifacts-pairing-')); cleanups.push(() => rm(directory, { recursive: true, force: true }));
+  const adapter: HarnessAdapter = { id: 'claude-code', info: async () => ({ id: 'claude-code', name: 'Test', available: true, capabilities: { textDeltas: true, reasoningDeltas: true, toolInputDeltas: true, commandOutputDeltas: true, approvals: true, fork: true } }), async *run() {} };
+  const app = await createArtifactsServer({ directory: join(directory, 'sessions'), instructions: 'test', harnesses: { 'claude-code': adapter }, pairing: { enabled: true, allowedOrigins: ['https://artifacts.example'], code: 'ABCD-EFGH-JKLM-NPQR' } });
+  await new Promise<void>(resolve => app.server.listen(0, '127.0.0.1', resolve)); cleanups.push(() => app.close());
+  return { app, base: `http://127.0.0.1:${(app.server.address() as { port: number }).port}`, cwd: directory };
+}
+
+test('pairs a hosted origin, binds the token to that origin, and exposes stable connection context', async () => {
+  const { base } = await setup(), hosted = { origin: 'https://artifacts.example' };
+  const denied = await fetch(`${base}/api/sessions`, { headers: hosted }); expect(denied.status).toBe(401); expect((await denied.json()).authRequired).toBe(true);
+  const pair = await fetch(`${base}/api/pair`, { method: 'POST', headers: { ...hosted, 'content-type': 'application/json' }, body: JSON.stringify({ code: 'abcd-efgh-jklm-npqr', origin: 'https://evil.example' }) });
+  expect(pair.status).toBe(200); const token = (await pair.json()).token as string;
+  const context = await fetch(`${base}/api/connection`, { headers: { ...hosted, authorization: `Bearer ${token}` } }); expect(context.status).toBe(200); expect(await context.json()).toMatchObject({ name: 'Macaron Artifacts', protocolVersion: 1 });
+  const wrongOrigin = await fetch(`${base}/api/connection`, { headers: { origin: 'https://evil.example', authorization: `Bearer ${token}` } }); expect(wrongOrigin.status).toBe(403);
+  const sessions = await fetch(`${base}/api/sessions`, { headers: { ...hosted, authorization: `Bearer ${token}` } }); expect(sessions.status).toBe(200);
+  expect(pair.headers.get('access-control-allow-origin')).toBe('https://artifacts.example'); expect(pair.headers.get('access-control-allow-credentials')).toBeNull();
+  const replay = await fetch(`${base}/api/pair`, { method: 'POST', headers: { ...hosted, 'content-type': 'application/json' }, body: JSON.stringify({ code: 'ABCD-EFGH-JKLM-NPQR' }) }); expect(replay.status).toBe(410);
+});
+
+test('keeps code and grant management local-only and supports multiple revocable grants', async () => {
+  const { base } = await setup(), local = { host: `127.0.0.1:${new URL(base).port}` };
+  const code = await fetch(`${base}/api/pair/code`, { method: 'POST', headers: local }); expect(code.status).toBe(200); expect((await code.json()).code).toMatch(/^[A-Z2-9]{4}(?:-[A-Z2-9]{4}){3}$/);
+  const cross = await fetch(`${base}/api/pair/code`, { method: 'POST', headers: { origin: 'https://artifacts.example' } }); expect(cross.status).toBe(403);
+  const connections = await fetch(`${base}/api/pair/connections`, { headers: local }); expect(connections.status).toBe(200); expect(await connections.json()).toEqual([]);
+  const spoofedHost = await fetch(`${base}/api/health`, { headers: { host: 'attacker.example' } }); expect(spoofedHost.status).toBe(403);
+  const deniedOrigin = await fetch(`${base}/api/health`, { headers: { origin: 'https://evil.example' } }); expect(deniedOrigin.status).toBe(403);
+  const deniedScheme = await fetch(`${base}/api/health`, { headers: { origin: `https://127.0.0.1:${new URL(base).port}` } }); expect(deniedScheme.status).toBe(403);
+});
+
+test('authenticated hosted clients can use file, metadata, and reconnect streams', async () => {
+  const { base, cwd } = await setup(), hosted = { origin: 'https://artifacts.example' };
+  const pair = await fetch(`${base}/api/pair`, { method: 'POST', headers: { ...hosted, 'content-type': 'application/json' }, body: JSON.stringify({ code: 'ABCD-EFGH-JKLM-NPQR' }) });
+  const token = (await pair.json()).token as string, headers = { ...hosted, authorization: `Bearer ${token}` }, create = await fetch(`${base}/api/sessions`, { method: 'POST', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ cwd, harness: 'claude-code' }) });
+  const session = await create.json() as { id: string };
+  const write = await fetch(`${base}/api/sessions/${session.id}/files?path=.artifacts/canvases/pair.ui4a.tsx`, { method: 'PUT', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ content: 'export default () => null' }) }); expect(write.status).toBe(200);
+  const read = await fetch(`${base}/api/sessions/${session.id}/files?path=.artifacts/canvases/pair.ui4a.tsx`, { headers }); expect(await read.text()).toBe('export default () => null');
+  const reconnect = await fetch(`${base}/api/chat/${session.id}/stream`, { headers }); expect(reconnect.status).toBe(204);
+  const metadata = await fetch(`${base}/api/sessions/${session.id}/metadata`, { headers }); expect(metadata.status).toBe(200);
+  const revoked = await fetch(`${base}/api/connection`, { method: 'DELETE', headers }); expect(revoked.status).toBe(200); expect(await metadata.text()).toContain('data:');
+});

--- a/artifacts/src/server/pairing.test.ts
+++ b/artifacts/src/server/pairing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { PairingManager, bearerToken, isLoopbackHost } from './pairing.js';
+
+describe('PairingManager', () => {
+  test('creates one hashed, origin-bound grant and consumes its code once', () => {
+    const manager = new PairingManager({ enabled: true, allowedOrigins: ['https://artifacts.example'], code: 'ABCD-EFGH-JKLM-NPQR' });
+    const result = manager.claim('abcd-efgh-jklm-npqr', 'https://artifacts.example');
+    expect(result.token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(manager.authenticate(result.token, 'https://artifacts.example')?.id).toBe(result.id);
+    expect(manager.authenticate(result.token, 'https://artifacts.example:443')).toBeUndefined();
+    expect(manager.authenticate(result.token, 'https://evil.example')).toBeUndefined();
+    expect(() => manager.claim('ABCD-EFGH-JKLM-NPQR', 'https://artifacts.example')).toThrow('expired');
+    expect(manager.list()).toEqual([{ id: result.id, name: 'Macaron Artifacts', expiresAt: result.expiresAt, protocolVersion: 1 }]);
+  });
+
+  test('expires codes and grants independently with a deterministic clock', () => {
+    let now = 1_000;
+    const manager = new PairingManager({ enabled: true, allowedOrigins: ['https://artifacts.example'], code: 'ABCD-EFGH-JKLM-NPQR', codeTtlMs: 100, grantTtlMs: 1_000, now: () => now });
+    now += 101;
+    expect(() => manager.claim('ABCD-EFGH-JKLM-NPQR', 'https://artifacts.example')).toThrow('expired');
+    const renewed = manager.generateCode();
+    const result = manager.claim(renewed.code, 'https://artifacts.example');
+    now += 999; expect(manager.authenticate(result.token, 'https://artifacts.example')).toBeDefined();
+    now += 1; expect(manager.authenticate(result.token, 'https://artifacts.example')).toBeUndefined();
+  });
+
+  test('limits invalid attempts and allows independent grants after code rotation', () => {
+    const manager = new PairingManager({ enabled: true, allowedOrigins: ['https://artifacts.example'], code: 'ABCD-EFGH-JKLM-NPQR' });
+    for (let i = 0; i < 10; i++) expect(() => manager.claim('WRONG-CODE', 'https://artifacts.example')).toThrow('Invalid pairing code');
+    expect(() => manager.claim('ABCD-EFGH-JKLM-NPQR', 'https://artifacts.example')).toThrow('Too many');
+    const renewed = manager.generateCode(), result = manager.claim(renewed.code, 'https://artifacts.example');
+    expect(manager.list()).toMatchObject([{ id: result.id, protocolVersion: 1 }]);
+  });
+
+  test('claims a code only once under concurrent callers', async () => {
+    const manager = new PairingManager({ enabled: true, allowedOrigins: ['https://artifacts.example'], code: 'ABCD-EFGH-JKLM-NPQR' });
+    const results = await Promise.allSettled([1, 2].map(() => Promise.resolve().then(() => manager.claim('ABCD-EFGH-JKLM-NPQR', 'https://artifacts.example'))));
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+  });
+
+  test('extracts bearer credentials only from the authorization scheme', () => {
+    expect(bearerToken('Bearer secret')).toBe('secret');
+    expect(bearerToken('Basic secret')).toBeUndefined();
+    expect(bearerToken(undefined)).toBeUndefined();
+  });
+
+  test('recognizes IPv4, IPv6, and localhost loopback hosts only', () => {
+    expect(isLoopbackHost('127.0.0.1:43860')).toBe(true); expect(isLoopbackHost('[::1]:43860')).toBe(true); expect(isLoopbackHost('localhost:43860')).toBe(true); expect(isLoopbackHost('0.0.0.0:43860')).toBe(false);
+  });
+});

--- a/artifacts/src/server/pairing.ts
+++ b/artifacts/src/server/pairing.ts
@@ -1,0 +1,106 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { ServerResponse } from 'node:http';
+
+const DEFAULT_CODE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_GRANT_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_ORIGINS = ['https://artifacts.macaron.im'];
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+export type PairingOptions = { enabled?: boolean; allowedOrigins?: string[]; code?: string; codeTtlMs?: number; grantTtlMs?: number; now?: () => number };
+export type PairingContext = { id: string; name: string; expiresAt: number; protocolVersion: 1 };
+export type PairingGrant = PairingContext & { origin: string };
+
+function digest(value: string): Buffer { return createHash('sha256').update(value).digest(); }
+function sameSecret(value: string, expected: Buffer): boolean { const actual = digest(value); return actual.length === expected.length && timingSafeEqual(actual, expected); }
+function validOrigin(value: string): string | undefined {
+  try {
+    const url = new URL(value), authority = value.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
+    if (!authority || !['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.pathname !== '/' && url.pathname !== '' || url.search || url.hash) return undefined;
+    const explicitPort = /:\d+$/.test(authority) ? authority.slice(authority.lastIndexOf(':')) : '';
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    return `${url.protocol}//${hostname.includes(':') ? `[${hostname}]` : hostname}${explicitPort}`;
+  } catch { return undefined; }
+}
+function makeCode(): string {
+  const bytes = randomBytes(16), chars = [...bytes].map(byte => ALPHABET[byte % ALPHABET.length]);
+  return `${chars.slice(0, 4).join('')}-${chars.slice(4, 8).join('')}-${chars.slice(8, 12).join('')}-${chars.slice(12).join('')}`;
+}
+function error(message: string, status: number): Error & { status: number } { return Object.assign(new Error(message), { status }); }
+
+type InternalGrant = PairingGrant & { tokenDigest: Buffer; close: Set<() => void>; expiryTimer?: ReturnType<typeof setTimeout> };
+
+export class PairingManager {
+  readonly enabled: boolean;
+  readonly allowedOrigins: readonly string[];
+  private readonly codeTtlMs: number;
+  private readonly grantTtlMs: number;
+  private readonly now: () => number;
+  private codeDigest: Buffer;
+  private codeExpiresAt: number;
+  private attempts = 0;
+  private currentCode: string;
+  private grants = new Map<string, InternalGrant>();
+
+  constructor(options: PairingOptions = {}) {
+    this.enabled = options.enabled === true;
+    this.now = options.now ?? Date.now;
+    this.codeTtlMs = Math.max(1, options.codeTtlMs ?? DEFAULT_CODE_TTL_MS);
+    this.grantTtlMs = Math.max(1, options.grantTtlMs ?? DEFAULT_GRANT_TTL_MS);
+    this.allowedOrigins = [...new Set((options.allowedOrigins?.length ? options.allowedOrigins : DEFAULT_ORIGINS).map(validOrigin).filter((origin): origin is string => Boolean(origin)))];
+    this.currentCode = options.code ?? makeCode();
+    this.codeDigest = digest(this.currentCode);
+    this.codeExpiresAt = this.now() + this.codeTtlMs;
+  }
+
+  get code(): string { return this.currentCode; }
+  get codeExpiry(): number { return this.codeExpiresAt; }
+  get paired(): boolean { this.expire(); return this.grants.size > 0; }
+
+  originAllowed(origin: string | undefined): boolean { return Boolean(origin && this.allowedOrigins.includes(origin)); }
+
+  claim(code: string, origin: string): { token: string; id: string; name: string; expiresAt: number; protocolVersion: 1 } {
+    if (!this.enabled) throw error('Pairing is disabled.', 404);
+    const normalizedOrigin = validOrigin(origin);
+    if (!normalizedOrigin || !this.originAllowed(normalizedOrigin)) throw error('This WebUI origin is not allowed.', 403);
+    this.expire();
+    if (this.now() >= this.codeExpiresAt) throw error('The pairing code has expired. Generate a new code locally.', 410);
+    if (this.attempts >= 10) throw error('Too many pairing attempts. Generate a new code locally.', 429);
+    this.attempts++;
+    if (!sameSecret(code.trim().toUpperCase(), this.codeDigest)) throw error('Invalid pairing code.', 401);
+    const id = crypto.randomUUID(), token = randomBytes(32).toString('base64url'), grant: InternalGrant = { id, name: 'Macaron Artifacts', origin: normalizedOrigin, expiresAt: this.now() + this.grantTtlMs, protocolVersion: 1, tokenDigest: digest(token), close: new Set() };
+    grant.expiryTimer = setTimeout(() => this.revoke(id), this.grantTtlMs); grant.expiryTimer.unref?.(); this.grants.set(id, grant);
+    this.currentCode = ''; this.codeDigest = digest(randomBytes(32).toString('base64url')); this.codeExpiresAt = this.now();
+    return { token, id, name: grant.name, expiresAt: grant.expiresAt, protocolVersion: 1 };
+  }
+
+  authenticate(token: string | undefined, origin: string | undefined): InternalGrant | undefined {
+    this.expire();
+    if (!token || !origin) return undefined;
+    const normalizedOrigin = validOrigin(origin);
+    if (!normalizedOrigin) return undefined;
+    for (const grant of this.grants.values()) if (grant.origin === normalizedOrigin && sameSecret(token, grant.tokenDigest)) return grant;
+    return undefined;
+  }
+
+  context(grant: PairingGrant): PairingContext { return { id: grant.id, name: grant.name, expiresAt: grant.expiresAt, protocolVersion: 1 }; }
+  list(): PairingContext[] { this.expire(); return [...this.grants.values()].map(grant => this.context(grant)); }
+  revoke(id: string): boolean { const grant = this.grants.get(id); if (!grant) return false; this.grants.delete(id); if (grant.expiryTimer) clearTimeout(grant.expiryTimer); for (const close of grant.close) close(); grant.close.clear(); return true; }
+  revokeCurrent(grant: PairingGrant): boolean { return this.revoke(grant.id); }
+  track(grant: PairingGrant, response: ServerResponse): () => void {
+    const internal = this.grants.get(grant.id); if (!internal) return () => {};
+    const close = () => { if (!response.writableEnded) response.end(); };
+    internal.close.add(close); const cleanup = () => { internal.close.delete(close); };
+    response.once('close', cleanup); response.once('finish', cleanup); return cleanup;
+  }
+  generateCode(): { code: string; expiresAt: number } {
+    if (!this.enabled) throw error('Pairing is disabled.', 404);
+    this.currentCode = makeCode(); this.codeDigest = digest(this.currentCode); this.codeExpiresAt = this.now() + this.codeTtlMs; this.attempts = 0;
+    return { code: this.currentCode, expiresAt: this.codeExpiresAt };
+  }
+  expire(): void { const now = this.now(); for (const grant of this.grants.values()) if (grant.expiresAt <= now) this.revoke(grant.id); }
+}
+
+export function bearerToken(value: string | undefined): string | undefined { return value?.startsWith('Bearer ') ? value.slice(7) : undefined; }
+export function isLoopbackHost(value: string | undefined): boolean { if (!value) return false; try { const host = new URL(`http://${value}`).hostname; return host === 'localhost' || host === '::1' || host === '[::1]' || host === '127.0.0.1'; } catch { return false; } }
+export function originHost(value: string | undefined): string | undefined { try { return value ? new URL(value).host : undefined; } catch { return undefined; } }
+export function originProtocol(value: string | undefined): string | undefined { try { return value ? new URL(value).protocol : undefined; } catch { return undefined; } }

--- a/artifacts/src/web/chat/connection.ts
+++ b/artifacts/src/web/chat/connection.ts
@@ -1,0 +1,6 @@
+const CONNECTION_KEY = 'macaron-artifacts:connection';
+export type LocalConnection = { origin: string; token: string; expiresAt?: number };
+function read(): LocalConnection | null { try { const value = sessionStorage.getItem(CONNECTION_KEY); if (!value) return null; const connection = JSON.parse(value) as LocalConnection; if (!connection.origin || !connection.token || connection.expiresAt && connection.expiresAt <= Date.now()) { sessionStorage.removeItem(CONNECTION_KEY); return null; } return connection; } catch { return null; } }
+export function consumePairHandoff(): void { if (typeof window === 'undefined') return; try { const pending = sessionStorage.getItem(`${CONNECTION_KEY}:pending`); if (pending) { sessionStorage.setItem(CONNECTION_KEY, pending); sessionStorage.removeItem(`${CONNECTION_KEY}:pending`); } } catch { /* Private browsing may reject storage; the server remains local-only. */ } }
+export function apiUrl(path: string): string { const base = read()?.origin; return base ? new URL(path, `${base}/`).toString() : path; }
+export function connectionHeaders(init?: HeadersInit): Headers { const headers = new Headers(init), token = read()?.token; if (token) headers.set('authorization', `Bearer ${token}`); return headers; }

--- a/artifacts/src/web/chat/store.ts
+++ b/artifacts/src/web/chat/store.ts
@@ -3,9 +3,10 @@ import { DefaultChatTransport, type DataUIPart } from 'ai';
 import type { Artifact, ChatMessage, HarnessId, HarnessInfo, MessageData, Session, SessionSummary } from '../../shared/types';
 import { consumeMetadata } from './metadata';
 import { artifactEntryPath } from '../../shared/artifact-path';
+import { apiUrl, connectionHeaders } from './connection';
 
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, { ...init, headers: { 'content-type': 'application/json', ...init?.headers } });
+  const response = await fetch(apiUrl(path), { ...init, headers: connectionHeaders({ 'content-type': 'application/json', ...init?.headers }) });
   if (!response.ok) { const body = await response.text(); let detail = body; try { detail = JSON.parse(body).error ?? body; } catch { /* Some failures are plain text. */ } throw new Error(detail || `请求失败 (${response.status})`); }
   return response.status === 204 ? undefined as T : await response.json() as T;
 }
@@ -84,7 +85,7 @@ export class WorkspaceStore {
       this.files.set(id, new Map(artifacts.map(artifact => [artifact.path, artifact])));
       const chat = new Chat<ChatMessage>({
         id, messages: session.messages,
-        transport: new DefaultChatTransport<ChatMessage>({ api: '/api/chat', prepareSendMessagesRequest: ({ id, messages }) => ({ body: { id, messages } }) }),
+        transport: new DefaultChatTransport<ChatMessage>({ api: apiUrl('/api/chat'), headers: connectionHeaders(), prepareSendMessagesRequest: ({ id, messages }) => ({ body: { id, messages }, headers: connectionHeaders() }) }),
         onData: part => this.onData(id, part),
         onError: error => this.update(id, { status: 'error', error: error.message }),
         onFinish: ({ isError, isDisconnect }) => {
@@ -148,7 +149,7 @@ export class WorkspaceStore {
     const controller = new AbortController();
     this.metadata.set(id, controller);
     try {
-      const response = await fetch(`/api/sessions/${id}/metadata`, { signal: controller.signal, headers: { accept: 'text/event-stream' } });
+      const response = await fetch(apiUrl(`/api/sessions/${id}/metadata`), { signal: controller.signal, headers: connectionHeaders({ accept: 'text/event-stream' }) });
       if (!response.ok || !response.body) return;
       await consumeMetadata(response.body, recap => {
         // Cancellation can race with a decoded frame; the ownership check prevents an old turn from renaming the new one.

--- a/artifacts/src/web/main.tsx
+++ b/artifacts/src/web/main.tsx
@@ -6,5 +6,7 @@ import { WorkspaceProvider } from './chat/WorkspaceProvider';
 import { ThemeProvider } from './theme/ThemeProvider';
 import 'virtual:uno.css';
 import './styles.css';
+import { consumePairHandoff } from './chat/connection';
 
+consumePairHandoff();
 createRoot(document.getElementById('root')!).render(<StrictMode><ThemeProvider><WorkspaceProvider><ProfileProvider><App /></ProfileProvider></WorkspaceProvider></ThemeProvider></StrictMode>);

--- a/artifacts/src/web/ui4a/files.ts
+++ b/artifacts/src/web/ui4a/files.ts
@@ -14,8 +14,10 @@ export function relativeUi4aPath(specifier: string, filename: string): string {
   return ui4aPath(`${filename.slice(0, filename.lastIndexOf("/") + 1)}${specifier}`);
 }
 
+import { apiUrl, connectionHeaders } from '../chat/connection';
+
 export function createFileClient(sessionId: string, fetcher: typeof fetch = fetch) {
-  const url = (path: string) => `/api/sessions/${encodeURIComponent(sessionId)}/files?path=${encodeURIComponent(ui4aPath(path))}`;
+  const url = (path: string) => apiUrl(`/api/sessions/${encodeURIComponent(sessionId)}/files?path=${encodeURIComponent(ui4aPath(path))}`);
   const checked = async (response: Response, path: string) => {
     if (!response.ok) {
       const text = await response.text();
@@ -25,10 +27,11 @@ export function createFileClient(sessionId: string, fetcher: typeof fetch = fetc
     }
     return response;
   };
+  const requestHeaders = () => { const headers = connectionHeaders(); return headers.has('authorization') ? { headers } : undefined; };
   return {
-    async readFile(path: string): Promise<string> { return (await checked(await fetcher(url(path)), path)).text(); },
+    async readFile(path: string): Promise<string> { return (await checked(await fetcher(url(path), requestHeaders()), path)).text(); },
     async writeFile(path: string, content: string): Promise<void> {
-      await checked(await fetcher(url(path), { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ content }) }), path);
+      await checked(await fetcher(url(path), { method: "PUT", headers: connectionHeaders({ "content-type": "application/json" }), body: JSON.stringify({ content }) }), path);
     },
   };
 }

--- a/bin/macaron-artifacts.mjs
+++ b/bin/macaron-artifacts.mjs
@@ -6,7 +6,8 @@ import { fileURLToPath } from 'node:url';
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i++) {
   const flag = args[i];
-  if (flag === '--help' || flag === '-h') { console.log('Usage: macaron-artifacts [--port 43860] [--data-dir PATH]\n\nOne local WebUI for Claude Code, Codex, OpenCode and pi, with UI4A. Requires Node.js 22.19 or newer.\nClaude Code, Codex and OpenCode use installed CLIs. The bundled pi SDK uses ~/.pi/agent.\nOverride executables with MACARON_CLAUDE_PATH, MACARON_CODEX_PATH or MACARON_OPENCODE_PATH; override pi configuration with PI_CODING_AGENT_DIR.'); process.exit(0); }
+  if (flag === '--help' || flag === '-h') { console.log('Usage: macaron-artifacts [--port 43860] [--data-dir PATH] [--pair]\n\nOne local WebUI for Claude Code, Codex, OpenCode and pi, with UI4A. Requires Node.js 22.19 or newer.\n--pair enables one-time pairing from the hosted WebUI; use SSH port forwarding to reach a remote machine.\nClaude Code, Codex and OpenCode use installed CLIs. The bundled pi SDK uses ~/.pi/agent.\nOverride executables with MACARON_CLAUDE_PATH, MACARON_CODEX_PATH or MACARON_OPENCODE_PATH; override pi configuration with PI_CODING_AGENT_DIR.\nMACARON_ALLOWED_ORIGINS accepts a comma-separated origin allowlist.'); process.exit(0); }
+  if (flag === '--pair') { process.env.MACARON_PAIR = '1'; continue; }
   const value = args[++i];
   if (!value || value.startsWith('--') || !['--port', '--data-dir'].includes(flag)) { console.error(`Invalid option: ${flag}`); process.exit(1); }
   if (flag === '--port' && (!/^\d+$/.test(value) || +value < 1 || +value > 65535)) { console.error('Port must be between 1 and 65535.'); process.exit(1); }

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -4,6 +4,7 @@
 # React Router
 /.react-router/
 /build/
+/public/app/
 .source
 .vercel
 .env*

--- a/site/app/routes/connect.tsx
+++ b/site/app/routes/connect.tsx
@@ -1,26 +1,25 @@
 import type { Route } from './+types/connect';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, LoaderCircle, Terminal } from 'lucide-react';
+import { useState, type FormEvent } from 'react';
 import { Link } from 'react-router';
 import { baseOptions } from '@/lib/layout.shared';
 
-export function meta({}: Route.MetaArgs) {
-  return [{ title: 'Open WebUI · Macaron Artifacts' }, { name: 'description', content: 'Open the unified Macaron Artifacts WebUI running locally on your machine.' }];
-}
+export function meta({}: Route.MetaArgs) { return [{ title: 'Connect · Macaron Artifacts' }, { name: 'description', content: 'Pair the Macaron Artifacts WebUI with a local or SSH-forwarded coding agent.' }]; }
+function normalizeOrigin(value: string): string { const input = value.trim(); const url = new URL(/^[a-z][a-z\d+.-]*:\/\//i.test(input) ? input : `http://${input}`); if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || (url.pathname !== '/' && url.pathname !== '')) throw new Error('请输入 http(s) 服务地址，不要带路径或账号信息。'); return url.origin; }
+function initialServer(): string { if (typeof window === 'undefined') return 'http://127.0.0.1:43860'; try { return new URLSearchParams(window.location.search).get('server') || 'http://127.0.0.1:43860'; } catch { return 'http://127.0.0.1:43860'; } }
 
 export default function Connect() {
-  return (
-    <HomeLayout {...baseOptions()}>
-      <div className="site:p-6 site:flex site:flex-col site:items-center site:justify-center site:flex-1">
-        <div className="site:w-full site:max-w-md">
-          <h1 className="site:text-xl site:font-bold site:mb-3">Open Macaron Artifacts</h1>
-          <p className="site:text-fd-muted-foreground site:text-sm site:leading-relaxed site:mb-6">Start <code>macaron-artifacts</code> on this device, then open its local WebUI. Choose Claude Code, Codex, OpenCode, or pi inside the app.</p>
-          <a href="http://127.0.0.1:43860" className="site:inline-flex site:items-center site:justify-center site:gap-2 site:text-sm site:bg-fd-primary site:text-fd-primary-foreground site:rounded-full site:font-medium site:px-4 site:py-2.5 site:focus-visible:outline-none site:focus-visible:ring-2 site:focus-visible:ring-fd-ring">Open local WebUI <ArrowRight aria-hidden="true" className="site:size-4" /></a>
-          <p className="site:text-xs site:text-fd-muted-foreground site:mt-3">Default address: <code>http://127.0.0.1:43860</code>. For another port, use the address printed by the launcher.</p>
-          <p className="site:text-sm site:mt-6"><Link to="/docs/usage" className="site:underline site:underline-offset-4">Install and configure Macaron Artifacts</Link></p>
-          <p className="site:text-xs site:text-fd-muted-foreground site:mt-6">The hosted v0 interface has been retired. Its source remains on the <a href="https://github.com/mindverse-ltd/macaron-artifacts/tree/v0" className="site:underline site:underline-offset-4">v0 branch</a>.</p>
-        </div>
-      </div>
-    </HomeLayout>
-  );
+  const [server, setServer] = useState(initialServer), [code, setCode] = useState(''), [error, setError] = useState(''), [pending, setPending] = useState(false);
+  async function connect(event: FormEvent) {
+    event.preventDefault(); setError(''); setPending(true);
+    try {
+      const origin = normalizeOrigin(server), response = await fetch(`${origin}/api/pair`, { method: 'POST', mode: 'cors', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ code: code.trim() }) });
+      const body = await response.json().catch(() => ({})) as { token?: string; expiresAt?: number; error?: string };
+      if (!response.ok || !body.token) throw new Error(body.error || `连接失败 (${response.status})`);
+      try { sessionStorage.setItem('macaron-artifacts:connection:pending', JSON.stringify({ origin, token: body.token, expiresAt: body.expiresAt })); } catch { throw new Error('浏览器无法保存本次连接，请检查隐私模式或存储权限。'); }
+      window.location.assign('/app');
+    } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); setPending(false); }
+  }
+  return <HomeLayout {...baseOptions()}><main className="site:p-6 site:flex site:flex-col site:items-center site:justify-center site:flex-1"><div className="site:w-full site:max-w-md"><div className="site:flex site:items-center site:gap-2 site:text-sm site:text-fd-muted-foreground site:mb-3"><Terminal aria-hidden="true" className="site:size-4" /> Macaron Artifacts</div><h1 className="site:text-2xl site:font-bold site:mb-2">连接本机 Agent</h1><p className="site:text-fd-muted-foreground site:text-sm site:leading-relaxed site:mb-6">在运行 coding agent 的机器上执行 <code>macaron-artifacts --pair</code>，然后输入它显示的一次性配对码。</p><form onSubmit={connect} className="site:space-y-4" aria-describedby="connect-help connect-error"><div><label htmlFor="server" className="site:block site:text-sm site:font-medium site:mb-1">服务地址</label><input id="server" type="url" inputMode="url" autoComplete="url" value={server} onChange={event => setServer(event.target.value)} className="site:w-full site:rounded-md site:border site:border-fd-border site:bg-fd-background site:px-3 site:py-2 site:text-sm site:focus-visible:outline-none site:focus-visible:ring-2 site:focus-visible:ring-fd-ring" required /></div><div><label htmlFor="pair-code" className="site:block site:text-sm site:font-medium site:mb-1">一次性配对码</label><input id="pair-code" type="text" inputMode="text" autoComplete="one-time-code" value={code} onChange={event => setCode(event.target.value)} className="site:w-full site:rounded-md site:border site:border-fd-border site:bg-fd-background site:px-3 site:py-2 site:tracking-[.18em] site:focus-visible:outline-none site:focus-visible:ring-2 site:focus-visible:ring-fd-ring" placeholder="例如 ABCD-EFGH-JKLM" required /></div><p id="connect-help" className="site:text-xs site:text-fd-muted-foreground">配对码只使用一次，短时间后自动失效。凭据不会写入地址栏或发送到 Macaron 云端。</p>{error && <p id="connect-error" role="alert" className="site:text-sm site:text-fd-destructive">{error}</p>}<button type="submit" disabled={pending} className="site:w-full site:inline-flex site:items-center site:justify-center site:gap-2 site:text-sm site:bg-fd-primary site:text-fd-primary-foreground site:rounded-md site:font-medium site:px-4 site:py-2.5 site:disabled:opacity-60 site:focus-visible:outline-none site:focus-visible:ring-2 site:focus-visible:ring-fd-ring">{pending ? <LoaderCircle aria-hidden="true" className="site:size-4 site:animate-spin" /> : <ArrowRight aria-hidden="true" className="site:size-4" />}连接 WebUI</button></form><section className="site:mt-8 site:border-t site:border-fd-border site:pt-5 site:text-xs site:text-fd-muted-foreground" aria-labelledby="ssh-help"><h2 id="ssh-help" className="site:text-sm site:font-medium site:text-fd-foreground site:mb-2">SSH 机器</h2><p className="site:mb-2">在本机建立端口转发后，把服务地址保持为 <code>http://127.0.0.1:43860</code>：</p><code className="site:block site:overflow-x-auto site:whitespace-nowrap site:rounded-md site:bg-fd-muted site:px-3 site:py-2">ssh -N -L 43860:127.0.0.1:43860 user@host</code></section><p className="site:text-sm site:mt-6"><Link to="/docs/usage" className="site:underline site:underline-offset-4">查看安装说明</Link></p></div></main></HomeLayout>;
 }

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -24,6 +24,18 @@ macaron-artifacts
 
 Open [http://127.0.0.1:43860](http://127.0.0.1:43860). The commands are pinned to this documentation build's commit; use a commit with a successful package preview build.
 
+### Connect from the website
+
+Run `macaron-artifacts --pair` on the machine that has your coding agents installed. On [the connect page](/connect), enter `http://127.0.0.1:43860` and the one-time code printed by the command. The code expires after ten minutes and is consumed once; credentials stay in the browser tab and the agent machine.
+
+For an SSH machine, keep the server bound to loopback and forward it to your computer:
+
+```sh
+ssh -N -L 43860:127.0.0.1:43860 user@host
+```
+
+Then use the forwarded `http://127.0.0.1:43860` address in the connect form. The website never needs direct network access to the remote machine.
+
 <Callout title="One package, one launcher">
   `macaron-artifacts` is the only published package and CLI. The old `mcc`, `mcx`, and `mkx` distributions are discontinued. Claude Code, Codex, OpenCode, and pi are selected inside the app. Kimi Code, Hermes, and dsh are not supported in this release.
 </Callout>
@@ -65,6 +77,8 @@ macaron-artifacts --help
 | `MACARON_CODEX_PATH` | Codex executable |
 | `MACARON_OPENCODE_PATH` | OpenCode executable |
 | `PI_CODING_AGENT_DIR` | pi configuration directory, default `~/.pi/agent` |
+| `MACARON_PAIR` | Enable one-time hosted WebUI pairing (`1` or `true`) |
+| `MACARON_ALLOWED_ORIGINS` | Comma-separated allowed website origins |
 
 For a custom Claude gateway, launch with the same `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY` environment as your CLI. Environment variables set only inside a shell alias do not reach a separately launched app.
 

--- a/site/host-webui.mjs
+++ b/site/host-webui.mjs
@@ -1,0 +1,10 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteDir = dirname(fileURLToPath(import.meta.url)), root = resolve(siteDir, '..'), artifactsDir = resolve(root, 'artifacts'), output = resolve(siteDir, 'build/client/app');
+rmSync(output, { recursive: true, force: true }); mkdirSync(output, { recursive: true });
+execFileSync(resolve(artifactsDir, 'node_modules/.bin/vite'), ['build', '--base=/app/', '--outDir', output, '--emptyOutDir'], { cwd: artifactsDir, stdio: 'inherit' });
+if (!existsSync(resolve(output, 'index.html'))) throw new Error('Hosted WebUI build did not emit app/index.html');
+console.log(`[host-webui] staged shared WebUI at ${output}`);

--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
     }
   },
   "scripts": {
-    "build": "react-router build",
+    "build": "react-router build && node host-webui.mjs",
     "dev": "react-router dev",
     "start": "serve ./build/client",
     "typecheck": "react-router typegen && fumadocs-mdx && tsc --noEmit",

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -2,8 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm build",
   "outputDirectory": "build/client",
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install --frozen-lockfile && cd .. && pnpm install --frozen-lockfile",
   "framework": null,
   "cleanUrls": true,
-  "redirects": [{ "source": "/app/:path*", "destination": "/connect", "permanent": true }]
+  "rewrites": [{ "source": "/app", "destination": "/app/index.html" }, { "source": "/app/:path*", "destination": "/app/index.html" }]
 }


### PR DESCRIPTION
## What changed

The official site can now open the shared Macaron Artifacts WebUI while coding agents keep running on the user's machine.

- add a one-time, 80-bit pairing code with a ten-minute TTL and a separate 24-hour origin-bound Bearer grant
- keep the server loopback-only; SSH users connect with `ssh -N -L 43860:127.0.0.1:43860 user@host`
- serve the same React WebUI under `/app`; handoff stays in same-tab sessionStorage and credentials never enter the URL
- gate cross-origin REST, SSE, reconnect, file, and metadata requests with exact Origin + Bearer checks
- add local code rotation, connection listing/revocation, expiry cleanup, CORS/LNA headers, and focused tests

## Validation

- `bun test src` — 298 passed, 2 skipped
- `bun run typecheck` and `bun run build` in `artifacts`
- `pnpm typecheck` and `pnpm build` in `site`
- `pnpm test:package` — isolated package install and serving smoke passed
- real browser smoke: claim from hosted origin, load `/app`, and read authenticated remote sessions

Closes the gap between the local-only app and the hosted WebUI without introducing a cloud agent relay.