### PR TITLE
group docs theme variants

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -19,4 +19,4 @@ All locally authored utility classes use UnoCSS `presetWind4`, prefixed with the
 
 Fumadocs' official precompiled `style.css` supplies its dependency-owned components, prose, search, and sidebar styles. The Vite compatibility plugin removes that stylesheet's duplicate reset with PostCSS; it does not compile Tailwind or scan local source. A test guards the vendor reset boundary. Per-module UnoCSS output supports React Router's client and prerender environments, with explicit cascade layer ordering in every CSS chunk.
 
-The navigation palette menu maps bundled Shiki themes to `--color-fd-*` variables and matching code-token themes. Neutral preserves the original Fumadocs colors. Theme preferences stay in browser storage and never enter model prompts.
+The navigation palette menu maps bundled Shiki theme families to `--color-fd-*` variables and matching code-token themes. Paired families select their light or dark variant with the site's appearance; Neutral preserves the original Fumadocs colors. Theme preferences stay in browser storage and never enter model prompts.

--- a/site/app/components/palette.tsx
+++ b/site/app/components/palette.tsx
@@ -2,31 +2,31 @@ import { createContext, use, useEffect, useState, type ReactNode } from 'react';
 import { useTheme } from 'fumadocs-ui/provider/base';
 import { Popover, PopoverContent, PopoverTrigger } from 'fumadocs-ui/components/ui/popover';
 import { Check, Moon, Palette, Sun } from 'lucide-react';
-import { loadPalette, palettes, paletteVariables, type PaletteId } from '@/lib/palettes';
+import { loadPalette, palettes, paletteFamily, paletteVariant, paletteVariables, type PaletteId } from '@/lib/palettes';
 
 const KEY = 'macaron-artifacts:docs-palette:v1';
 const PaletteContext = createContext<{ selected: PaletteId; select: (id: PaletteId) => void; error?: string } | null>(null);
 export function PaletteProvider({ children }: { children: ReactNode }) {
   const [selected, select] = useState<PaletteId>('neutral');
   const [error, setError] = useState<string>();
-  const { setTheme } = useTheme();
-  useEffect(() => { try { const saved = localStorage.getItem(KEY); if (palettes.some(palette => palette.id === saved)) select(saved as PaletteId); } catch { /* Optional browser preferences. */ } }, []);
+  const { resolvedTheme } = useTheme();
+  useEffect(() => { try { const family = paletteFamily(localStorage.getItem(KEY)); if (family) select(family); } catch { /* Optional browser preferences. */ } }, []);
   useEffect(() => {
     let current = true;
     const root = document.documentElement;
     const clear = () => { for (const name of [...root.style]) if (name.startsWith('--color-fd-')) root.style.removeProperty(name); root.style.removeProperty('--genui'); delete root.dataset.palette; };
-    if (selected === 'neutral') { clear(); setError(undefined); }
-    else void loadPalette(selected).then(theme => {
+    const variant = selected === 'neutral' ? undefined : paletteVariant(selected, resolvedTheme === 'dark' ? 'dark' : 'light');
+    if (!variant) { clear(); setError(undefined); }
+    else void loadPalette(variant).then(theme => {
       if (!current) return;
       clear();
       for (const [name, value] of Object.entries(paletteVariables(theme))) root.style.setProperty(`--color-fd-${name}`, value);
       root.style.setProperty('--genui', theme.colors?.['button.background'] ?? theme.fg ?? '#c96442');
-      root.dataset.palette = selected;
-      setTheme(theme.type === 'dark' ? 'dark' : 'light');
+      root.dataset.palette = variant;
       setError(undefined);
     }, reason => { if (current) setError(reason instanceof Error ? reason.message : 'Theme could not be loaded'); });
     return () => { current = false; };
-  }, [selected, setTheme]);
+  }, [selected, resolvedTheme]);
   const choose = (id: PaletteId) => { select(id); try { localStorage.setItem(KEY, id); } catch { /* Optional browser preferences. */ } };
   return <PaletteContext value={{ selected, select: choose, error }}>{children}</PaletteContext>;
 }
@@ -37,8 +37,7 @@ export function PaletteSwitch({ className = '' }: { className?: string }) {
   if (!palette) return null;
   const toggle = () => {
     const dark = resolvedTheme === 'dark';
-    if (palette.selected === 'neutral') setTheme(dark ? 'light' : 'dark');
-    else palette.select(palette.selected.startsWith('github') ? dark ? 'github-light' : 'github-dark' : dark ? 'vitesse-light' : 'vitesse-dark');
+    setTheme(dark ? 'light' : 'dark');
   };
   return <div className={`site:inline-flex site:shrink-0 site:items-center site:gap-1 ${className}`}>
     {/* Keep both icons and labels in the prerendered HTML; next-themes sets the root class before hydration. */}

--- a/site/app/lib/palettes.test.ts
+++ b/site/app/lib/palettes.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { paletteFamily, palettes, paletteVariant } from './palettes';
+
+test('docs palette menu exposes only complete light and dark theme families', () => {
+  assert.deepEqual(palettes.map(palette => palette.id), ['neutral', 'vitesse', 'github']);
+  for (const palette of palettes) if (palette.id !== 'neutral') {
+    assert.ok(palette.light.endsWith('-light'));
+    assert.ok(palette.dark.endsWith('-dark'));
+  }
+});
+
+test('docs palettes migrate legacy variant preferences and resolve the active appearance', () => {
+  assert.equal(paletteFamily('vitesse-light'), 'vitesse');
+  assert.equal(paletteFamily('github-dark'), 'github');
+  assert.equal(paletteVariant('vitesse', 'light'), 'vitesse-light');
+  assert.equal(paletteVariant('vitesse', 'dark'), 'vitesse-dark');
+  assert.equal(paletteVariant('github', 'light'), 'github-light');
+  assert.equal(paletteVariant('github', 'dark'), 'github-dark');
+});

--- a/site/app/lib/palettes.ts
+++ b/site/app/lib/palettes.ts
@@ -1,10 +1,15 @@
 import type { ThemeRegistration } from '@shikijs/types';
 
-export const palettes = [{ id: 'neutral', label: 'Neutral' }, { id: 'vitesse-light', label: 'Vitesse Light' }, { id: 'vitesse-dark', label: 'Vitesse Dark' }, { id: 'github-light', label: 'GitHub Light' }, { id: 'github-dark', label: 'GitHub Dark' }, { id: 'nord', label: 'Nord' }] as const;
+const pairedPalettes = [{ id: 'vitesse', label: 'Vitesse', light: 'vitesse-light', dark: 'vitesse-dark' }, { id: 'github', label: 'GitHub', light: 'github-light', dark: 'github-dark' }] as const;
+export const palettes = [{ id: 'neutral', label: 'Neutral' }, ...pairedPalettes] as const;
 export type PaletteId = typeof palettes[number]['id'];
+export type PaletteVariantId = Exclude<keyof typeof loaders, never>;
+const legacyPaletteFamilies = { 'vitesse-light': 'vitesse', 'vitesse-dark': 'vitesse', 'github-light': 'github', 'github-dark': 'github' } as const;
+export function paletteFamily(id: string | null | undefined): PaletteId | undefined { if (!id) return; if (palettes.some(palette => palette.id === id)) return id as PaletteId; return legacyPaletteFamilies[id as keyof typeof legacyPaletteFamilies]; }
+export function paletteVariant(id: Exclude<PaletteId, 'neutral'>, mode: 'light' | 'dark'): PaletteVariantId { return pairedPalettes.find(item => item.id === id)![mode]; }
 const loaders = { 'vitesse-light': () => import('@shikijs/themes/vitesse-light'), 'vitesse-dark': () => import('@shikijs/themes/vitesse-dark'), 'github-light': () => import('@shikijs/themes/github-light'), 'github-dark': () => import('@shikijs/themes/github-dark'), nord: () => import('@shikijs/themes/nord') };
 export const syntaxThemes = { light: 'github-light', dark: 'github-dark', 'vitesse-light': 'vitesse-light', 'vitesse-dark': 'vitesse-dark', 'github-light': 'github-light', 'github-dark': 'github-dark', nord: 'nord' } as const;
-export const loadPalette = async (id: Exclude<PaletteId, 'neutral'>) => (await loaders[id]()).default;
+export const loadPalette = async (id: PaletteVariantId) => (await loaders[id]()).default;
 
 function luminance(hex: string) {
   const value = hex.replace('#', '');

--- a/site/content/docs/usage.mdx
+++ b/site/content/docs/usage.mdx
@@ -58,7 +58,7 @@ OpenCode's native question dialogs and pi prompts that require a terminal UI are
 - An inline `ui4a/tsx` fenced module renders inside its assistant message as the source arrives.
 - A file at `.artifacts/canvases/<name>.ui4a.tsx` opens in **Canvas**. Relative TypeScript, TSX, and JSON imports resolve inside `.artifacts`.
 - The small `$ui4a/ui` component library shares the app's theme. Separate `$ui4a/chat`, `$ui4a/state`, and `$ui4a/fs` modules provide scoped host capabilities.
-- Choose a Shiki theme from the sidebar; both syntax highlighting and interface colors follow it.
+- Choose a paired Shiki theme family from the sidebar; its light or dark variant follows the site appearance, and both syntax highlighting and interface colors follow it.
 
 Workspace files remain in the selected directory. Deleting a conversation does not delete those files. Existing native session-history migration and attachments are not included in this version.
 


### PR DESCRIPTION
## What changed

The docs theme picker now presents paired theme families instead of separate light and dark entries.

- Show `Neutral`, `Vitesse`, and `GitHub` families only.
- Resolve each family's light or dark Shiki variant from the existing site appearance.
- Keep appearance switching independent from family selection, including automatic mode.
- Migrate legacy `*-light` and `*-dark` localStorage values.
- Keep concrete Shiki variant mappings for static code highlighting.

## Validation

- `pnpm -C site typecheck`
- `pnpm -C site test` (13 passed, 1 skipped)
- `pnpm -C site build`
- `git diff --check`
