### PR TITLE
add manual public release workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,13 @@
+# Public releases
+
+Use **Actions → Release to Public → Run workflow**, select `main`, and enter an existing source version tag, such as `v1.0.0`. The workflow publishes that tag from `mindverse-ltd/macaron-artifacts` to `MindLab-Research/macaron-artifacts` through the existing `mindlab-bot` release skill. It runs only when dispatched and does not force-push existing releases.
+
+The release skill exports a snapshot without `.github/`, commits as `mindlab-bot <contact@mindlab.ltd>`, pushes public `main` and the tag, and records the source/public commit mapping in `MindLab-Research/mindlab-bot`.
+
+Before the first run, a maintainer must provide a self-hosted runner available to this source repository with `bash`, `git`, `gh`, `jq`, `rsync`, and authenticated `pi` installed. A runner registered only to the `MindLab-Research` organization is not available to this `mindverse-ltd` repository.
+
+The runner's normal `gh` credentials need source read access and `mindlab-bot` write access for the mapping. Public clone/push uses a separate bot token, supplied as the repository secret `MINDLAB_BOT_GH_TOKEN` or the runner's private `$HOME/.config/mindlab-bot/github-token` file. Do not use the source repository's `GITHUB_TOKEN` as the cross-repository credential.
+
+The existing bot configuration selects `public_token_env: MINDLAB_BOT_GH_TOKEN` for Macaron Artifacts. An SSH key alone does not satisfy this configuration; switching to SSH also requires updating the bot's credential policy and this workflow. The old source name in its mapping, `mindverse-ltd/macaron-claude-code`, currently redirects to this repository and is checked through the GitHub API before publishing.
+
+The dispatch button appears after this workflow is on the default branch. Validate the first real release by checking the public tag and `main`, bot commit identity, exported files, and the recorded commit mapping.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+# Adapted from MindLab-Research/mindlab-bot/workflows/release-on-tag.yml.
+name: Release to Public
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing source tag to publish (for example, v1.0.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-to-public
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.repository == 'mindverse-ltd/macaron-artifacts'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash --noprofile --norc -euo pipefail {0}
+    env:
+      RELEASE_TAG: ${{ inputs.tag_name }}
+    steps:
+      - name: Check release prerequisites
+        run: |
+          # Keep free-form dispatch input out of shell code and the agent's instructions.
+          [[ "$RELEASE_TAG" =~ ^v[0-9][0-9A-Za-z.+-]*$ ]] || { echo '::error::Enter a version tag such as v1.0.0'; exit 1; }
+          command -v pi
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object.sha'
+
+      - name: Define action directory
+        run: |
+          action_root="$HOME/.mindlab-bot-actions"
+          mkdir -p "$action_root"
+          action_dir="$(mktemp -d "$action_root/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.XXXXXX")"
+          echo "MINDLAB_BOT_ACTION_DIR=$action_dir" >> "$GITHUB_ENV"
+
+      - name: Clone mindlab-bot
+        run: gh repo clone MindLab-Research/mindlab-bot "$MINDLAB_BOT_ACTION_DIR"
+
+      - name: Load public repository credentials
+        env:
+          MINDLAB_BOT_GH_TOKEN: ${{ secrets.MINDLAB_BOT_GH_TOKEN }}
+        run: |
+          token_file="$HOME/.config/mindlab-bot/github-token"
+          if [[ -z "$MINDLAB_BOT_GH_TOKEN" && -r "$token_file" ]]; then
+            MINDLAB_BOT_GH_TOKEN="$(cat "$token_file")"
+          fi
+          [[ -n "$MINDLAB_BOT_GH_TOKEN" ]] || { echo '::error::Configure the mindlab-bot token on the runner or in MINDLAB_BOT_GH_TOKEN'; exit 1; }
+          echo "::add-mask::$MINDLAB_BOT_GH_TOKEN"
+          echo "MINDLAB_BOT_GH_TOKEN=$MINDLAB_BOT_GH_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Check repository mapping
+        working-directory: ${{ env.MINDLAB_BOT_ACTION_DIR }}
+        run: |
+          jq -e '.repositories[] | select(.name == "macaron-artifacts") | .public == "MindLab-Research/macaron-artifacts" and .public_token_env == "MINDLAB_BOT_GH_TOKEN" and .public_ssh_key_env == null' config/repositories.json
+          source_repo="$(jq -r '.repositories[] | select(.name == "macaron-artifacts") | .private' config/repositories.json)"
+          # The bot still lists macaron-claude-code; GitHub resolves its rename to this repository.
+          [[ "$(gh api "repos/$source_repo" --jq '.full_name')" == "$GITHUB_REPOSITORY" ]]
+
+      - name: Publish source tag
+        working-directory: ${{ env.MINDLAB_BOT_ACTION_DIR }}
+        # The runner supplies pi configuration and separate gh access for source reads and mapping writes.
+        run: pi --no-session -p "Use the release skill to publish repository macaron-artifacts at tag $RELEASE_TAG"
+
+      - name: Cleanup
+        if: always() && env.MINDLAB_BOT_ACTION_DIR != ''
+        run: rm -rf -- "$MINDLAB_BOT_ACTION_DIR"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: '12'
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## What changed

- add a manual `Release to Public` workflow for an existing `v*` tag
- reuse `mindlab-bot`'s release skill and validate the renamed source mapping before publishing
- load the bot token from `MINDLAB_BOT_GH_TOKEN` or the runner's standard token file
- document runner, credential, and first-release checks in `.github/README.md`
- restore pnpm 12's package-manager metadata removed from the root lockfile; GitHub Actions and Vercel require it for frozen installs, and the project dependency graph is unchanged

## Validation

- shell syntax checks pass for all workflow run blocks
- mocked checks cover valid and rejected tags, command-injection attempts, missing credentials, renamed/mismatched mappings, and release invocation
- `CI=true pnpm install --frozen-lockfile` passes
- regenerated lockfile matches the last working version exactly, with no project dependency changes
- `git diff --check` passes

The first real public release still needs a self-hosted runner and bot credentials with source read, public repository write, and `mindlab-bot` mapping write access.