### PR TITLE
replace the release agent with a deterministic script

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,15 +1,26 @@
 # Public releases
 
-Use **Actions → Release to Public → Run workflow**, select `main`, and enter an existing source version tag, such as `v1.0.0`. Leave **dry_run** checked to verify the runner tools, source tag, repository mapping, bot identity, and API-reported write permissions without invoking the release agent. This checks GitHub access; it does not test model-provider authentication or actual push acceptance under branch rules.
+Use **Actions → Release to Public → Run workflow**, select `main`, and enter an existing source tag. Leave **dry_run** checked to build the filtered public tree, check bot identity and API-reported write permissions, and show the proposed diff. It writes no remote commits, tags, or mappings. No new source tag is created.
 
-Uncheck **dry_run** only when ready to publish that tag from `mindverse-ltd/macaron-artifacts` to `MindLab-Research/macaron-artifacts` through the existing `mindlab-bot` release skill. It runs only when dispatched and does not force-push existing releases.
+For a real release, fill in **summary** (under 72 characters) and **details** describing the public-facing changes, then uncheck **dry_run**. These become the public commit's subject and body; omit internal repository names, authors, and PR/issue references. No model generates or guesses release notes. The CLI likewise defaults to dry-run and requires `--publish` to write:
 
-The release skill exports a snapshot without `.github/`, commits as `mindlab-bot <contact@mindlab.ltd>`, pushes public `main` and the tag, and records the source/public commit mapping in `MindLab-Research/mindlab-bot`.
+```sh
+node .github/scripts/public-release.mjs --tag v1.2.3
+node .github/scripts/public-release.mjs --tag v1.2.3 --publish --message-file public-notes.md
+```
 
-Before the first run, a maintainer must provide a self-hosted runner available to this source repository with `bash`, `git`, `gh`, `jq`, `rsync`, and authenticated `pi` installed. A runner registered only to the `MindLab-Research` organization is not available to this `mindverse-ltd` repository.
+The workflow uses `ubuntu-latest`, Node.js, and Git. It does not require `pi`, a model key, `m sd`, or a self-hosted runner. The source repository's `GITHUB_TOKEN` reads its tag; the repository Actions secret **MINDLAB_BOT_GH_TOKEN** must belong to `mindlab-bot` and have Contents read/write access to both `MindLab-Research/macaron-artifacts` and `MindLab-Research/mindlab-bot`. This standalone script explicitly uses the bot token for both repositories, replacing the old template's separate runner login for mapping writes. A token stored only on an existing runner is not available to GitHub-hosted jobs.
 
-The runner's normal `gh` credentials need source read access and `mindlab-bot` write access for the mapping. Public clone/push uses a separate bot token, supplied as the repository secret `MINDLAB_BOT_GH_TOKEN` or the runner's private `$HOME/.config/mindlab-bot/github-token` file. Do not use the source repository's `GITHUB_TOKEN` as the cross-repository credential.
+The script implements the export and mapping rules from [mindlab-bot's release skill](https://github.com/MindLab-Research/mindlab-bot/blob/49bf494ea65da0eed857aeb055548889c3449d6e/.codex/skills/release/SKILL.md):
 
-The existing bot configuration selects `public_token_env: MINDLAB_BOT_GH_TOKEN` for Macaron Artifacts. An SSH key alone does not satisfy this configuration; switching to SSH also requires updating the bot's credential policy and this workflow. The old source name in its mapping, `mindverse-ltd/macaron-claude-code`, currently redirects to this repository and is checked through the GitHub API before publishing.
+Release scripts and tests live under `.github/`, so the public snapshot automatically excludes them.
 
-The dispatch button appears after this workflow is on the default branch. Validate the first real release by checking the public tag and `main`, bot commit identity, exported files, and the recorded commit mapping.
+- Read the current `config/repositories.json` and `config/commits.json`; verify the source/public pair and the legacy source URL redirect.
+- Construct a Git tree from the exact source tag, preserving tracked files, executable modes, and symlinks. Exclude `.github/` at every level and apply only the configured gitignore-style `public_exclude` rules. Source `.gitignore` and archive filters do not silently remove tracked files. Unexcluded submodules and empty exports fail explicitly.
+- Create a snapshot commit as `mindlab-bot <contact@mindlab.ltd>` with only the existing public history as its parent. Source history never becomes public ancestry.
+- Push public `main` and the tag atomically, rejecting any ref change since the initial read. Repeating an already-published tag is idempotent and never rewinds a newer public `main`.
+- Write only this project's source/public hash mapping, retrying against the latest bot config when another project updates it concurrently. If mapping write fails after public publication, rerun the same release to repair it without another public commit.
+
+**force** explicitly permits replacing a conflicting public tag and mapping using exact ref leases. It appends a corrective snapshot; it does not erase old public commits or anonymize previously published history. Dry-run remains read-only even with force selected.
+
+A dry-run cannot prove branch rules will accept a later push. GitHub cannot transact across two repositories: public publication and mapping update are separate operations, and failures report which side completed. After publishing, verify the public `main/tag`, filtered files, bot authorship, and recorded mapping. Source CI should pass before choosing a release tag; the sync script does not execute or build code from that tag.

--- a/.github/scripts/public-release.mjs
+++ b/.github/scripts/public-release.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// Deterministic implementation of MindLab's release skill. No source checkout code is executed.
+import { spawnSync } from 'node:child_process';
+import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const NAME = 'macaron-artifacts';
+export const SOURCE = 'mindverse-ltd/macaron-artifacts';
+export const LEGACY_SOURCE = 'mindverse-ltd/macaron-claude-code';
+export const PUBLIC = 'MindLab-Research/macaron-artifacts';
+export const BOT = 'MindLab-Research/mindlab-bot';
+const IDENTITY = { GIT_AUTHOR_NAME: 'mindlab-bot', GIT_AUTHOR_EMAIL: 'contact@mindlab.ltd', GIT_COMMITTER_NAME: 'mindlab-bot', GIT_COMMITTER_EMAIL: 'contact@mindlab.ltd' };
+
+function git(args, { cwd, env = {}, input, allow = [0] } = {}) {
+  const result = spawnSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+    cwd, input, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, timeout: 120_000,
+    env: { ...process.env, ...env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  if (result.error) throw result.error;
+  if (!allow.includes(result.status)) throw new Error(`git ${args[0]} failed: ${(result.stderr || result.stdout).trim()}`);
+  return result.stdout;
+}
+
+export function parseArgs(argv) {
+  const options = { dryRun: true, force: false, tag: '' };
+  let mode;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--tag' || arg === '--message-file') {
+      const value = argv[++i];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      options[arg === '--tag' ? 'tag' : 'messageFile'] = value;
+    } else if (arg === '--publish' || arg === '--dry-run') {
+      if (mode && mode !== arg) throw new Error('choose either --publish or --dry-run');
+      mode = arg; options.dryRun = arg !== '--publish';
+    } else if (arg === '--force') options.force = true;
+    else if (arg === '--help') options.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+export function validateMessage(message) {
+  const lines = message.replaceAll('\r\n', '\n').trim().split('\n');
+  if (!lines[0] || [...lines[0]].length >= 72 || lines[1] !== '' || !lines[2]?.trim()) throw new Error('provide a public summary under 72 characters, a blank line, and a nonempty description');
+  if (/mindverse-ltd|macaron-claude-code|Co-authored-by:|Signed-off-by:|(?:^|\s|\()#\d+|github\.com\/[^\s]+\/(?:pull|issues)\//im.test(message)) throw new Error('public description must not include internal repository names, author trailers, or PR/issue references');
+  return lines.join('\n');
+}
+
+export function readConfiguration(text) {
+  const matches = JSON.parse(text).repositories?.filter(entry => entry.name === NAME);
+  if (matches?.length !== 1) throw new Error(`expected exactly one ${NAME} repository mapping`);
+  const config = matches[0];
+  if (![SOURCE, LEGACY_SOURCE].includes(config.private) || config.public !== PUBLIC || config.public_token_env !== 'MINDLAB_BOT_GH_TOKEN' || Object.hasOwn(config, 'public_ssh_key_env')) throw new Error('unexpected source, public repository, or credential policy');
+  if (config.public_exclude !== undefined && (!Array.isArray(config.public_exclude) || config.public_exclude.some(pattern => typeof pattern !== 'string' || /[\r\n\0]/.test(pattern)))) throw new Error('public_exclude must contain single-line gitignore patterns');
+  return config;
+}
+
+function readMappings(text) {
+  const data = JSON.parse(text), entries = data.mappings?.[NAME];
+  if (!entries || typeof entries !== 'object' || Array.isArray(entries)) throw new Error(`missing mappings.${NAME}`);
+  if (Object.entries(entries).some(([source, target]) => !/^[a-f0-9]{40}$/.test(source) || typeof target !== 'string' || !/^[a-f0-9]{40}$/.test(target))) throw new Error('invalid release commit mapping');
+  return data;
+}
+
+export function updateMappingText(text, source, target, force = false) {
+  const data = readMappings(text), entries = data.mappings[NAME];
+  if (entries[source] === target) return text;
+  if (entries[source] && !force) throw new Error(`source ${source} already maps to ${entries[source]}`);
+  // Preserve formatting outside this project's object so concurrent projects keep minimal diffs.
+  const match = /"macaron-artifacts"\s*:\s*\{[^{}]*\}/.exec(text);
+  if (!match) throw new Error('cannot locate the release mapping object');
+  const indent = text.slice(text.lastIndexOf('\n', match.index) + 1, match.index).match(/^\s*/)[0];
+  entries[source] = target;
+  const replacement = `"${NAME}": ${JSON.stringify(entries, null, 2).replaceAll('\n', `\n${indent}`)}`;
+  const updated = text.slice(0, match.index) + replacement + text.slice(match.index + match[0].length);
+  if (JSON.stringify(JSON.parse(updated)) !== JSON.stringify(data)) throw new Error('mapping update would change unrelated data');
+  return updated;
+}
+
+function oid(cwd, ref, required = true) {
+  const value = git(['rev-parse', '--verify', '--quiet', ref], { cwd, allow: required ? [0] : [0, 1] }).trim();
+  return value || null;
+}
+function tree(cwd, ref) { return oid(cwd, `${ref}^{tree}`); }
+function isAncestor(cwd, ancestor, descendant) {
+  // merge-base has no stdout; rev-list gives the count of commits not reachable from the descendant.
+  return git(['rev-list', '--count', ancestor, `^${descendant}`], { cwd }).trim() === '0';
+}
+function botAuthored(cwd, ref) {
+  return git(['show', '-s', '--format=%an <%ae>%n%cn <%ce>', ref], { cwd }).trim() === 'mindlab-bot <contact@mindlab.ltd>\nmindlab-bot <contact@mindlab.ltd>';
+}
+function createCommit(cwd, snapshot, parent, message, date) {
+  return git(['commit-tree', snapshot, '-p', parent], { cwd, input: message + '\n', env: { ...IDENTITY, ...(date ? { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date } : {}) } }).trim();
+}
+
+async function snapshotTree(cwd, sourceCommit, patterns, scratch) {
+  git(['read-tree', sourceCommit], { cwd });
+  const entries = git(['ls-tree', '-rz', sourceCommit], { cwd }).split('\0').filter(Boolean).map(entry => {
+    const tab = entry.indexOf('\t');
+    return { path: entry.slice(tab + 1), mode: entry.slice(0, 6) };
+  });
+  const excluded = new Set(entries.filter(entry => entry.path.split('/').some(part => part === '.github' || part === '.git')).map(entry => entry.path));
+  if (patterns.length) {
+    const file = join(scratch, 'excludes');
+    await writeFile(file, patterns.join('\n') + '\n');
+    // The worktree is empty: source .gitignore files must not alter public_exclude or drop tracked files.
+    const ignored = git(['-c', `core.excludesFile=${file}`, 'check-ignore', '--no-index', '-z', '--stdin'], {
+      cwd, input: entries.map(entry => entry.path).join('\0') + '\0', allow: [0, 1],
+    });
+    for (const path of ignored.split('\0').filter(Boolean)) excluded.add(path);
+  }
+  if (entries.some(entry => entry.mode === '160000' && !excluded.has(entry.path))) throw new Error('source contains a submodule; exclude it or vendor its contents before publishing');
+  if (!entries.some(entry => !excluded.has(entry.path))) throw new Error('refusing an empty public snapshot');
+  if (excluded.size) git(['update-index', '--force-remove', '-z', '--stdin'], { cwd, input: [...excluded].join('\0') + '\0' });
+  return git(['write-tree'], { cwd }).trim();
+}
+
+async function saveMapping(cwd, source, target, tag, force, expectedConfig, env) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    git(['fetch', '--quiet', 'origin', '+refs/heads/main:refs/remotes/origin/main'], { cwd, env });
+    const base = oid(cwd, 'refs/remotes/origin/main');
+    const config = readConfiguration(git(['show', `${base}:config/repositories.json`], { cwd }));
+    if (JSON.stringify(config) !== JSON.stringify(expectedConfig)) throw new Error('release policy changed; rerun dry-run before updating the mapping');
+    const before = git(['show', `${base}:config/commits.json`], { cwd });
+    const after = updateMappingText(before, source, target, force);
+    if (after === before) return;
+    git(['read-tree', base], { cwd });
+    const blob = git(['hash-object', '-w', '--stdin'], { cwd, input: after }).trim();
+    git(['update-index', '--add', '--cacheinfo', `100644,${blob},config/commits.json`], { cwd });
+    const commit = createCommit(cwd, git(['write-tree'], { cwd }).trim(), base, `Record ${NAME} ${tag} mapping`);
+    try {
+      git(['push', `--force-with-lease=refs/heads/main:${base}`, 'origin', `${commit}:refs/heads/main`], { cwd, env });
+      return;
+    } catch (error) { if (attempt === 2) throw error; }
+  }
+}
+
+// URLs and git environments are injected for integration tests against disposable local bare repos.
+export async function release({ tag, dryRun = true, force = false, message = '', sourceUrl, publicUrl, botUrl, sourceEnv = {}, publicEnv = {}, botEnv = {} }) {
+  if (!/^v[0-9][0-9A-Za-z.+-]*$/.test(tag)) throw new Error('tag must be an existing version such as v1.0.0');
+  if (typeof dryRun !== 'boolean' || typeof force !== 'boolean') throw new Error('dryRun and force must be booleans');
+  if (!dryRun || message) message = validateMessage(message);
+  const scratch = await mkdtemp(join(tmpdir(), 'macaron-public-release-'));
+  try {
+    const source = join(scratch, 'source'), target = join(scratch, 'public'), bot = join(scratch, 'bot');
+    const tagRef = `refs/tags/${tag}`;
+    // Only the tagged tree is needed; fetching the entire internal history slows down every dry-run.
+    git(['init', '--quiet', source]);
+    git(['fetch', '--quiet', '--depth=1', '--no-tags', sourceUrl, `${tagRef}:${tagRef}`], { cwd: source, env: sourceEnv });
+    for (const [url, destination, env] of [[publicUrl, target, publicEnv], [botUrl, bot, botEnv]]) git(['clone', '--quiet', '--no-checkout', '--', url, destination], { env });
+    const sourceCommit = oid(source, `${tagRef}^{commit}`);
+    const publicBase = oid(target, 'refs/remotes/origin/main'), oldTag = oid(target, tagRef, false), oldTagCommit = oldTag && oid(target, `${tagRef}^{commit}`);
+    const botBase = oid(bot, 'refs/remotes/origin/main');
+    const config = readConfiguration(git(['show', `${botBase}:config/repositories.json`], { cwd: bot }));
+    const mappings = readMappings(git(['show', `${botBase}:config/commits.json`], { cwd: bot })).mappings[NAME];
+    // Import objects only. The public commit has ONLY a public parent, never a source-history parent.
+    git(['fetch', '--quiet', '--no-tags', source, sourceCommit], { cwd: target });
+    const snapshot = await snapshotTree(target, sourceCommit, config.public_exclude || [], scratch);
+    let publicCommit, publicMain = publicBase;
+    if (oldTagCommit && tree(target, oldTagCommit) === snapshot && botAuthored(target, oldTagCommit) && isAncestor(target, oldTagCommit, publicBase)) {
+      publicCommit = oldTagCommit; // A retry of an older tag must not rewind a newer public main.
+    } else if (oldTag && !force) {
+      throw new Error(`public tag ${tag} conflicts with this snapshot; replacement requires --force`);
+    } else if (!oldTag && mappings[sourceCommit] && oid(target, `${mappings[sourceCommit]}^{commit}`, false) && tree(target, mappings[sourceCommit]) === snapshot && botAuthored(target, mappings[sourceCommit]) && isAncestor(target, mappings[sourceCommit], publicBase)) {
+      publicCommit = mappings[sourceCommit];
+    } else if (tree(target, publicBase) === snapshot && botAuthored(target, publicBase)) {
+      publicCommit = publicBase;
+    } else if (message) {
+      const date = git(['show', '-s', '--format=%cI', sourceCommit], { cwd: source }).trim();
+      publicCommit = createCommit(target, snapshot, publicBase, message, date);
+      publicMain = publicCommit;
+    }
+    if (publicCommit) updateMappingText(git(['show', `${botBase}:config/commits.json`], { cwd: bot }), sourceCommit, publicCommit, force);
+    const diff = git(['diff', '--stat', publicBase, snapshot, '--'], { cwd: target });
+    const result = { tag, dryRun, sourceCommit, snapshot, publicCommit: publicCommit || null, publicMain, diff, needsMessage: !publicCommit };
+    if (dryRun) return result;
+
+    const refspecs = [], leases = [];
+    if (publicMain !== publicBase) { refspecs.push(`${publicMain}:refs/heads/main`); leases.push(`--force-with-lease=refs/heads/main:${publicBase}`); }
+    if (oldTagCommit !== publicCommit) { refspecs.push(`${publicCommit}:${tagRef}`); leases.push(`--force-with-lease=${tagRef}:${oldTag || ''}`); }
+    // Both refs advance together; exact leases reject any change since the initial read, including forced tags.
+    if (refspecs.length) git(['push', '--atomic', ...leases, 'origin', ...refspecs], { cwd: target, env: publicEnv });
+    try { await saveMapping(bot, sourceCommit, publicCommit, tag, force, config, botEnv); }
+    catch (error) { throw new Error(`public ${tag} is published at ${publicCommit}, but mapping write failed: ${error.message}. Rerun the same release to repair it.`); }
+    return result;
+  } finally { await rm(scratch, { recursive: true, force: true }); }
+}
+
+function authEnv(token) {
+  // Credentials stay out of argv, remote URLs, and persistent git config.
+  return token ? { GIT_CONFIG_COUNT: '1', GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader', GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}` } : {};
+}
+async function api(path, token) {
+  const response = await fetch(`https://api.github.com/${path}`, { headers: { Accept: 'application/vnd.github+json', ...(token ? { Authorization: `Bearer ${token}` } : {}) }, signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) throw new Error(`GitHub GET ${path} returned ${response.status}`);
+  return response.json();
+}
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) { console.log('Usage: node .github/scripts/public-release.mjs --tag vX.Y.Z [--dry-run | --publish] [--message-file notes.md] [--force]'); return; }
+  const token = process.env.MINDLAB_BOT_GH_TOKEN?.trim(), sourceToken = process.env.GITHUB_TOKEN?.trim();
+  if (!token) throw new Error('MINDLAB_BOT_GH_TOKEN is required in repository Actions secrets');
+  if (process.env.GITHUB_REPOSITORY && process.env.GITHUB_REPOSITORY !== SOURCE) throw new Error(`run this workflow in ${SOURCE}`);
+  const checks = await Promise.all([api('user', token), api(`repos/${PUBLIC}`, token), api(`repos/${BOT}`, token), api(`repos/${LEGACY_SOURCE}`, sourceToken)]);
+  if (checks[0].login !== 'mindlab-bot') throw new Error('MINDLAB_BOT_GH_TOKEN must belong to mindlab-bot');
+  if (!checks[1].permissions?.push || !checks[2].permissions?.push) throw new Error('bot token needs Contents read/write on both the public repository and mindlab-bot');
+  if (checks[3].full_name !== SOURCE) throw new Error('legacy source URL no longer resolves to the expected repository');
+  const summary = process.env.PUBLIC_RELEASE_SUMMARY || '', details = process.env.PUBLIC_RELEASE_DETAILS || '';
+  const message = options.messageFile ? await readFile(options.messageFile, 'utf8') : (summary || details ? `${summary}\n\n${details}` : '');
+  const result = await release({ ...options, message, sourceUrl: `https://github.com/${SOURCE}.git`, publicUrl: `https://github.com/${PUBLIC}.git`, botUrl: `https://github.com/${BOT}.git`, sourceEnv: authEnv(sourceToken), publicEnv: authEnv(token), botEnv: authEnv(token) });
+  const report = [
+    `### ${result.dryRun ? 'Dry run' : 'Published'} ${result.tag}`, '', `Source commit: ${result.sourceCommit}`, `Public snapshot tree: ${result.snapshot}`,
+    `Public commit: ${result.publicCommit || 'pending public release description'}`, '', result.diff || 'No public file changes.', '',
+    ...(result.needsMessage ? ['Provide a public summary and description before publishing.'] : []),
+    result.dryRun ? 'No remote commits, tags, or mappings were written. API-reported permissions do not prove branch-rule acceptance.' : 'Public refs and commit mapping are synchronized.',
+  ].join('\n');
+  console.log(report);
+  if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, report + '\n');
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch(error => { console.error(`public-release: ${error.message}`); process.exitCode = 1; });

--- a/.github/scripts/public-release.test.mjs
+++ b/.github/scripts/public-release.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { LEGACY_SOURCE, NAME, PUBLIC, parseArgs, readConfiguration, release, validateMessage } from './public-release.mjs';
+
+const identity = { GIT_AUTHOR_NAME: 'mindlab-bot', GIT_AUTHOR_EMAIL: 'contact@mindlab.ltd', GIT_COMMITTER_NAME: 'mindlab-bot', GIT_COMMITTER_EMAIL: 'contact@mindlab.ltd' };
+const message = 'Add shared artifact workspaces\n\nKeep documentation and runnable examples together in the application.';
+function git(cwd, args, env = {}) {
+  const result = spawnSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], { cwd, env: { ...process.env, ...identity, ...env }, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+const head = path => git(path, ['rev-parse', 'refs/heads/main']);
+const refs = path => git(path, ['show-ref']);
+async function file(root, path, text) { const full = join(root, path); await mkdir(join(full, '..'), { recursive: true }); await writeFile(full, text); }
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'release-fixture-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const source = join(root, 'source'), publicWork = join(root, 'public-work'), botWork = join(root, 'bot-work');
+  for (const dir of [source, publicWork, botWork]) { await mkdir(dir); git(dir, ['init', '-q', '-b', 'main']); }
+  const content = {
+    'README.md': 'workspace\n', '.github/workflows/internal.yml': 'internal', 'nested/.github/hidden': 'hidden',
+    'internal/plan.md': 'secret plan', 'internal/keep.md': 'public plan', 'private.secret': 'secret', 'visible.secret': 'keep',
+    'docs/guide.md': 'guide', '.gitignore': 'ignored.txt\n', 'ignored.txt': 'tracked despite gitignore',
+    '.gitattributes': 'docs/guide.md export-ignore\n', 'run.sh': '#!/bin/sh\necho example\n',
+    'odd \nfile.md': 'newline filename',
+  };
+  for (const [path, text] of Object.entries(content)) await file(source, path, text);
+  await chmod(join(source, 'run.sh'), 0o755);
+  await symlink('docs/guide.md', join(source, 'guide.md'));
+  git(source, ['add', '-f', '.']);
+  git(source, ['commit', '-qm', 'Internal implementation (#42)'], { GIT_AUTHOR_NAME: 'Private developer', GIT_COMMITTER_NAME: 'Private developer' });
+  git(source, ['tag', '-a', 'v0.9.2', '-m', 'internal release annotation']);
+  for (const [path, text] of Object.entries({ 'obsolete.txt': 'delete', '.github/old.yml': 'delete', 'internal/old.md': 'delete' })) await file(publicWork, path, text);
+  git(publicWork, ['add', '.']); git(publicWork, ['commit', '-qm', 'Existing public snapshot']);
+  const config = { repositories: [{ name: NAME, private: LEGACY_SOURCE, public: PUBLIC, public_token_env: 'MINDLAB_BOT_GH_TOKEN', public_exclude: ['internal/*', '!internal/keep.md', '*.secret', '!visible.secret'] }] };
+  const mappings = '{\n  "mappings": {\n    "other": { "keep": "untouched" },\n    "macaron-artifacts": {},\n    "last": {}\n  }\n}\n';
+  await file(botWork, 'config/repositories.json', JSON.stringify(config));
+  await file(botWork, 'config/commits.json', mappings);
+  await file(botWork, 'unrelated.txt', 'keep this file');
+  git(botWork, ['add', '.']); git(botWork, ['commit', '-qm', 'Existing bot config']);
+  const publicUrl = join(root, 'public.git'), botUrl = join(root, 'bot.git');
+  git(root, ['clone', '-q', '--bare', publicWork, publicUrl]); git(root, ['clone', '-q', '--bare', botWork, botUrl]);
+  return { root, source, publicUrl, botUrl, config, mappings, publicBefore: head(publicUrl), botBefore: head(botUrl),
+    options: { sourceUrl: source, publicUrl, botUrl, tag: 'v0.9.2', message } };
+}
+function allRefs(f) { return [refs(f.source), refs(f.publicUrl), refs(f.botUrl)]; }
+
+test('CLI defaults to dry-run, requires explicit publish, and rejects conflicting flags', () => {
+  assert.equal(parseArgs(['--tag', 'v0.9.2']).dryRun, true);
+  assert.equal(parseArgs(['--tag', 'v0.9.2', '--publish']).dryRun, false);
+  assert.throws(() => parseArgs(['--publish', '--dry-run']), /choose either/);
+  assert.throws(() => parseArgs(['--tag', '--publish']), /requires a value/);
+  assert.equal(parseArgs(['--help']).help, true);
+  assert.throws(() => validateMessage('only a subject'), /blank line/);
+  assert.throws(() => validateMessage('Update (#42)\n\nPrivate implementation.'), /internal/);
+});
+
+test('dry-run builds a full snapshot without writing any remote refs', async t => {
+  const f = await fixture(t), before = allRefs(f);
+  const result = await release(f.options);
+  assert.equal(result.dryRun, true);
+  assert.match(result.snapshot, /^[0-9a-f]{40}$/);
+  assert.match(result.diff, /obsolete.txt/);
+  assert.match(result.diff, /docs\/guide.md/);
+  assert.equal(result.needsMessage, false);
+  assert.deepEqual(allRefs(f), before);
+  const withoutNotes = await release({ ...f.options, message: '' });
+  assert.equal(withoutNotes.needsMessage, true);
+  assert.equal(withoutNotes.publicCommit, null);
+  await assert.rejects(release({ ...f.options, message: '', dryRun: false }), /public summary/);
+  assert.deepEqual(allRefs(f), before);
+});
+
+test('publication preserves exact files, modes, symlinks, and only public commit ancestry', async t => {
+  const f = await fixture(t), beforeSource = refs(f.source);
+  const preview = await release(f.options);
+  const published = await release({ ...f.options, dryRun: false });
+  assert.equal(published.publicCommit, preview.publicCommit);
+  assert.equal(head(f.publicUrl), published.publicCommit);
+  assert.equal(git(f.publicUrl, ['rev-parse', 'refs/tags/v0.9.2']), published.publicCommit);
+  assert.equal(git(f.publicUrl, ['show', '-s', '--format=%P', 'main']), f.publicBefore);
+  assert.equal(git(f.publicUrl, ['rev-list', '--count', 'main']), '2');
+  assert.equal(git(f.publicUrl, ['show', '-s', '--format=%an <%ae>%n%cn <%ce>', 'main']), 'mindlab-bot <contact@mindlab.ltd>\nmindlab-bot <contact@mindlab.ltd>');
+  assert.equal(git(f.publicUrl, ['show', '-s', '--format=%B', 'main']), message);
+  const files = git(f.publicUrl, ['ls-tree', '-rz', 'main']).split('\0').filter(Boolean).map(s => s.slice(s.indexOf('\t') + 1));
+  for (const path of ['README.md', 'docs/guide.md', 'internal/keep.md', 'ignored.txt', 'visible.secret', 'odd \nfile.md']) assert.ok(files.includes(path), path);
+  for (const path of ['.github/old.yml', '.github/workflows/internal.yml', 'nested/.github/hidden', 'obsolete.txt', 'private.secret', 'internal/plan.md']) assert.ok(!files.includes(path), path);
+  assert.match(git(f.publicUrl, ['ls-tree', 'main', 'run.sh']), /^100755 /);
+  assert.match(git(f.publicUrl, ['ls-tree', 'main', 'guide.md']), /^120000 /);
+  assert.equal(git(f.publicUrl, ['show', 'main:guide.md']), 'docs/guide.md');
+  const mapping = git(f.botUrl, ['show', 'main:config/commits.json']);
+  assert.equal(JSON.parse(mapping).mappings[NAME][published.sourceCommit], published.publicCommit);
+  assert.match(mapping, /"other": \{ "keep": "untouched" \}/);
+  assert.equal(git(f.botUrl, ['diff', '--name-only', f.botBefore, 'main']), 'config/commits.json');
+  assert.equal(refs(f.source), beforeSource);
+});
+
+test('retries are idempotent and older tags never rewind a newer public main', async t => {
+  const f = await fixture(t);
+  const first = await release({ ...f.options, dryRun: false });
+  const afterFirst = allRefs(f);
+  await release({ ...f.options, dryRun: false });
+  assert.deepEqual(allRefs(f), afterFirst);
+  await file(f.source, 'README.md', 'updated workspace');
+  git(f.source, ['add', '.']); git(f.source, ['commit', '-qm', 'Next version']); git(f.source, ['tag', 'v0.9.3']);
+  await release({ ...f.options, tag: 'v0.9.3', dryRun: false });
+  const afterSecond = allRefs(f);
+  const retried = await release({ ...f.options, dryRun: false });
+  assert.equal(retried.publicCommit, first.publicCommit);
+  assert.deepEqual(allRefs(f), afterSecond);
+});
+
+test('existing tag conflicts require force and force dry-run still writes nothing', async t => {
+  const f = await fixture(t);
+  await release({ ...f.options, dryRun: false });
+  await file(f.source, 'README.md', 'replacement contents');
+  git(f.source, ['add', '.']); git(f.source, ['commit', '-qm', 'Replacement']); git(f.source, ['tag', '-f', 'v0.9.2']);
+  const before = allRefs(f);
+  await assert.rejects(release({ ...f.options, dryRun: false }), /requires --force/);
+  await release({ ...f.options, force: true });
+  assert.deepEqual(allRefs(f), before);
+  const forced = await release({ ...f.options, force: true, dryRun: false });
+  assert.equal(head(f.publicUrl), forced.publicCommit);
+  assert.equal(git(f.publicUrl, ['show', 'main:README.md']), 'replacement contents');
+});
+
+test('a rejected tag cannot leave main partially published', async t => {
+  const f = await fixture(t), before = allRefs(f);
+  // Receive hooks are server-side; the client cannot disable them with core.hooksPath.
+  await file(f.publicUrl, 'hooks/update', '#!/bin/sh\ncase "$1" in refs/tags/*) exit 1;; esac\n');
+  await chmod(join(f.publicUrl, 'hooks/update'), 0o755);
+  await assert.rejects(release({ ...f.options, dryRun: false }), /git push failed/);
+  assert.deepEqual(allRefs(f), before);
+});
+
+test('mapping push failure is recoverable after the public refs are published', async t => {
+  const f = await fixture(t);
+  await file(f.botUrl, 'hooks/pre-receive', '#!/bin/sh\nexit 1\n');
+  await chmod(join(f.botUrl, 'hooks/pre-receive'), 0o755);
+  await assert.rejects(release({ ...f.options, dryRun: false }), /mapping write failed.*Rerun/s);
+  const publicRefs = refs(f.publicUrl);
+  assert.equal(head(f.botUrl), f.botBefore);
+  await rm(join(f.botUrl, 'hooks/pre-receive'));
+  const retry = await release({ ...f.options, dryRun: false });
+  assert.equal(refs(f.publicUrl), publicRefs);
+  const mappings = JSON.parse(git(f.botUrl, ['show', 'main:config/commits.json'])).mappings;
+  assert.equal(mappings[NAME][retry.sourceCommit], retry.publicCommit);
+});
+
+test('invalid policies, tags, and missing mappings fail without changing remotes', async t => {
+  const f = await fixture(t), before = allRefs(f);
+  for (const tag of ['main', 'v1;touch injected', 'v1\nnext', 'v1$(id)', 'v99.0.0']) await assert.rejects(release({ ...f.options, tag }));
+  assert.throws(() => readConfiguration(JSON.stringify({ repositories: [f.config.repositories[0], f.config.repositories[0]] })), /exactly one/);
+  for (const public_exclude of ['internal', ['internal\nREADME.md']]) assert.throws(() => readConfiguration(JSON.stringify({ repositories: [{ ...f.config.repositories[0], public_exclude }] })), /single-line/);
+  assert.deepEqual(allRefs(f), before);
+});
+
+test('mapping retries preserve a concurrent update from another project', async t => {
+  const f = await fixture(t), other = join(f.root, 'other-writer');
+  git(f.root, ['clone', '-q', f.botUrl, other]);
+  const nextMappings = f.mappings.replace('"keep": "untouched"', '"keep": "concurrently updated"');
+  await file(other, 'config/commits.json', nextMappings);
+  git(other, ['add', '.']); git(other, ['commit', '-qm', 'Other project mapping']);
+  const next = head(other);
+  git(f.botUrl, ['fetch', '-q', other, 'main:refs/heads/other-writer']);
+  // Advance the real remote after the client has read it, so its first compare-and-swap fails.
+  await file(f.botUrl, 'hooks/pre-receive', `#!/bin/sh
+unset GIT_QUARANTINE_PATH GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+if [ ! -f hooks/raced ]; then
+  touch hooks/raced
+  git update-ref refs/heads/main ${next} ${f.botBefore} || exit 1
+  exit 1
+fi
+`);
+  await chmod(join(f.botUrl, 'hooks/pre-receive'), 0o755);
+  const result = await release({ ...f.options, dryRun: false });
+  const mapping = JSON.parse(git(f.botUrl, ['show', 'main:config/commits.json'])).mappings;
+  assert.equal(mapping.other.keep, 'concurrently updated');
+  assert.equal(mapping[NAME][result.sourceCommit], result.publicCommit);
+  assert.equal(git(f.botUrl, ['show', '-s', '--format=%P', 'main']), next);
+});
+
+test('missing mapping sections and empty exports are rejected before publishing', async t => {
+  const f = await fixture(t), botWork = join(f.root, 'bot-work');
+  await file(botWork, 'config/commits.json', '{"mappings":{}}');
+  git(botWork, ['add', '.']); git(botWork, ['commit', '-qm', 'Missing project mapping']);
+  git(botWork, ['push', '-q', f.botUrl, 'main']);
+  const before = allRefs(f);
+  await assert.rejects(release({ ...f.options, dryRun: false }), /missing mappings/);
+  assert.deepEqual(allRefs(f), before);
+  await file(botWork, 'config/commits.json', f.mappings);
+  f.config.repositories[0].public_exclude = ['*'];
+  await file(botWork, 'config/repositories.json', JSON.stringify(f.config));
+  git(botWork, ['add', '.']); git(botWork, ['commit', '-qm', 'Empty export policy']); git(botWork, ['push', '-q', f.botUrl, 'main']);
+  const emptyBefore = allRefs(f);
+  await assert.rejects(release({ ...f.options, dryRun: false }), /empty public snapshot/);
+  assert.deepEqual(allRefs(f), emptyBefore);
+});

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -22,6 +22,7 @@ jobs:
       # Keep bun even though deps install with pnpm: the publish step's `npm pack`
       # fires the root `prepack`, which runs `bun build` to bundle the server.
       - uses: oven-sh/setup-bun@v2
+      - run: node --test .github/scripts/public-release.test.mjs
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-# Adapted from MindLab-Research/mindlab-bot/workflows/release-on-tag.yml.
 name: Release to Public
-run-name: "${{ inputs.dry_run && 'Dry run' || 'Publish' }} ${{ inputs.tag_name }}"
+run-name: "${{ github.event.inputs.dry_run == 'false' && 'Publish' || 'Dry run' }} ${{ inputs.tag_name }}"
 
 on:
   workflow_dispatch:
@@ -10,10 +9,21 @@ on:
         required: true
         type: string
       dry_run:
-        description: Check release access without publishing
+        description: Preview the public snapshot without publishing
         required: true
         type: boolean
         default: true
+      force:
+        description: Allow replacing a conflicting public tag and mapping
+        required: true
+        type: boolean
+        default: false
+      summary:
+        description: Public commit summary under 72 characters (required to publish)
+        type: string
+      details:
+        description: Public-facing changes, without internal names or PR references (required to publish)
+        type: string
 
 permissions:
   contents: read
@@ -25,68 +35,30 @@ concurrency:
 jobs:
   release:
     if: github.repository == 'mindverse-ltd/macaron-artifacts'
-    runs-on: self-hosted
-    timeout-minutes: 60
-    defaults:
-      run:
-        shell: bash --noprofile --norc -euo pipefail {0}
-    env:
-      RELEASE_TAG: ${{ inputs.tag_name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - name: Check release prerequisites
-        run: |
-          # Keep free-form dispatch input out of shell code and the agent's instructions.
-          [[ "$RELEASE_TAG" =~ ^v[0-9][0-9A-Za-z.+-]*$ ]] || { echo '::error::Enter a version tag such as v1.0.0'; exit 1; }
-          for tool in git gh jq rsync pi; do command -v "$tool"; done
-          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object.sha'
-
-      - name: Define action directory
-        run: |
-          action_root="$HOME/.mindlab-bot-actions"
-          mkdir -p "$action_root"
-          action_dir="$(mktemp -d "$action_root/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.XXXXXX")"
-          echo "MINDLAB_BOT_ACTION_DIR=$action_dir" >> "$GITHUB_ENV"
-
-      - name: Clone mindlab-bot
-        run: gh repo clone MindLab-Research/mindlab-bot "$MINDLAB_BOT_ACTION_DIR"
-
-      - name: Load public repository credentials
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Test release script
+        run: node --test .github/scripts/public-release.test.mjs
+      - name: Build public snapshot
         env:
+          RELEASE_TAG: ${{ inputs.tag_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          FORCE_RELEASE: ${{ inputs.force }}
+          PUBLIC_RELEASE_SUMMARY: ${{ inputs.summary }}
+          PUBLIC_RELEASE_DETAILS: ${{ inputs.details }}
           MINDLAB_BOT_GH_TOKEN: ${{ secrets.MINDLAB_BOT_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
         run: |
-          token_file="$HOME/.config/mindlab-bot/github-token"
-          if [[ -z "$MINDLAB_BOT_GH_TOKEN" && -r "$token_file" ]]; then
-            MINDLAB_BOT_GH_TOKEN="$(cat "$token_file")"
-          fi
-          [[ -n "$MINDLAB_BOT_GH_TOKEN" ]] || { echo '::error::Configure the mindlab-bot token on the runner or in MINDLAB_BOT_GH_TOKEN'; exit 1; }
-          echo "::add-mask::$MINDLAB_BOT_GH_TOKEN"
-          echo "MINDLAB_BOT_GH_TOKEN=$MINDLAB_BOT_GH_TOKEN" >> "$GITHUB_ENV"
-
-      - name: Check repository mapping
-        working-directory: ${{ env.MINDLAB_BOT_ACTION_DIR }}
-        run: |
-          jq -e '.repositories[] | select(.name == "macaron-artifacts") | .public == "MindLab-Research/macaron-artifacts" and .public_token_env == "MINDLAB_BOT_GH_TOKEN" and .public_ssh_key_env == null' config/repositories.json
-          source_repo="$(jq -r '.repositories[] | select(.name == "macaron-artifacts") | .private' config/repositories.json)"
-          # The bot still lists macaron-claude-code; GitHub resolves its rename to this repository.
-          [[ "$(gh api "repos/$source_repo" --jq '.full_name')" == "$GITHUB_REPOSITORY" ]]
-
-      - name: Check release access without publishing
-        if: inputs.dry_run
-        run: |
-          # API permission checks cannot prove branch-rule acceptance or model-provider authentication.
-          [[ "$(gh api repos/MindLab-Research/mindlab-bot --jq '.permissions.push')" == 'true' ]] || { echo '::error::Runner credentials cannot write the commit mapping'; exit 1; }
-          bot_login="$(GH_TOKEN="$MINDLAB_BOT_GH_TOKEN" gh api user --jq '.login')"
-          [[ "$bot_login" == 'mindlab-bot' ]] || { echo '::error::Public repository token must belong to mindlab-bot'; exit 1; }
-          [[ "$(GH_TOKEN="$MINDLAB_BOT_GH_TOKEN" gh api repos/MindLab-Research/macaron-artifacts --jq '.permissions.push')" == 'true' ]] || { echo '::error::Bot token cannot write the public repository'; exit 1; }
-          printf '%s\n' 'Dry run passed: tools, source tag, repository mapping, bot identity, and API-reported write permissions checked.' 'No release agent was invoked, and no tags, public commits, or mappings were written. Model-provider authentication and actual push acceptance were not tested.' >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Publish source tag
-        # Require an explicit false input: missing input must never fall through to publishing.
-        if: github.event.inputs.dry_run == 'false'
-        working-directory: ${{ env.MINDLAB_BOT_ACTION_DIR }}
-        # The runner supplies pi configuration and separate gh access for source reads and mapping writes.
-        run: pi --no-session -p "Use the release skill to publish repository macaron-artifacts at tag $RELEASE_TAG"
-
-      - name: Cleanup
-        if: always() && env.MINDLAB_BOT_ACTION_DIR != ''
-        run: rm -rf -- "$MINDLAB_BOT_ACTION_DIR"
+          args=(--tag "$RELEASE_TAG")
+          # Missing or invalid inputs stay dry; only an explicit false enables remote writes.
+          [[ "$DRY_RUN" == 'false' ]] && args+=(--publish)
+          [[ "$FORCE_RELEASE" == 'true' ]] && args+=(--force)
+          node .github/scripts/public-release.mjs "${args[@]}"


### PR DESCRIPTION
Public sync currently invokes `pi` on a self-hosted runner, which leaves this repository's manual runs queued and ties releases to machine-local credentials. Run the fixed Git flow on `ubuntu-latest` with Node.js and Git instead.

- Keep manual dispatch and default dry-run; only explicit `dry_run=false`/`--publish` writes remote refs. No source tags are created.
- Build the filtered tree from the selected tag's Git objects, preserving modes, symlinks and tracked files while excluding `.github/` and the current `public_exclude` policy. Release scripts live under `.github/` and stay out of public snapshots. Public commits have only public ancestry.
- Use operator-provided public summary/details instead of AI-generated release notes. Publish `main` and tag atomically with exact leases; make retries idempotent and recover a pending mapping write without republishing.
- Read/write both MindLab repositories using `MINDLAB_BOT_GH_TOKEN`; the source job token remains read-only. This explicitly replaces the upstream template's separate runner login for mapping writes.

Validation:

- 10 integration tests against disposable Git repositories pass locally and on a GitHub-hosted Linux runner. Coverage includes dry-run immutability, export fidelity, public ancestry, retries, forced-tag conflicts, atomic push rejection, mapping recovery, concurrent mapping updates and invalid/empty exports.
- A live snapshot-only dry-run of source `v0.9.2` using existing read access produced tree `1e2234779db9525e5980cda4ad4323c39fe5da03` without changing remote refs or mappings.
- The hosted dry-run started and passed the test step; bot authentication stopped explicitly because `MINDLAB_BOT_GH_TOKEN` is absent from repository Actions secrets. That run does not prove bot permissions.
- YAML, shell syntax and `git diff --check` pass. No real public release was performed.

`force` appends a corrective snapshot and replaces a conflicting tag/mapping; it does not erase old public history. GitHub cannot atomically update two repositories, so mapping failures report the completed public commit and can be repaired by rerunning.