### PR TITLE
add HTML snapshots for inline cards and Canvas

### DIFF
--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -30,6 +30,10 @@ App conversations live in `~/.macaron-artifacts/sessions`; `MACARON_DATA_DIR` ov
 
 For a custom Claude gateway, start the app with the same `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY` environment as the CLI. Environment injected only by a shell alias is not inherited by a separately launched app.
 
+## HTML snapshots
+
+Use the export arrow beside **Source** on an inline card or in the Canvas header to download or copy an HTML snapshot after the preview finishes. Canvas downloads use the artifact name. Snapshots preserve the rendered content, current form values, readable canvas images, and active theme. They are static: React handlers, chat/file capabilities, scripts, and embedded frames are not included. External images, fonts, and styles may still require network access. Switch back to preview before exporting from source view.
+
 ## Boundaries
 
 | Module | Responsibility |

--- a/artifacts/src/web/components/ArtifactPanel.tsx
+++ b/artifacts/src/web/components/ArtifactPanel.tsx
@@ -1,20 +1,23 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useRef, useState } from 'react';
 import type { Artifact, SessionSummary } from '../../shared/types';
 import { CodeBlock } from './code/CodeBlock';
 import { Icon } from './Icon';
 import { Select } from './Select';
+import { ExportMenu } from './ExportMenu';
 
 const Ui4aSurface = lazy(() => import('../ui4a/Ui4aSurface').then(module => ({ default: module.Ui4aSurface })));
 const artifactName = (path: string) => path.split('/').at(-1)?.replace(/\.ui4a\.tsx$/, '').replace(/\.tsx$/, '') ?? path;
 
 export function ArtifactPanel({ session, artifacts, selected, onSelect, onClose, onSend }: { session: SessionSummary; artifacts: Artifact[]; selected?: string; onSelect: (path: string) => void; onClose: () => void; onSend: (text: string) => void }) {
   const [source, setSource] = useState(false);
+  const target = useRef<HTMLDivElement>(null);
   const artifact = artifacts.find(item => item.path === selected);
   return <section className="theme-panel @container flex h-full min-w-0 flex-col" aria-label="Canvas"><header className="flex h-12 shrink-0 items-center gap-2 px-3">
     {artifacts.length > 1 ? <div className="min-w-0 flex-1"><Select label="选择 Canvas" value={selected ?? artifacts[0].path} options={artifacts.map(item => ({ value: item.path, label: artifactName(item.path) }))} onChange={onSelect} /></div> : <span className="min-w-0 flex-1 truncate text-sm font-medium">{artifact ? artifactName(artifact.path) : 'Canvas'}</span>}
     {artifact ? <button type="button" onClick={() => setSource(value => !value)} className="interactive shrink-0 rounded-md px-2 py-1 text-xs text-muted hover:bg-surface-3 hover:text-hover-fg">{source ? '预览' : '源码'}</button> : null}
+    {artifact ? <ExportMenu key={artifact.path} target={target} filename={artifactName(artifact.path)} disabled={artifact.streaming || source} /> : null}
     <button type="button" onClick={onClose} title="关闭 Canvas" aria-label="关闭 Canvas" className="interactive grid size-7 shrink-0 place-items-center rounded-md text-muted hover:bg-surface-3 hover:text-hover-fg"><Icon name="x" className="size-3.5" /></button>
-  </header><div className="min-h-0 flex-1 overflow-y-auto">
+  </header><div ref={target} className="min-h-0 flex-1 overflow-y-auto">
     {artifact ? source ? <CodeBlock code={artifact.source} /> : <Suspense fallback={<CodeBlock code={artifact.source} />}><Ui4aSurface key={`${session.id}:${artifact.path}`} source={artifact.source} streaming={artifact.streaming} scope={`${session.id}:canvas:${artifact.path}`} sessionId={session.id} filename={artifact.path} revision={artifact.streaming ? undefined : artifact.revision} onSend={onSend} /></Suspense> : artifacts.length ? <ul className="flex flex-col gap-1 p-3">{artifacts.map(item => <li key={item.path}><button type="button" onClick={() => onSelect(item.path)} className="interactive w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-surface-3 hover:text-hover-fg">{artifactName(item.path)}</button></li>)}</ul> : <p className="p-6 text-center text-xs leading-relaxed text-muted">还没有 Canvas。让模型在 <code className="rounded bg-inline-code px-1 text-inline-code-fg">.artifacts/</code> 中创建一个界面。</p>}
   </div></section>;
 }

--- a/artifacts/src/web/components/ExportMenu.tsx
+++ b/artifacts/src/web/components/ExportMenu.tsx
@@ -1,0 +1,31 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { useEffect, useState, type RefObject } from 'react';
+import { Icon } from './Icon';
+import { downloadHtml, snapshotHtml } from '../ui4a/export';
+
+export function ExportMenu({ target, filename = 'macaron-card', disabled = false }: { target: RefObject<HTMLElement | null>; filename?: string; disabled?: boolean }) {
+  const [busy, setBusy] = useState(false), [feedback, setFeedback] = useState<{ text: string; error?: boolean }>();
+  useEffect(() => { if (!feedback || feedback.error) return; const timer = setTimeout(() => setFeedback(undefined), 2000); return () => clearTimeout(timer); }, [feedback]);
+  const run = async (copy: boolean) => {
+    setBusy(true); setFeedback(undefined);
+    try {
+      const surface = target.current?.querySelector<HTMLElement>('[data-ui4a-ready="true"]');
+      if (!surface || disabled) throw new Error('预览尚未就绪，请稍后重试');
+      const html = snapshotHtml(surface, filename);
+      if (copy) { if (!navigator.clipboard) throw new Error('浏览器不支持复制，请下载 HTML'); await navigator.clipboard.writeText(html); }
+      else downloadHtml(html, filename);
+      setFeedback({ text: copy ? '已复制 HTML' : '已下载 HTML' });
+    } catch (error) { setFeedback({ text: error instanceof Error ? error.message : '导出失败，请重试', error: true }); }
+    finally { setBusy(false); }
+  };
+  return <div className="relative shrink-0">
+    <Menu>
+      <MenuButton type="button" title={disabled ? '预览完成后可导出' : '导出 HTML 快照'} aria-label="导出 HTML 快照" disabled={disabled || busy} onClick={() => setFeedback(undefined)} className="interactive grid size-9 place-items-center rounded-md text-muted hover:bg-surface-3 hover:text-hover-fg data-[open]:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-40"><Icon name={busy ? 'ellipsis' : 'arrowDown'} /></MenuButton>
+      <MenuItems anchor={{ to: 'bottom end', gap: 6, padding: 8 }} className="theme-menu z-50 w-44 max-w-[calc(100vw-16px)] rounded-lg p-1 outline-none">
+        <MenuItem><button type="button" onClick={() => void run(false)} className="interactive flex min-h-10 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg"><Icon name="arrowDown" />下载 HTML 快照</button></MenuItem>
+        <MenuItem><button type="button" onClick={() => void run(true)} className="interactive block min-h-10 w-full rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg">复制 HTML 快照</button></MenuItem>
+      </MenuItems>
+    </Menu>
+    {feedback ? <div role={feedback.error ? 'alert' : 'status'} className={`theme-widget absolute top-full right-0 z-20 mt-1 w-52 max-w-[calc(100vw-24px)] rounded-md p-2 text-xs break-words ${feedback.error ? 'text-danger' : 'text-fg'}`}><div className="flex items-start gap-1"><span className="min-w-0 flex-1">{feedback.text}</span><button type="button" onClick={() => setFeedback(undefined)} aria-label="关闭导出提示" className="grid size-6 shrink-0 place-items-center rounded hover:bg-surface-3"><Icon name="x" className="size-3" /></button></div></div> : null}
+  </div>;
+}

--- a/artifacts/src/web/components/chat/MessageBody.tsx
+++ b/artifacts/src/web/components/chat/MessageBody.tsx
@@ -1,9 +1,10 @@
-import { lazy, memo, Suspense, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { lazy, memo, Suspense, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { Streamdown } from 'streamdown';
 import { cjk } from '@streamdown/cjk';
 import { CodeBlock } from '../code/CodeBlock';
 import { Collapsible } from '../code/Collapsible';
 import { parseSegments } from './segments';
+import { ExportMenu } from '../ExportMenu';
 
 const Ui4aSurface = lazy(() => import('../../ui4a/Ui4aSurface').then(module => ({ default: module.Ui4aSurface })));
 const PLUGINS = { cjk };
@@ -21,6 +22,7 @@ export const MessageBody = memo(function MessageBody({ text, messageId, streamin
 
 function InlineUi4a({ source, ...props }: { source: string; streaming: boolean; scope: string; sessionId: string; onSend: (text: string) => void }) {
   const [showSource, setShowSource] = useState(false);
+  const target = useRef<HTMLDivElement>(null);
   const fallback = <div className="theme-code overflow-clip rounded-xl"><Collapsible><CodeBlock code={source} /></Collapsible></div>;
-  return <div className="group relative"><button type="button" onClick={() => setShowSource(value => !value)} className="theme-widget interactive absolute top-2 right-2 z-10 rounded-lg px-2 py-1 text-xs text-muted opacity-0 group-hover:opacity-100 hover:text-fg focus-visible:opacity-100">{showSource ? '预览' : '源码'}</button>{showSource ? fallback : <Suspense fallback={fallback}><Ui4aSurface source={source} {...props} /></Suspense>}</div>;
+  return <div><div className="flex h-10 items-center justify-end gap-1"><button type="button" onClick={() => setShowSource(value => !value)} aria-pressed={showSource} className="interactive h-9 rounded-md px-2 text-xs text-muted hover:bg-surface-3 hover:text-hover-fg">{showSource ? '预览' : '源码'}</button><ExportMenu target={target} disabled={props.streaming || showSource} /></div><div ref={target}>{showSource ? fallback : <Suspense fallback={fallback}><Ui4aSurface source={source} {...props} /></Suspense>}</div></div>;
 }

--- a/artifacts/src/web/ui4a/Ui4aSurface.tsx
+++ b/artifacts/src/web/ui4a/Ui4aSurface.tsx
@@ -83,7 +83,7 @@ export function Ui4aSurface({ source, streaming, scope, sessionId, filename, rev
     };
   }, [sessionId, scope, filename]);
 
-  return <div className={UI4A_CLASS} data-ui4a-scope={scope} data-ui4a-streaming={streaming ? "true" : "false"} style={{ containerType: "inline-size", minWidth: 0 }}>
+  return <div className={UI4A_CLASS} data-ui4a-ready={painted && !streaming && !error ? "true" : "false"} data-ui4a-scope={scope} data-ui4a-streaming={streaming ? "true" : "false"} style={{ containerType: "inline-size", minWidth: 0 }}>
     <div ref={host} data-ui4a-render-host="" />
     {!painted && source ? <CodeBlock code={source} /> : null}
     {error ? <div role="alert" className="mt-2 rounded border border-danger/30 p-3 text-sm text-danger">{error}</div> : null}

--- a/artifacts/src/web/ui4a/export.ts
+++ b/artifacts/src/web/ui4a/export.ts
@@ -1,0 +1,70 @@
+/** Capture the visible result, never the generated module or its privileged host bridges. */
+export function snapshotHtml(surface: HTMLElement, title: string): string {
+  const sourceDocument = surface.ownerDocument;
+  const output = sourceDocument.implementation.createHTMLDocument(title);
+  const root = sourceDocument.documentElement;
+  for (const name of ['lang', 'dir', 'data-theme', 'style']) { const value = root.getAttribute(name); if (value !== null) output.documentElement.setAttribute(name, value); }
+  const charset = output.createElement('meta'); charset.setAttribute('charset', 'utf-8'); output.head.prepend(charset);
+  const viewport = output.createElement('meta'); viewport.name = 'viewport'; viewport.content = 'width=device-width, initial-scale=1'; output.head.append(viewport);
+  const policy = output.createElement('meta'); policy.httpEquiv = 'Content-Security-Policy'; policy.content = "script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"; output.head.append(policy);
+  for (const sheet of sourceDocument.styleSheets) {
+    if (sheet.disabled) continue;
+    const style = output.createElement('style');
+    try { style.textContent = [...sheet.cssRules].map(rule => rule.cssText).join('\n').replace(/</g, '\\3c '); }
+    catch {
+      if (!sheet.href) throw new Error('部分样式无法读取，暂时无法导出完整 HTML');
+      const link = output.createElement('link'); link.rel = 'stylesheet'; link.href = sheet.href; link.media = sheet.media.mediaText; output.head.append(link); continue;
+    }
+    style.media = sheet.media.mediaText; output.head.append(style);
+  }
+  // App chrome locks body scrolling; exported documents need their own scrollable viewport.
+  const layout = output.createElement('style'); layout.textContent = 'html,body{height:auto;min-height:100%;overflow:auto}body{margin:0}.ui4a-surface{min-height:100vh}'; output.head.append(layout);
+  const clone = surface.cloneNode(true) as HTMLElement;
+  // Canvas inherits a panel palette that is different from the document palette.
+  const computed = sourceDocument.defaultView!.getComputedStyle(surface);
+  for (const name of computed) if (name.startsWith('--') || ['color', 'font-family', 'font-size', 'line-height', 'color-scheme'].includes(name)) clone.style.setProperty(name, computed.getPropertyValue(name));
+  const originals = [surface, ...surface.querySelectorAll('*')], copies = [clone, ...clone.querySelectorAll('*')];
+  for (let index = 0; index < originals.length; index++) {
+    const original = originals[index]!, copy = copies[index]!;
+    if (original instanceof HTMLInputElement) {
+      if (original.type === 'password' || original.type === 'file') copy.removeAttribute('value');
+      else copy.setAttribute('value', original.value);
+      copy.toggleAttribute('checked', original.checked);
+    }
+    if (original instanceof HTMLTextAreaElement) copy.textContent = original.value;
+    if (original instanceof HTMLOptionElement) copy.toggleAttribute('selected', original.selected);
+    if (original instanceof HTMLCanvasElement) {
+      const image = output.createElement('img');
+      for (const attribute of copy.attributes) image.setAttribute(attribute.name, attribute.value);
+      try { image.src = original.toDataURL(); } catch { throw new Error('画布包含无法读取的图片，请等待图片加载或检查跨域权限'); }
+      image.width = original.width; image.height = original.height; copy.replaceWith(image);
+    }
+    if (original instanceof HTMLImageElement) {
+      copy.removeAttribute('srcset'); copy.removeAttribute('sizes');
+      const src = original.currentSrc || original.src;
+      if (src.startsWith('blob:')) {
+        if (!original.complete || !original.naturalWidth) throw new Error('图片尚未加载完成，请稍后重试');
+        const canvas = sourceDocument.createElement('canvas'); canvas.width = original.naturalWidth; canvas.height = original.naturalHeight;
+        try { canvas.getContext('2d')!.drawImage(original, 0, 0); copy.setAttribute('src', canvas.toDataURL()); } catch { throw new Error('无法读取图片，请检查图片的跨域权限'); }
+      } else copy.setAttribute('src', src);
+    }
+    if (original instanceof HTMLAnchorElement && original.getAttribute('href') && !original.getAttribute('href')!.startsWith('#')) copy.setAttribute('href', original.href);
+    if (original instanceof HTMLMediaElement || original instanceof HTMLSourceElement) {
+      if (original.src.startsWith('blob:')) throw new Error('临时音视频无法导出，请先使用可访问的媒体链接');
+      if (original.getAttribute('src')) copy.setAttribute('src', original.src);
+    }
+    if (original instanceof HTMLVideoElement && original.poster) copy.setAttribute('poster', original.poster);
+    for (const attribute of [...copy.attributes]) if (/^on/i.test(attribute.name) || ['data-ui4a-scope', 'data-ui4a-streaming', 'data-ui4a-ready'].includes(attribute.name)) copy.removeAttribute(attribute.name);
+  }
+  // The selected picture is already captured in img.currentSrc; old source sets can override it when reopened.
+  clone.querySelectorAll('script, iframe, object, embed, picture source, [data-export-control]').forEach(node => node.remove());
+  output.body.append(clone);
+  return `<!doctype html>\n${output.documentElement.outerHTML}`;
+}
+
+export function downloadHtml(html: string, filename: string) {
+  const url = URL.createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }));
+  const anchor = document.createElement('a'); anchor.href = url; anchor.download = `${filename.replace(/[<>:"/\\|?*\u0000-\u001f]/g, '-').replace(/\.+$/, '').slice(0, 120) || 'macaron-card'}.html`;
+  document.body.append(anchor);
+  try { anchor.click(); } finally { anchor.remove(); setTimeout(() => URL.revokeObjectURL(url), 1000); }
+}


### PR DESCRIPTION
Inline cards and Canvas previews now expose a shared Headless UI export menu beside the source toggle. Download or copy the rendered HTML, including current form values, readable canvas images, and the active theme; Canvas downloads use the artifact name.

The toolbar stays outside generated content, supports keyboard navigation, and reports copy/download errors. Streaming and source views disable export.

> [!NOTE]
> These are static snapshots. React interactions, chat/file capabilities, scripts, and embedded frames are not exported. External media, fonts, and styles may still need network access.

Validation: `pnpm --dir artifacts typecheck`, `pnpm --dir artifacts test` (332 passed, 2 skipped), and `pnpm --dir artifacts build`. Chromium smoke covered both menus at desktop and 390px mobile widths, keyboard copy, real downloads reopened through `file://`, form values, canvas pixels, theme preservation, scrolling, and source-view gating.

Reviewed in two `m clhh` passes and refined using an `m km` UI review.