### PR TITLE
show adaptive reasoning streams

### DIFF
--- a/artifacts/reasoning.html
+++ b/artifacts/reasoning.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Reasoning · Macaron Artifacts</title></head><body><div id="root"></div><script type="module" src="/src/web/reasoning-preview.tsx"></script></body></html>

--- a/artifacts/src/server/harnesses/codex-events.ts
+++ b/artifacts/src/server/harnesses/codex-events.ts
@@ -1,7 +1,7 @@
 import type { ChatChunk } from '../../shared/types.js';
 import { record, safeError, string } from './common.js';
 
-type Part = { id: string; itemId: string; kind: 'text' | 'reasoning'; ended: boolean; receivedDelta: boolean };
+type Part = { id: string; itemId: string; kind: 'text' | 'summary' | 'full'; ended: boolean; receivedDelta: boolean };
 
 /** Protocol fields verified with `codex app-server generate-ts --experimental` (0.153.4). */
 export class CodexEventMapper {
@@ -14,9 +14,9 @@ export class CodexEventMapper {
     if (method === 'item/agentMessage/delta' || method === 'item/plan/delta') {
       this.delta(itemId, itemId, 'text', params.delta, chunks);
     } else if (method === 'item/reasoning/summaryTextDelta') {
-      this.delta(`${itemId}:summary:${params.summaryIndex ?? 0}`, itemId, 'reasoning', params.delta, chunks);
+      this.delta(`${itemId}:summary:${params.summaryIndex ?? 0}`, itemId, 'summary', params.delta, chunks);
     } else if (method === 'item/reasoning/textDelta') {
-      this.delta(`${itemId}:content:${params.contentIndex ?? 0}`, itemId, 'reasoning', params.delta, chunks);
+      this.delta(`${itemId}:content:${params.contentIndex ?? 0}`, itemId, 'full', params.delta, chunks);
     } else if (method === 'item/commandExecution/outputDelta' || method === 'item/fileChange/outputDelta') {
       if (typeof params.delta === 'string') chunks.push({ type: 'data-command', data: { toolCallId: itemId, output: params.delta } });
     } else if (method === 'thread/tokenUsage/updated') {
@@ -34,8 +34,8 @@ export class CodexEventMapper {
         else this.start(id, id, 'text', chunks);
       } else if (item.type === 'reasoning') {
         if (completed) {
-          for (const [index, text] of (Array.isArray(item.summary) ? item.summary : []).entries()) this.fallback(`${id}:summary:${index}`, id, 'reasoning', text, chunks);
-          for (const [index, text] of (Array.isArray(item.content) ? item.content : []).entries()) this.fallback(`${id}:content:${index}`, id, 'reasoning', text, chunks);
+          for (const [index, text] of (Array.isArray(item.summary) ? item.summary : []).entries()) this.fallback(`${id}:summary:${index}`, id, 'summary', text, chunks);
+          for (const [index, text] of (Array.isArray(item.content) ? item.content : []).entries()) this.fallback(`${id}:content:${index}`, id, 'full', text, chunks);
         }
       } else {
         const tool = this.tool(item);
@@ -64,7 +64,8 @@ export class CodexEventMapper {
     if (existing) return existing;
     const part: Part = { id, itemId, kind, ended: false, receivedDelta: false };
     this.parts.set(id, part);
-    chunks.push({ type: kind === 'text' ? 'text-start' : 'reasoning-start', id });
+    if (kind === 'text') chunks.push({ type: 'text-start', id });
+    else chunks.push({ type: 'reasoning-start', id, providerMetadata: { macaron: { reasoningKind: kind, itemId } } });
     return part;
   }
   private delta(id: string, itemId: string, kind: Part['kind'], value: unknown, chunks: ChatChunk[]) {

--- a/artifacts/src/server/harnesses/events.test.ts
+++ b/artifacts/src/server/harnesses/events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { readUIMessageStream } from 'ai';
 import type { ChatChunk } from '../../shared/types.js';
 import type { HarnessTurn } from './types.js';
 import { ClaudeEventMapper, claudeOptions } from './claude.js';
@@ -90,7 +91,25 @@ describe('Codex native deltas', () => {
     chunks.push(...mapper.map('item/completed', { item: { id: 'r', type: 'reasoning', summary: ['Summary'], content: ['Detail'] } }));
     expect(chunks.filter((chunk) => chunk.type === 'text-delta').map((chunk) => chunk.delta)).toEqual(['A', ' ', '中']);
     expect(chunks.filter((chunk) => chunk.type === 'reasoning-delta').map((chunk) => chunk.delta)).toEqual(['Summary', 'Detail']);
+    expect(chunks.filter((chunk) => chunk.type === 'reasoning-start')).toEqual([
+      { type: 'reasoning-start', id: 'r:summary:0', providerMetadata: { macaron: { reasoningKind: 'summary', itemId: 'r' } } },
+      { type: 'reasoning-start', id: 'r:content:0', providerMetadata: { macaron: { reasoningKind: 'full', itemId: 'r' } } },
+    ]);
     expect(chunks.filter((chunk) => chunk.type === 'reasoning-end')).toHaveLength(2);
+  });
+
+  test('keeps fallback reasoning boundaries and metadata through UI message parsing', async () => {
+    const mapper = new CodexEventMapper();
+    const chunks = mapper.map('item/completed', { item: { id: 'r', type: 'reasoning', summary: ['', '**Inspecting the source**', '**Checking the tests**'], content: ['Full reasoning\nkeeps its original text.'] } });
+    const stream = new ReadableStream<ChatChunk>({ start(controller) { for (const chunk of chunks) controller.enqueue(chunk); controller.close(); } });
+    let message;
+    for await (const snapshot of readUIMessageStream({ stream })) message = snapshot;
+    expect(message?.parts).toEqual([
+      { type: 'reasoning', id: 'r:summary:1', text: '**Inspecting the source**', state: 'done', providerMetadata: { macaron: { reasoningKind: 'summary', itemId: 'r' } } },
+      { type: 'reasoning', id: 'r:summary:2', text: '**Checking the tests**', state: 'done', providerMetadata: { macaron: { reasoningKind: 'summary', itemId: 'r' } } },
+      { type: 'reasoning', id: 'r:content:0', text: 'Full reasoning\nkeeps its original text.', state: 'done', providerMetadata: { macaron: { reasoningKind: 'full', itemId: 'r' } } },
+    ]);
+    expect(mapper.finish()).toEqual([]);
   });
 
   test('keeps each native command output delta rather than synthesizing final output chunks', () => {

--- a/artifacts/src/server/harnesses/hermes.test.ts
+++ b/artifacts/src/server/harnesses/hermes.test.ts
@@ -19,8 +19,15 @@ describe('Hermes gateway adapter protocol helpers', () => {
     expect(rpcPayload({ session_id: 'runtime-1' })).toEqual({ session_id: 'runtime-1' });
   });
 
-  test('resumes the durable session and maps Hermes thinking deltas', async () => {
+  test.each(['streamed', 'fallback', 'interleaved'] as const)('resumes the durable session and preserves %s reasoning boundaries', async mode => {
     const OriginalWebSocket = globalThis.WebSocket;
+    const originalUrl = process.env.MACARON_HERMES_URL;
+    const events: [string, Record<string, unknown>][] = mode === 'interleaved' ? [
+      ['thinking.delta', { text: 'plan ' }], ['reasoning.delta', { text: 'first' }],
+      ['tool.start', { tool_id: 'tool-1', name: 'read_file', args: {} }], ['tool.complete', { tool_id: 'tool-1', result: 'source' }],
+      ['thinking.delta', { text: 'check ' }], ['message.delta', { text: '' }], ['reasoning.delta', { text: 'result' }],
+      ['message.delta', { text: 'answer' }], ['message.complete', { text: 'answer' }],
+    ] : [['thinking.delta', { text: 'plan' }], ...(mode === 'streamed' ? [['message.delta', { text: 'answer' }]] as [string, Record<string, unknown>][] : []), ['message.complete', { text: 'answer' }]];
     let runtime = 0;
     class FakeWebSocket {
       static OPEN = 1;
@@ -32,7 +39,7 @@ describe('Hermes gateway adapter protocol helpers', () => {
         const request = JSON.parse(raw) as { id: number; method: string; params: Record<string, unknown> }, reply = (result: Record<string, unknown>) => this.emit('message', { data: JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) });
         if (request.method === 'session.create') { runtime = 1; reply({ session_id: 'runtime-1', stored_session_id: 'stored-1' }); }
         else if (request.method === 'session.resume') { runtime = 2; reply({ session_id: 'runtime-2', stored_session_id: 'stored-1' }); }
-        else if (request.method === 'prompt.submit') { reply({ status: 'streaming' }); queueMicrotask(() => { const sid = `runtime-${runtime}`; for (const [type, payload] of [['thinking.delta', { text: 'plan' }], ['message.delta', { text: 'answer' }], ['message.complete', { text: 'answer' }]] as const) this.emit('message', { data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type, session_id: sid, payload } }) }); }); }
+        else if (request.method === 'prompt.submit') { reply({ status: 'streaming' }); queueMicrotask(() => { const sid = `runtime-${runtime}`; for (const [type, payload] of events) this.emit('message', { data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type, session_id: sid, payload } }) }); }); }
         else reply({});
       }
       close() { this.readyState = 3; }
@@ -46,13 +53,23 @@ describe('Hermes gateway adapter protocol helpers', () => {
       let nativeId: string | undefined;
       const run = async (prompt: string) => { const chunks = []; for await (const chunk of hermesAdapter.run({ ...base, prompt, nativeId, onNativeSession: id => { nativeId = id; } })) chunks.push(chunk); return chunks; };
       const first = await run('first'), resumed = await run('second');
-      expect(first.filter(chunk => chunk.type === 'reasoning-delta').map(chunk => chunk.delta)).toEqual(['plan']);
+      expect(first.filter(chunk => chunk.type === 'reasoning-delta').map(chunk => chunk.delta)).toEqual(mode === 'interleaved' ? ['plan ', 'first', 'check ', 'result'] : ['plan']);
+      const starts = first.filter(chunk => chunk.type === 'reasoning-start'), ends = first.filter(chunk => chunk.type === 'reasoning-end');
+      expect(new Set(starts.map(chunk => chunk.id)).size).toBe(mode === 'interleaved' ? 2 : 1);
+      expect(ends.map(chunk => chunk.id)).toEqual(starts.map(chunk => chunk.id));
+      expect(first.findLastIndex(chunk => chunk.type === 'reasoning-end')).toBeLessThan(first.findIndex(chunk => chunk.type === 'text-start'));
+      if (mode === 'interleaved') {
+        const toolIndex = first.findIndex(chunk => chunk.type === 'tool-input-available');
+        expect(first[toolIndex - 1]).toEqual({ type: 'reasoning-end', id: starts[0]?.id });
+        expect(first[toolIndex + 2]).toEqual({ type: 'reasoning-start', id: starts[1]?.id });
+        expect(first.filter(chunk => chunk.type === 'reasoning-delta').map(chunk => chunk.id)).toEqual([starts[0]?.id, starts[0]?.id, starts[1]?.id, starts[1]?.id]);
+      }
       expect(decodeHermesNativeId(nativeId!).sessionId).toBe('runtime-2');
       expect(resumed.filter(chunk => chunk.type === 'text-delta').map(chunk => chunk.delta)).toEqual(['answer']);
     } finally {
       await closeHermesConnections();
       globalThis.WebSocket = OriginalWebSocket;
-      delete process.env.MACARON_HERMES_URL;
+      if (originalUrl === undefined) delete process.env.MACARON_HERMES_URL; else process.env.MACARON_HERMES_URL = originalUrl;
     }
   });
 });

--- a/artifacts/src/server/harnesses/hermes.ts
+++ b/artifacts/src/server/harnesses/hermes.ts
@@ -42,11 +42,13 @@ export const hermesAdapter: HarnessAdapter = {
     if (ref?.profile && ref.profile !== profileName(turn.profile)) throw new Error('Hermes session belongs to a different native profile; start a new session before switching Hermes profiles');
     const token = turn.profile?.authToken;
     const rpc = connectionFor(turn, token);
-    let nativeId = ref?.sessionId || '', storedId = ref?.storedId, activeTurn = false, done = false, textStarted = false, thoughtStarted = false, streamed = false, metadataText = '', resolveDone!: () => void, rejectDone!: (error: Error) => void;
+    let nativeId = ref?.sessionId || '', storedId = ref?.storedId, activeTurn = false, done = false, textStarted = false, thoughtId = '', thoughtSequence = 0, streamed = false, metadataText = '', resolveDone!: () => void, rejectDone!: (error: Error) => void;
     const completed = new Promise<void>((resolve, reject) => { resolveDone = resolve; rejectDone = reject; });
     void completed.catch(() => {});
     const queue = new EventQueue<ChatChunk>();
     const push = (items: ChatChunk[]) => { for (const item of items) queue.push(item); };
+    // Preserve the tool/text boundary when the next native thinking delta starts a new segment.
+    const endThought = () => { if (thoughtId) { push([{ type: 'reasoning-end', id: thoughtId }]); thoughtId = ''; } };
     const fail = (error: Error) => { queue.fail(error); rejectDone(error); };
     const unsub = rpc.onEvent(event => {
       const type = string(event.type), sid = string(event.session_id), payload = record(event.payload);
@@ -55,11 +57,11 @@ export const hermesAdapter: HarnessAdapter = {
       if (turn.enrichment) return;
       if (!activeTurn) return;
       if (type === 'message.start') { push([]); return; }
-      if (type === 'message.delta') { const text = string(payload.text); if (text && !textStarted) { textStarted = true; push([{ type: 'text-start', id: 'hermes-message' }]); } if (text) { streamed = true; push([{ type: 'text-delta', id: 'hermes-message', delta: text }]); } }
-      else if (type === 'reasoning.delta' || type === 'thinking.delta') { const text = string(payload.text); if (text && !thoughtStarted) { thoughtStarted = true; push([{ type: 'reasoning-start', id: 'hermes-reasoning' }]); } if (text) push([{ type: 'reasoning-delta', id: 'hermes-reasoning', delta: text }]); }
-      else if (type === 'tool.start') push([{ type: 'tool-input-available', toolCallId: string(payload.tool_id), toolName: string(payload.name), input: payload.args ?? {}, dynamic: true, providerExecuted: true }]);
+      if (type === 'message.delta') { const text = string(payload.text); if (text) endThought(); if (text && !textStarted) { textStarted = true; push([{ type: 'text-start', id: 'hermes-message' }]); } if (text) { streamed = true; push([{ type: 'text-delta', id: 'hermes-message', delta: text }]); } }
+      else if (type === 'reasoning.delta' || type === 'thinking.delta') { const text = string(payload.text); if (text && !thoughtId) { thoughtId = `hermes-reasoning-${++thoughtSequence}`; push([{ type: 'reasoning-start', id: thoughtId }]); } if (text) push([{ type: 'reasoning-delta', id: thoughtId, delta: text }]); }
+      else if (type === 'tool.start') { endThought(); push([{ type: 'tool-input-available', toolCallId: string(payload.tool_id), toolName: string(payload.name), input: payload.args ?? {}, dynamic: true, providerExecuted: true }]); }
       else if (type === 'tool.complete') { const id = string(payload.tool_id); push([{ type: 'tool-output-available', toolCallId: id, output: payload.result ?? payload.result_text ?? '', dynamic: true, providerExecuted: true }]); }
-      else if (type === 'message.complete') { const text = string(payload.text); if (!streamed && text) { textStarted = true; push([{ type: 'text-start', id: 'hermes-message' }, { type: 'text-delta', id: 'hermes-message', delta: text }]); } if (thoughtStarted) push([{ type: 'reasoning-end', id: 'hermes-reasoning' }]); if (textStarted) push([{ type: 'text-end', id: 'hermes-message' }]); done = true; queue.end(); resolveDone(); }
+      else if (type === 'message.complete') { endThought(); const text = string(payload.text); if (!streamed && text) { textStarted = true; push([{ type: 'text-start', id: 'hermes-message' }, { type: 'text-delta', id: 'hermes-message', delta: text }]); } if (textStarted) push([{ type: 'text-end', id: 'hermes-message' }]); done = true; queue.end(); resolveDone(); }
       else if (type === 'error' || type === 'connection.error') fail(new Error(string(payload.message) || 'Hermes turn failed'));
       else if (type === 'approval.request') {
         void abortable(turn.approve({ id: string(payload.request_id), tool: 'terminal', input: payload }), turn.signal)

--- a/artifacts/src/web/components/chat/Conversation.tsx
+++ b/artifacts/src/web/components/chat/Conversation.tsx
@@ -7,7 +7,8 @@ import { MessageBody } from './MessageBody';
 import { ToolCall } from './ToolCall';
 import { ApprovalCard } from './ApprovalCard';
 import { Composer } from './Composer';
-import { Collapsible } from '../code/Collapsible';
+import { Reasoning } from './Reasoning';
+import { reasoningRunAt } from './reasoning-model';
 import { Button } from '../ui4a-ui';
 import { Icon } from '../Icon';
 
@@ -58,7 +59,10 @@ const Message = memo(function Message({ message, streaming, sessionId, cwd, onSe
   return <article data-message-role={message.role} className={message.role === 'user' ? 'theme-bubble max-w-[85%] self-end rounded-2xl px-4 py-2 text-sm' : 'flex flex-col gap-3'}>
     {message.parts.map((part, index) => {
       if (part.type === 'text') return <MessageBody key={index} text={part.text} messageId={`${message.id}:${index}`} streaming={streaming} sessionId={sessionId} onSend={onSend} allowUi={message.role === 'assistant'} />;
-      if (part.type === 'reasoning') return <details key={index} className="overflow-clip rounded-lg bg-surface-2 text-xs text-muted"><summary className="interactive cursor-pointer px-3 py-2 select-none hover:bg-surface-3 hover:text-hover-fg">思考过程</summary><Collapsible className="theme-code"><p className="px-3 py-2 leading-relaxed whitespace-pre-wrap text-code-fg">{part.text}</p></Collapsible></details>;
+      if (part.type === 'reasoning') {
+        const parts = reasoningRunAt(message.parts, index);
+        return parts ? <Reasoning key={index} parts={parts} live={streaming && index + parts.length === message.parts.length} /> : null;
+      }
       if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') return <ToolCall key={index} cwd={cwd} part={part} commandOutput={'toolCallId' in part ? outputs.get(part.toolCallId) : undefined} onArtifact={onArtifact} />;
       if (part.type === 'data-approval') return <ApprovalCard key={part.data.id} approval={part.data} onDecide={approved => onApprove(part.data.id, approved)} />;
       // An orphan command stream renders once, at its first delta, carrying the joined output.

--- a/artifacts/src/web/components/chat/Reasoning.css
+++ b/artifacts/src/web/components/chat/Reasoning.css
@@ -1,0 +1,40 @@
+@property --reasoning-fade-top { syntax: '<number>'; inherits: true; initial-value: 0; }
+@property --reasoning-fade-bottom { syntax: '<number>'; inherits: true; initial-value: 0; }
+
+.reasoning { display: flex; align-items: flex-start; gap: .625rem; min-width: 0; color: var(--muted); font-size: 13px; line-height: 1.7; }
+.reasoning-indicator { flex: 0 0 5px; height: 5px; margin-top: .55rem; border-radius: 50%; background: currentColor; opacity: .45; }
+.reasoning[data-reasoning-active='true'] .reasoning-indicator { opacity: .85; animation: reasoning-breathe 1.8s ease-in-out infinite; }
+.reasoning-main { flex: 1; min-width: 0; }
+.reasoning-viewport { max-height: min(14rem, 36svh); overflow: auto; overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: var(--border) transparent; transition: --reasoning-fade-top 140ms ease, --reasoning-fade-bottom 140ms ease; mask-image: linear-gradient(to bottom, rgb(0 0 0 / calc(1 - var(--reasoning-fade-top))) 0, #000 16px, #000 calc(100% - 16px), rgb(0 0 0 / calc(1 - var(--reasoning-fade-bottom))) 100%); }
+.reasoning[data-reasoning-kind='summary'] .reasoning-viewport { max-height: min(10rem, 30svh); }
+.reasoning-content { min-width: 0; overflow-wrap: anywhere; padding-block: 4px; }
+.reasoning-content [data-reasoning-entry] + [data-reasoning-entry] { margin-top: .75rem; }
+.reasoning-content :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) { margin: 0; font-size: inherit; }
+.reasoning-content :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) + :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) { margin-top: .5rem; }
+.reasoning-content :where(strong, [data-streamdown='strong'], h1, h2, h3, h4, h5, h6) { color: var(--fg); font-weight: 500; }
+.reasoning-content [data-reasoning-latest='false'] :where(strong, [data-streamdown='strong']) { color: inherit; font-weight: 400; }
+.reasoning-content [data-reasoning-latest='true'] :where(strong, [data-streamdown='strong']) { font-weight: 600; }
+.reasoning-content :where(ul, ol) { padding-left: 1.25rem; }
+.reasoning-content [data-streamdown='unordered-list'] { list-style: disc; }
+.reasoning-content [data-streamdown='ordered-list'] { list-style: decimal; }
+.reasoning-content :where(pre, code) { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .92em; }
+.reasoning-content a { color: inherit; text-decoration: underline; text-underline-offset: 3px; }
+.reasoning-content pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+.reasoning-content [data-streamdown='code-block'] { background: transparent; border: 0; border-radius: 0; }
+.reasoning-content [data-streamdown='code-block-header'] { display: none; }
+.reasoning-content [data-streamdown='code-block-body'] { padding: 0; }
+.reasoning-actions { display: flex; flex-wrap: wrap; align-items: center; gap: .25rem .75rem; margin-top: .25rem; min-height: 24px; }
+.reasoning-action { display: inline-flex; align-items: center; gap: .25rem; min-height: 24px; padding: 0 .125rem; border: 0; border-radius: 3px; background: transparent; color: var(--muted); font: inherit; font-size: 12px; cursor: pointer; }
+.reasoning-action-icon { width: 14px; height: 14px; flex: none; }
+.reasoning-action[data-open] .reasoning-action-icon { transform: rotate(180deg); }
+.reasoning-resume { margin-left: auto; }
+.reasoning :focus-visible { outline: 2px solid var(--focus, var(--accent)); outline-offset: 2px; }
+/* Keep the keyboard outline outside the masked scroll plane so the edge fade cannot erase it. */
+.reasoning-viewport:focus-visible { outline: none; }
+.reasoning-main:has(> .reasoning-viewport:focus-visible) { outline: 2px solid var(--focus, var(--accent)); outline-offset: 3px; border-radius: 3px; }
+.reasoning-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.reasoning-current { animation: reasoning-arrive 160ms ease-out; }
+@media (hover: hover) { .reasoning-action:hover { color: var(--fg); } }
+@keyframes reasoning-breathe { 50% { opacity: .3; } }
+@keyframes reasoning-arrive { from { opacity: .5; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { .reasoning *, .reasoning { animation: none !important; transition: none !important; } }

--- a/artifacts/src/web/components/chat/Reasoning.tsx
+++ b/artifacts/src/web/components/chat/Reasoning.tsx
@@ -1,0 +1,51 @@
+'use client';
+/* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- The named overflowing region must support keyboard scrolling. */
+
+import { memo, useId, useMemo } from 'react';
+import { Disclosure, DisclosureButton } from '@headlessui/react';
+import type { ReasoningUIPart } from 'ai';
+import { Streamdown } from 'streamdown';
+import { cjk } from '@streamdown/cjk';
+import { Icon } from '../Icon';
+import { analyzeReasoning } from './reasoning-model';
+import { useReasoningScroll } from './useReasoningScroll';
+import './Reasoning.css';
+
+const PLUGINS = { cjk };
+const Markdown = memo(function Markdown({ text, live }: { text: string; live: boolean }) {
+  // Reasoning is text, never an executable UI4A surface. Streamdown handles incomplete Markdown.
+  return <Streamdown plugins={PLUGINS} controls={false} isAnimating={live}>{text}</Streamdown>;
+});
+
+export const Reasoning = memo(function Reasoning({ parts, live }: { parts: readonly ReasoningUIPart[]; live: boolean }) {
+  const active = live && parts.some(part => part.state !== 'done');
+  const presentation = useMemo(() => analyzeReasoning(parts, active), [parts, active]);
+  if (!presentation.entries.length && !active) return null;
+  return <Disclosure as="section" className="reasoning" data-reasoning-kind={presentation.kind} data-reasoning-active={active}>
+    {({ open }) => <ReasoningView presentation={presentation} active={active} historyOpen={open} />}
+  </Disclosure>;
+});
+
+function ReasoningView({ presentation, active, historyOpen }: { presentation: ReturnType<typeof analyzeReasoning>; active: boolean; historyOpen: boolean }) {
+  const regionId = useId();
+  const { kind, entries } = presentation;
+  const visible = kind === 'summary' && !historyOpen ? entries.slice(-1) : entries;
+  const contentKey = `${historyOpen}:${visible.map(entry => `${entry.key}:${entry.text}`).join('\n')}`;
+  const { viewport, content, following, overflowing, resume } = useReasoningScroll(contentKey, active && !historyOpen);
+  return <>
+    <div className="reasoning-indicator" aria-hidden="true" />
+    <div className="reasoning-main">
+      <span className="reasoning-sr-only" role="status">{active ? '正在思考' : ''}</span>
+      <div id={regionId} ref={viewport} className="reasoning-viewport" role="region" aria-label={kind === 'summary' ? '思考摘要' : '思考过程'} tabIndex={overflowing ? 0 : undefined}>
+        <div ref={content} className="reasoning-content">
+          {visible.map(entry => <div key={entry.key} data-reasoning-entry data-reasoning-latest={kind === 'summary' ? entry.key === entries.at(-1)?.key : undefined} className={kind === 'summary' && !historyOpen ? 'reasoning-current' : undefined}><Markdown text={entry.text} live={active} /></div>)}
+          {!entries.length && active ? <span className="reasoning-placeholder">正在思考</span> : null}
+        </div>
+      </div>
+      {(kind === 'summary' && entries.length > 1) || (overflowing && !following && active && !historyOpen) ? <div className="reasoning-actions">
+        {kind === 'summary' && entries.length > 1 ? <DisclosureButton aria-controls={regionId} className="reasoning-action" onClick={() => { if (historyOpen) resume(); }} title={historyOpen ? '仅显示最新摘要' : '查看先前摘要'}><Icon name="chevronDown" className="reasoning-action-icon" /><span>{historyOpen ? '仅显示最新' : `${entries.length} 段摘要`}</span></DisclosureButton> : null}
+        {overflowing && !following && active && !historyOpen ? <button type="button" className="reasoning-action reasoning-resume" onClick={resume} title="继续跟随思考"><Icon name="arrowDown" className="reasoning-action-icon" /><span>跟随最新</span></button> : null}
+      </div> : null}
+    </div>
+  </>;
+}

--- a/artifacts/src/web/components/chat/ReasoningExamples.css
+++ b/artifacts/src/web/components/chat/ReasoningExamples.css
@@ -1,0 +1,19 @@
+.reasoning-examples { height: 100dvh; overflow: auto; background: var(--surface); color: var(--fg); }
+.reasoning-examples-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px 20px; padding: 14px 24px; background: var(--surface-2); font-size: 12px; }
+.reasoning-examples-field { display: flex; align-items: center; gap: 8px; min-width: 0; color: var(--muted); }
+.reasoning-examples-field select { appearance: auto; max-width: min(240px, 62vw); padding: 6px 8px; border: 0; border-radius: 4px; background: var(--surface); color: var(--fg); font: inherit; }
+.reasoning-examples-playback { display: flex; gap: 4px; }
+.reasoning-examples-playback button { min-width: 44px; min-height: 32px; padding: 4px 8px; border: 0; border-radius: 4px; background: transparent; color: var(--fg); font: inherit; cursor: pointer; }
+.reasoning-examples-playback button:hover { background: var(--surface-3); }
+.reasoning-examples-progress { display: flex; align-items: center; flex: 1; min-width: 100px; max-width: 200px; }
+.reasoning-examples-progress input { width: 100%; accent-color: var(--accent); }
+.reasoning-examples :focus-visible { outline: 2px solid var(--focus, var(--accent)); outline-offset: 3px; }
+.reasoning-examples-conversation { width: min(100% - 48px, 760px); margin: 64px auto; }
+.reasoning-examples-user { width: fit-content; max-width: 88%; margin-left: auto; margin-bottom: 36px; padding: 12px 16px; border-radius: 8px; background: var(--surface-2); font-size: 14px; line-height: 1.7; }
+.reasoning-examples-user p { margin: 0; }
+.reasoning-examples-assistant { display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+.reasoning-examples-tool { padding-block: 4px; color: var(--muted); font-size: 12px; line-height: 1.7; }
+.reasoning-examples-answer { margin: 0; font-size: 15px; line-height: 1.8; }
+.reasoning-examples-stopped { margin: 0; color: var(--muted); font-size: 12px; }
+.reasoning-examples-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+@media (max-width: 600px) { .reasoning-examples-toolbar { padding: 12px 16px; gap: 10px 12px; } .reasoning-examples-conversation { width: calc(100% - 32px); margin-block: 36px; } .reasoning-examples-progress { max-width: none; } }

--- a/artifacts/src/web/components/chat/ReasoningExamples.tsx
+++ b/artifacts/src/web/components/chat/ReasoningExamples.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Button, Field, Label, Select } from '@headlessui/react';
+import type { ReasoningUIPart } from 'ai';
+import { Reasoning } from './Reasoning';
+import './ReasoningExamples.css';
+
+const CASES = [
+  ['summary-titles', 'GPT · 连续摘要标题'], ['summary-description', 'GPT · 标题和说明'], ['long', '开源模型 · 长思考'],
+  ['claude', 'Claude · 分段思考'], ['interrupted', '已停止'], ['empty', '等待首段'], ['unknown', '未知来源 · 混合 Markdown'],
+] as const;
+type CaseId = typeof CASES[number][0];
+type Playback = 'playing' | 'paused' | 'finished';
+type Segment = { kind: 'reasoning'; parts: ReasoningUIPart[] } | { kind: 'tool' | 'answer'; text: string };
+type Frame = { segments: Segment[]; live: boolean };
+type PreviewProps = { initialCase?: string; initialState?: string; initialStep?: number; initialTheme?: string; themeControl?: ReactNode };
+const REQUEST = '帮我检查会话恢复的实现，特别是多轮对话里模型状态有没有正确保留。';
+const ANSWER = '已经核对了会话标识、历史消息和下一轮请求。恢复时会沿用原来的会话；正在生成的一轮完成后，再应用更新的配置。';
+const normalizeCase = (value?: string): CaseId => CASES.find(([id]) => id === value)?.[0] ?? 'summary-titles';
+
+function createFrames(example: CaseId): Frame[] {
+  const frames: Frame[] = [];
+  const segments: Segment[] = [];
+  let current: ReasoningUIPart | undefined;
+  let live = true;
+  const capture = () => frames.push({ live, segments: segments.map(segment => segment.kind === 'reasoning' ? { ...segment, parts: segment.parts.map(part => ({ ...part })) } : { ...segment }) });
+  const begin = (kind: 'summary' | 'full' | 'unknown', id: string) => {
+    if (current) current.state = 'done';
+    current = { type: 'reasoning', id, text: '', state: 'streaming', ...(kind === 'unknown' ? {} : { providerMetadata: { macaron: { reasoningKind: kind } } }) };
+    const last = segments.at(-1);
+    if (last?.kind === 'reasoning') last.parts.push(current);
+    else segments.push({ kind: 'reasoning', parts: [current] });
+    capture();
+  };
+  const write = (text: string) => {
+    // Splitting inside Markdown delimiters exercises the actual incremental rendering path.
+    for (let offset = 0; offset < text.length; offset += 12) { current!.text += text.slice(offset, offset + 12); capture(); }
+  };
+  const hold = (count = 10) => { for (let index = 0; index < count; index++) capture(); };
+  const answer = (stale = false) => { if (current && !stale) current.state = 'done'; live = false; segments.push({ kind: 'answer', text: ANSWER }); capture(); };
+
+  if (example === 'summary-titles') {
+    for (const [index, heading] of ['Checking session restoration flow', 'Tracing the saved conversation', 'Verifying the next turn', 'Confirming the final behavior'].entries()) {
+      begin('summary', `summary-${index}`); write(`**${heading}**`); hold();
+    }
+    answer();
+  } else if (example === 'summary-description') {
+    for (const [index, [heading, description]] of [
+      ['Checking session restoration', 'I am following the saved session identifier through the restore path and checking that the next request uses the same conversation.'],
+      ['Comparing provider behavior', 'The adapters preserve different pieces of state. I am checking the boundaries before deciding which behavior should be shared.'],
+      ['Verifying the final result', 'The restored session keeps its message history, while configuration changes are applied at the start of the next turn.'],
+    ].entries()) { begin('summary', `description-${index}`); write(`**${heading}**\n\n${description}`); hold(); }
+    answer();
+  } else if (example === 'long' || example === 'interrupted') {
+    begin('full', 'full-reasoning');
+    for (let index = 0; index < 8; index++) write(`首先看第 ${index + 1} 个恢复分支。这里需要区分会话中保存的配置与当前这一轮已经拿到的配置快照：前者可以更新，后者应当保持稳定。\n\n接着沿着请求的 sessionId 向下追踪。如果恢复时重新生成了标识，下一轮就可能丢失之前的上下文。需要检查持久化的消息是否仍然按原来的顺序进入适配器，以及工具结果是否与调用记录配对。\n\n`);
+    if (example === 'interrupted') { live = false; capture(); }
+    else answer();
+  } else if (example === 'claude') {
+    begin('full', 'claude-before-tool');
+    write('我先确认会话恢复的入口。需要查看保存的会话标识怎样传入适配器，以及每一轮请求是否重新读取配置。\n\n这一处会影响多轮对话，所以接下来检查恢复路径和对应的测试。');
+    current!.state = 'done'; capture();
+    segments.push({ kind: 'tool', text: '已读取 session.ts 和 adapter.test.ts · 找到 3 个恢复分支' }); capture(); hold();
+    begin('full', 'claude-after-tool');
+    write('恢复路径保留了原来的会话标识。工具返回的测试记录也显示，第二轮沿用了第一轮的上下文。\n\n还需要确认配置更新只影响下一轮，避免生成过程中替换当前的模型或连接参数。');
+    hold(); answer();
+  } else if (example === 'empty') {
+    begin('full', 'waiting-reasoning'); hold(50); answer();
+  } else {
+    begin('unknown', 'imported-reasoning');
+    write('The provider returned a reasoning stream without a presentation hint. This paragraph is part of the original content.\n\n**A heading within the transcript**\n\nA bold line does not mean the rest of the reasoning should disappear. The full stream must remain readable, including the explanation after this heading.\n\n');
+    write('1. Check the saved session identifier.\n2. Keep tool results paired with their calls.\n3. Apply updated settings on the next turn.\n\n`sessionId` should survive reconnects, and **important inline emphasis** should stay within its paragraph.\n\n');
+    write('This is a long unbroken identifier to verify wrapping: session_restore_0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz.');
+    // Persisted streams can retain a stale part state after reload; live=false must win.
+    answer(true);
+  }
+  return frames;
+}
+
+export function ReasoningExamples({ initialCase, initialState, initialStep, initialTheme, themeControl }: PreviewProps) {
+  const [example, setExample] = useState(() => normalizeCase(initialCase));
+  const frames = useMemo(() => createFrames(example), [example]);
+  const [cursor, setCursor] = useState(() => initialState === 'finished' ? frames.length - 1 : Math.max(0, Math.min(Number.isFinite(initialStep) ? Math.floor(initialStep!) : 0, frames.length - 1)));
+  const [playing, setPlaying] = useState(initialState !== 'paused' && initialState !== 'finished');
+  const [theme, setTheme] = useState(initialTheme === 'dark' ? 'dark' : 'light');
+  const frame = frames[Math.min(cursor, frames.length - 1)];
+  const state: Playback = cursor === frames.length - 1 ? 'finished' : playing ? 'playing' : 'paused';
+  useEffect(() => {
+    if (!playing || cursor >= frames.length - 1) return;
+    const timeout = window.setTimeout(() => setCursor(value => Math.min(value + 1, frames.length - 1)), 90);
+    return () => window.clearTimeout(timeout);
+  }, [playing, cursor, frames.length]);
+  useEffect(() => { if (!themeControl) document.documentElement.dataset.theme = theme; }, [theme, themeControl]);
+  const choose = (next: string) => { setExample(normalizeCase(next)); setCursor(0); setPlaying(true); };
+  const replay = () => { setCursor(0); setPlaying(true); };
+  return <main className="reasoning-examples" data-example-case={example} data-example-state={state} data-example-step={cursor} data-example-total={frames.length}>
+    <header className="reasoning-examples-toolbar">
+      <Field className="reasoning-examples-field"><Label>场景</Label><Select value={example} onChange={event => choose(event.target.value)}>{CASES.map(([id, label]) => <option key={id} value={id}>{label}</option>)}</Select></Field>
+      <div className="reasoning-examples-playback"><Button onClick={state === 'finished' ? replay : () => setPlaying(value => !value)}>{state === 'playing' ? '暂停' : '播放'}</Button><Button onClick={replay}>重播</Button></div>
+      <label className="reasoning-examples-progress"><span className="reasoning-examples-sr-only">播放进度</span><input type="range" min={0} max={frames.length - 1} value={cursor} onChange={event => { setCursor(Number(event.target.value)); setPlaying(false); }} /></label>
+      {themeControl ?? <Field className="reasoning-examples-field"><Label>外观</Label><Select value={theme} onChange={event => setTheme(event.target.value)}><option value="light">浅色</option><option value="dark">深色</option></Select></Field>}
+    </header>
+    <div className="reasoning-examples-conversation">
+      <article className="reasoning-examples-user" aria-label="用户消息"><p>{REQUEST}</p></article>
+      <article className="reasoning-examples-assistant" aria-label="助手消息">
+        {frame.segments.map((segment, index) => segment.kind === 'reasoning' ? <Reasoning key={index} parts={segment.parts} live={frame.live} /> : segment.kind === 'tool' ? <div key={index} className="reasoning-examples-tool" data-example-tool>{segment.text}</div> : <p key={index} className="reasoning-examples-answer" data-example-answer>{segment.text}</p>)}
+        {example === 'interrupted' && state === 'finished' ? <p className="reasoning-examples-stopped" data-example-stopped>已停止生成</p> : null}
+      </article>
+    </div>
+  </main>;
+}

--- a/artifacts/src/web/components/chat/reasoning-model.ts
+++ b/artifacts/src/web/components/chat/reasoning-model.ts
@@ -1,0 +1,66 @@
+import type { ReasoningUIPart } from 'ai';
+import { parseMarkdownIntoBlocks } from 'streamdown';
+
+type ReasoningEntry = { key: string; text: string };
+type ReasoningKind = 'summary' | 'full';
+
+export function reasoningRunAt(parts: readonly { type: string }[], index: number): ReasoningUIPart[] | undefined {
+  if (parts[index]?.type !== 'reasoning' || parts[index - 1]?.type === 'reasoning') return undefined;
+  const run: ReasoningUIPart[] = [];
+  for (let current = index; current < parts.length && parts[current].type === 'reasoning'; current++) run.push(parts[current] as ReasoningUIPart);
+  return run;
+}
+
+function declaredKind(part: ReasoningUIPart): ReasoningKind | undefined {
+  const kind = part.providerMetadata?.macaron?.reasoningKind;
+  if (kind === 'summary' || kind === 'full') return kind;
+  const legacy = /:(summary|content):\d+$/.exec(part.id ?? '')?.[1];
+  return legacy === 'summary' ? 'summary' : legacy === 'content' ? 'full' : undefined;
+}
+
+function summaryEntries(part: ReasoningUIPart, partIndex: number, live: boolean) {
+  const entries: ReasoningEntry[] = [];
+  const prefix = part.id ?? `reasoning-${partIndex}`;
+  let text = '';
+  let headingCount = 0;
+  let headingsOnly = true;
+  const flush = () => {
+    if (text.trim()) entries.push({ key: `${prefix}:${entries.length}`, text: text.trim() });
+    text = '';
+  };
+  const blocks = parseMarkdownIntoBlocks(part.text);
+  for (const block of blocks) {
+    // Parse block boundaries first so a code sample cannot become a thinking status.
+    if (/^ {0,3}(?:`{3,}|~{3,})/.test(block) || /^ {4}\S/.test(block)) {
+      headingsOnly = false;
+      text += block;
+      continue;
+    }
+    const lines = block.split(/(?<=\n)/);
+    for (const line of lines) {
+      if (/^ {0,3}(\*\*|__)(?=\S)((?:(?!\1).)+?)\1[\t ]*\r?\n?$/.test(line)) {
+        flush();
+        headingCount++;
+        text = line;
+      } else if (live && (/^ {0,3}(\*\*|__)(?:(?!\1)[^\n])*$/.test(line) || /^ {0,3}[*_]$/.test(line)) && block === blocks.at(-1) && line === lines.at(-1)) {
+        // A streaming heading replaces the previous status only when its closing marker arrives.
+        continue;
+      } else {
+        if (line.trim()) headingsOnly = false;
+        text += line;
+      }
+    }
+  }
+  flush();
+  return { entries, headingCount, headingsOnly };
+}
+
+export function analyzeReasoning(parts: readonly ReasoningUIPart[], live = false): { kind: ReasoningKind; entries: ReasoningEntry[] } {
+  const nonempty = parts.flatMap((part, index) => part.text.trim() ? [{ part, index }] : []);
+  const kinds = nonempty.map(({ part }) => declaredKind(part));
+  const full = { kind: 'full' as const, entries: nonempty.map(({ part, index }) => ({ key: part.id ?? `reasoning-${index}`, text: part.text })) };
+  if (kinds.includes('full')) return full;
+  const summaries = nonempty.map(({ part, index }) => summaryEntries(part, index, live && part.state !== 'done'));
+  const inferredSummary = summaries.every((summary) => summary.headingsOnly) && summaries.reduce((total, summary) => total + summary.headingCount, 0) >= 2;
+  return kinds.includes('summary') || inferredSummary ? { kind: 'summary', entries: summaries.flatMap((result) => result.entries) } : full;
+}

--- a/artifacts/src/web/components/chat/reasoning.test.ts
+++ b/artifacts/src/web/components/chat/reasoning.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import type { ReasoningUIPart } from 'ai';
+import { analyzeReasoning, reasoningRunAt } from './reasoning-model';
+
+const part = (text: string, extra: Partial<ReasoningUIPart> = {}): ReasoningUIPart => ({ type: 'reasoning', text, ...extra });
+const summary = (text: string, extra: Partial<ReasoningUIPart> = {}) => part(text, { providerMetadata: { macaron: { reasoningKind: 'summary' } }, ...extra });
+
+describe('reasoning presentation', () => {
+  test('groups only adjacent parts without erasing their identities or crossing an answer or tool', () => {
+    const first = part('First block', { id: 'first' });
+    const second = part('Second block', { id: 'second' });
+    const third = part('Third block', { id: 'third' });
+    const parts = [first, second, { type: 'tool-read' }, third, { type: 'text' }, part('Fourth block')];
+    expect(reasoningRunAt(parts, 0)).toEqual([first, second]);
+    expect(reasoningRunAt(parts, 0)?.[0]).toBe(first);
+    expect(reasoningRunAt(parts, 1)).toBeUndefined();
+    expect(reasoningRunAt(parts, 2)).toBeUndefined();
+    expect(reasoningRunAt(parts, 3)).toEqual([third]);
+    expect(reasoningRunAt(parts, 5)).toHaveLength(1);
+  });
+
+  test('keeps raw full reasoning and separate provider blocks intact', () => {
+    const texts = ['  Inspect the constraints.\n\nThen compare both paths.  ', 'A separate block after an unseen reasoning gap.'];
+    const result = analyzeReasoning(texts.map((text, index) => part(text, { id: `block-${index}` })));
+    expect(result.kind).toBe('full');
+    expect(result.entries.map((entry) => entry.text)).toEqual(texts);
+    expect(result.entries.map((entry) => entry.key)).toEqual(['block-0', 'block-1']);
+  });
+
+  test('keeps descriptions with their summary heading and retains history across parts', () => {
+    const result = analyzeReasoning([
+      summary('**Inspecting the existing code**\n\nRead both implementations before changing the presentation.\n\n**Comparing the rendering paths**\n\nCheck which events preserve the summary.', { id: 'one' }),
+      summary('**Preparing the final patch**', { id: 'two' }),
+    ]);
+    expect(result.kind).toBe('summary');
+    expect(result.entries.map((entry) => entry.text)).toEqual([
+      '**Inspecting the existing code**\n\nRead both implementations before changing the presentation.',
+      '**Comparing the rendering paths**\n\nCheck which events preserve the summary.',
+      '**Preparing the final patch**',
+    ]);
+    expect(new Set(result.entries.map((entry) => entry.key)).size).toBe(3);
+  });
+
+  test('does not replace the previous summary while the next heading is incomplete', () => {
+    const previous = '**Inspecting the source**\n\nThe implementation is under review.';
+    const next = '**Comparing the rendering paths**';
+    const stable = analyzeReasoning([summary(previous)]).entries.at(-1);
+    for (let length = 1; length < next.length; length++) {
+      expect(analyzeReasoning([summary(`${previous}\n\n${next.slice(0, length)}`)], true).entries.at(-1)).toEqual(stable);
+    }
+    expect(analyzeReasoning([summary(`${previous}\n\n${next}`)]).entries.at(-1)?.text).toBe(next);
+  });
+
+  test('keeps inferred summary compact during a new heading but preserves interrupted text', () => {
+    const complete = '**Inspecting the source**\n\n**Comparing the rendering paths**';
+    const next = '**Preparing the final patch**';
+    for (let length = 1; length < next.length; length++) {
+      const result = analyzeReasoning([part(`${complete}\n\n${next.slice(0, length)}`)], true);
+      expect(result.kind).toBe('summary');
+      expect(result.entries.at(-1)?.text).toBe('**Comparing the rendering paths**');
+      const separate = analyzeReasoning([part(complete), part(next.slice(0, length), { state: 'streaming' })], true);
+      expect(separate.kind).toBe('summary');
+      expect(separate.entries.at(-1)?.text).toBe('**Comparing the rendering paths**');
+    }
+    const interrupted = `${complete}\n\n**Preparing the`;
+    expect(analyzeReasoning([part(interrupted)]).entries[0].text).toBe(interrupted);
+    expect(analyzeReasoning([summary(interrupted)]).entries.at(-1)?.text).toContain('**Preparing the');
+    expect(analyzeReasoning([summary(interrupted, { state: 'done' })], true).entries.at(-1)?.text).toContain('**Preparing the');
+  });
+
+  test('infers summary only from multiple standalone headings and respects explicit full metadata', () => {
+    expect(analyzeReasoning([part('**One heading**')]).kind).toBe('full');
+    expect(analyzeReasoning([part('**One heading**\n**Another heading**')]).kind).toBe('summary');
+    expect(analyzeReasoning([part('**One heading**'), part('**Another heading**')]).kind).toBe('summary');
+    expect(analyzeReasoning([part('**One heading**\n\nSome explanation.\n\n**Another heading**')]).kind).toBe('full');
+    expect(analyzeReasoning([part('**One heading** and **some prose**\n\n**Another heading**')]).kind).toBe('full');
+    expect(analyzeReasoning([part('**One heading**\n\n**Another heading**', { providerMetadata: { macaron: { reasoningKind: 'full' } } })]).kind).toBe('full');
+  });
+
+  test('honors known legacy IDs and lets explicit metadata override them', () => {
+    expect(analyzeReasoning([part('A plain summary.', { id: 'turn:item:summary:0' })]).kind).toBe('summary');
+    expect(analyzeReasoning([part('**One heading**\n\n**Another heading**', { id: 'turn:item:content:0' })]).kind).toBe('full');
+    expect(analyzeReasoning([summary('A plain summary.', { id: 'turn:item:content:0' })]).kind).toBe('summary');
+  });
+
+  test('does not interpret headings in fenced code as new status entries', () => {
+    const text = '**Inspecting the example**\n\n```markdown\n**This is example code**\n```\n\n**Checking the result**';
+    const result = analyzeReasoning([summary(text)]);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0].text).toContain('```markdown\n**This is example code**\n```');
+    expect(analyzeReasoning([part('```markdown\n**One heading**\n**Another heading**\n```')]).kind).toBe('full');
+  });
+
+  test('ignores empty completed blocks without hiding earlier content', () => {
+    const result = analyzeReasoning([summary('**Inspecting the source**'), summary('', { state: 'done' }), part(' \n ', { state: 'done' })]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].text).toBe('**Inspecting the source**');
+    expect(analyzeReasoning([part('', { state: 'done' })])).toEqual({ kind: 'full', entries: [] });
+  });
+});

--- a/artifacts/src/web/components/chat/useReasoningScroll.ts
+++ b/artifacts/src/web/components/chat/useReasoningScroll.ts
@@ -1,0 +1,85 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const EDGE_RAMP = 24;
+const BOTTOM_TOLERANCE = 2;
+
+export function useReasoningScroll(contentKey: string, live: boolean) {
+  const viewport = useRef<HTMLDivElement>(null);
+  const content = useRef<HTMLDivElement>(null);
+  const [following, setFollowing] = useState(true);
+  const [overflowing, setOverflowing] = useState(false);
+  const followingRef = useRef(true);
+  const liveRef = useRef(live);
+  const forcePin = useRef(false);
+  const schedule = useRef(() => {});
+
+  const resume = useCallback(() => {
+    followingRef.current = true;
+    forcePin.current = true;
+    schedule.current();
+  }, []);
+
+  useEffect(() => {
+    const element = viewport.current;
+    const inner = content.current;
+    if (!element || !inner) return;
+    let frame = 0;
+    let lastTop = element.scrollTop;
+    let lastHeight = element.scrollHeight;
+    const measure = () => {
+      frame = 0;
+      const gap = Math.max(0, element.scrollHeight - element.clientHeight);
+      if (forcePin.current || (liveRef.current && followingRef.current)) element.scrollTop = gap;
+      forcePin.current = false;
+      const top = Math.max(0, element.scrollTop);
+      const bottom = Math.max(0, gap - top);
+      if (bottom <= BOTTOM_TOLERANCE) followingRef.current = true;
+      else if (!liveRef.current) followingRef.current = false;
+      lastTop = top;
+      lastHeight = element.scrollHeight;
+      element.style.setProperty('--reasoning-fade-top', String(Math.min(1, top / EDGE_RAMP)));
+      element.style.setProperty('--reasoning-fade-bottom', String(Math.min(1, bottom / EDGE_RAMP)));
+      setFollowing((previous) => previous === followingRef.current ? previous : followingRef.current);
+      setOverflowing((previous) => previous === (gap > BOTTOM_TOLERANCE) ? previous : gap > BOTTOM_TOLERANCE);
+    };
+    const requestMeasure = () => {
+      if (!frame) frame = requestAnimationFrame(measure);
+    };
+    schedule.current = requestMeasure;
+    const onScroll = () => {
+      const top = element.scrollTop;
+      const shrank = element.scrollHeight < lastHeight;
+      if (!shrank && top < lastTop - 0.5) followingRef.current = false;
+      if (element.scrollHeight - element.clientHeight - top <= BOTTOM_TOLERANCE) followingRef.current = true;
+      lastTop = top;
+      lastHeight = element.scrollHeight;
+      requestMeasure();
+    };
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) followingRef.current = false;
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home' || (event.key === ' ' && event.shiftKey)) followingRef.current = false;
+    };
+    const observer = new ResizeObserver(requestMeasure);
+    observer.observe(element);
+    observer.observe(inner);
+    element.addEventListener('scroll', onScroll, { passive: true });
+    element.addEventListener('wheel', onWheel, { passive: true });
+    element.addEventListener('keydown', onKeyDown);
+    requestMeasure();
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+      schedule.current = () => {};
+      element.removeEventListener('scroll', onScroll);
+      element.removeEventListener('wheel', onWheel);
+      element.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  // Content/viewport resize handles new tokens; only the committed live state belongs in this effect.
+  useEffect(() => { liveRef.current = live; if (contentKey) schedule.current(); }, [contentKey, live]);
+  return { viewport, content, following, overflowing, resume };
+}

--- a/artifacts/src/web/reasoning-preview.tsx
+++ b/artifacts/src/web/reasoning-preview.tsx
@@ -1,0 +1,18 @@
+import { StrictMode, useCallback, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Field, Label, Select } from '@headlessui/react';
+import { ReasoningExamples } from './components/chat/ReasoningExamples';
+import { ThemeProvider, useTheme } from './theme/ThemeProvider';
+import { THEME_OPTIONS, type ThemeId } from './theme/themes';
+import 'virtual:uno.css';
+import './styles.css';
+
+const query = new URLSearchParams(location.search);
+function ThemeControl() {
+  const { appearance, select, setMode } = useTheme();
+  const change = useCallback((id: ThemeId) => { const dark = THEME_OPTIONS.find(theme => theme.id === id)?.type === 'dark'; const slot = dark ? 'dark' : 'light'; select(slot, id); setMode(slot); }, [select, setMode]);
+  useEffect(() => { const id = query.get('theme'); if (THEME_OPTIONS.some(theme => theme.id === id)) change(id as ThemeId); }, [change]);
+  return <Field className="reasoning-examples-field"><Label>主题</Label><Select value={appearance.id} onChange={event => change(event.target.value as ThemeId)}>{THEME_OPTIONS.map(theme => <option key={theme.id} value={theme.id}>{theme.label}</option>)}</Select></Field>;
+}
+
+createRoot(document.getElementById('root')!).render(<StrictMode><ThemeProvider><ReasoningExamples initialCase={query.get('case') ?? undefined} initialState={query.get('state') ?? undefined} initialStep={Number(query.get('step') ?? 0)} themeControl={<ThemeControl />} /></ThemeProvider></StrictMode>);

--- a/site/content/docs/architecture/web.mdx
+++ b/site/content/docs/architecture/web.mdx
@@ -19,6 +19,8 @@ Host controls use native HTML plus Headless UI where behavior is stateful: dialo
 
 The layout preserves background turns when the selected conversation changes. Mobile viewports collapse Canvas into a drawer, and the split separator exposes its current value to assistive technology. Focus indicators come from the theme's focus token rather than from repeated container borders.
 
+Reasoning is visible by default. Summary updates show the latest entry while keeping earlier entries available; full reasoning uses a height-limited scrolling region with fading edges. Scrolling up pauses automatic following. The UI preserves independent AI SDK reasoning parts and their tool/text boundaries instead of joining them into one monologue. Streaming motion and automatic following stop when the turn ends or is interrupted.
+
 ## Themes
 
 The picker stores a paired light/dark family. Appearance (`auto`, light, or dark) remains independent from family selection, and only the variant matching the current appearance is loaded. Theme roles include editor, sidebar, title bar, menu, widget, input, dropdown, selection, focus, and optional borders; missing roles fall back to composited semantic values instead of painting every surface with a border.


### PR DESCRIPTION
Reasoning was rendered as a collapsed `<details>` block, which hid live output and treated provider-specific streams alike. This change adds one shared adaptive renderer to Artifacts and the matching local UI4A Playground implementation.

- Shows reasoning by default with separate summary and full-thinking presentations.
- Replaces the visible GPT-style summary with the latest complete heading while preserving history for inline review.
- Keeps long reasoning bounded with internal scrolling, edge fades, pause-on-user-scroll, and an explicit resume action.
- Preserves Claude/tool boundaries, empty and interrupted states, `ReasoningUIPart` ids/state/provider metadata, and historical raw text.
- Adds Codex summary/full metadata and closes Hermes reasoning at tool/text boundaries so later thinking starts a new part.
- Adds deterministic preview routes with seven scenarios and synchronized screenshots for both projects.

Validation: Artifacts 332 tests passed with 2 environment-dependent OpenCode tests skipped, typecheck and production build passed. Playground 137 tests passed, oxlint/typecheck/build passed. 30 cross-project browser scenarios passed, including light/dark, mobile, summary replacement, history, interrupted output, keyboard scrolling, reduced motion, continuous fade, and axe checks with zero violations.