### PR TITLE
export conversations as themed HTML

### DIFF
--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -34,6 +34,8 @@ For a custom Claude gateway, start the app with the same `ANTHROPIC_BASE_URL` an
 
 Use the export arrow beside **Source** on an inline card or in the Canvas header to download or copy an HTML snapshot after the preview finishes. Canvas downloads use the artifact name. Snapshots preserve the rendered content, current form values, readable canvas images, and active theme. They are static: React handlers, chat/file capabilities, scripts, and embedded frames are not included. External images, fonts, and styles may still require network access. Switch back to preview before exporting from source view.
 
+The conversation title bar also exports the whole chat after the current turn finishes. Its HTML contains only the message column in the current theme, including links, highlighted code, tool calls, and complete reasoning history. Tool details, long outputs, and earlier summaries can still expand and collapse without the app server. The sidebar, composer, suggestions, and approval actions are omitted; inline cards remain static snapshots. A small embedded script handles transcript controls only.
+
 ## Boundaries
 
 | Module | Responsibility |

--- a/artifacts/src/web/App.tsx
+++ b/artifacts/src/web/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { HarnessId } from '../shared/types';
 import { useWorkspace } from './chat/WorkspaceProvider';
 import { useTheme } from './theme/ThemeProvider';
@@ -14,6 +14,7 @@ import { AppearanceDialog } from './components/ThemePicker';
 import { ProfileManager } from './components/profiles/ProfileManager';
 import { SessionProfileDialog } from './components/profiles/SessionProfile';
 import { useProfiles } from './components/profiles/ProfileProvider';
+import { ExportMenu } from './components/ExportMenu';
 
 export default function App() {
   const { state, actions } = useWorkspace();
@@ -25,6 +26,7 @@ export default function App() {
   const [newSession, setNewSession] = useState<{ harness?: HarnessId } | null>(null);
   const [emptyCanvasOpen, setEmptyCanvasOpen] = useState(false);
   const split = useSplit();
+  const chatTarget = useRef<HTMLDivElement>(null);
   const session = actions.active();
   const chat = session ? actions.chat(session.id) : undefined;
   const settingsSession = state.sessions.find(item => item.id === sessionSettings);
@@ -46,14 +48,15 @@ export default function App() {
 
   return <main className="@container/shell flex h-dvh flex-col overflow-x-clip">
     <header className="theme-titlebar flex h-12 shrink-0 items-center gap-2 border-b border-border px-3"><button type="button" onClick={() => setSidebarOpen(true)} title="会话" aria-label="打开会话列表" className="interactive grid size-8 shrink-0 place-items-center rounded-lg text-muted hover:bg-surface-3 hover:text-hover-fg @[960px]/shell:hidden"><Icon name="menu" /></button><span className="min-w-0 flex-1 truncate text-sm font-medium">{session?.title ?? 'Macaron Artifacts'}</span>
-      {state.harnesses.length ? <div className="ml-auto w-28 shrink-0 @md:w-36"><Select label="选择 Harness" value={session?.harness ?? state.harnesses.find(item => item.available)?.id ?? state.harnesses[0].id} options={state.harnesses.map(item => ({ value: item.id, label: item.name, disabled: !item.available }))} onChange={harness => setNewSession({ harness })} /></div> : null}
+      {state.harnesses.length ? <div className="ml-auto hidden w-28 shrink-0 @md/shell:block @md:w-36"><Select label="选择 Harness" value={session?.harness ?? state.harnesses.find(item => item.available)?.id ?? state.harnesses[0].id} options={state.harnesses.map(item => ({ value: item.id, label: item.name, disabled: !item.available }))} onChange={harness => setNewSession({ harness })} /></div> : null}
       {session ? <button type="button" title="会话配置" aria-label="会话配置" aria-haspopup="dialog" onClick={() => setSessionSettings(session.id)} className="interactive flex size-8 shrink-0 items-center justify-center gap-2 rounded-lg text-sm text-muted hover:bg-surface-3 hover:text-hover-fg @xl:w-auto @xl:max-w-48 @xl:px-3"><Icon name="sliders" /><span className="hidden truncate @xl:block">{activeProfile?.name ?? session.model ?? '会话配置'}</span></button> : null}
+      {session && chat ? <ExportMenu key={session.id} target={chatTarget} filename={session.title} kind="chat" disabled={session.status === 'running' || !chat.messages.length} /> : null}
       <button type="button" onClick={() => setAppearanceOpen(true)} title="外观设置" aria-label="外观设置" aria-haspopup="dialog" className="interactive grid size-8 shrink-0 place-items-center rounded-lg text-muted hover:bg-surface-3 hover:text-hover-fg"><Icon name={preferences.mode === 'system' ? 'monitor' : appearance.dark ? 'moon' : 'sun'} /></button><button type="button" onClick={toggleCanvas} aria-pressed={canvasOpen} className={`interactive shrink-0 rounded-lg px-2 py-1 text-xs ${canvasOpen ? 'bg-surface-3 text-hover-fg' : 'text-muted hover:bg-surface-3 hover:text-hover-fg'}`}>Canvas</button>
     </header>
     {state.error || themeError ? <div role="alert" className="flex items-center gap-3 border-b border-danger/30 px-4 py-2 text-xs text-danger"><span className="min-w-0 flex-1 break-words">{state.error ?? themeError}</span><button type="button" onClick={actions.clearError} aria-label="关闭错误提示" className="grid size-7 place-items-center"><Icon name="x" /></button></div> : null}
     <div className="flex min-h-0 flex-1"><Sidebar {...sidebar} /><SidebarDrawer {...sidebar} open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       <div ref={split.container} className="@container/panes flex min-h-0 min-w-0 flex-1" style={{ ['--canvas-w' as string]: `${(split.fraction * 100).toFixed(2)}%` }}>
-        <div className={`min-w-0 flex-1 ${canvasOpen ? 'hidden @[681px]/panes:flex' : 'flex'}`}>
+        <div ref={chatTarget} className={`min-w-0 flex-1 ${canvasOpen ? 'hidden @[681px]/panes:flex' : 'flex'}`}>
           {session && chat ? <Conversation key={session.id} instance={chat} session={session} store={actions} /> : <div className="flex flex-1 items-center justify-center p-6"><div className="max-w-sm text-center">{!state.ready || state.loading ? <p className="text-sm text-muted" role="status">正在载入会话…</p> : <><p className="mb-4 text-sm text-muted">在同一个工作区里，用熟悉的 harness 构建界面。</p><Button onClick={create} disabled={!state.harnesses.some(item => item.available)}>新会话</Button>{state.harnesses.length && !state.harnesses.some(item => item.available) ? <p className="mt-3 text-xs text-danger">尚未检测到可用的 harness。请检查 CLI 安装或 pi SDK 加载状态。</p> : null}</>}</div></div>}
         </div>
         {canvasOpen ? <SplitHandle fraction={split.fraction * 100} dragging={split.dragging} handlers={split.handlers} /> : null}

--- a/artifacts/src/web/chat/export-links.ts
+++ b/artifacts/src/web/chat/export-links.ts
@@ -1,0 +1,15 @@
+import { defaultRehypePlugins } from 'streamdown';
+
+type Node = { type: string; tagName?: string; properties?: Record<string, unknown>; children?: Node[] };
+
+/** Streamdown's link-safety button omits href; retain the sanitized destination without changing its live behavior. */
+export function exportLinks() {
+  return function visit(node: Node) {
+    for (const child of node.children ?? []) visit(child);
+    if (node.tagName !== 'a' || typeof node.properties?.href !== 'string') return;
+    const link = { ...node };
+    node.tagName = 'span'; node.properties = { 'data-export-link': node.properties.href }; node.children = [link];
+  };
+}
+
+export const exportRehypePlugins = [...Object.values(defaultRehypePlugins), exportLinks];

--- a/artifacts/src/web/chat/export-runtime.ts
+++ b/artifacts/src/web/chat/export-runtime.ts
@@ -32,8 +32,8 @@ export function initializeChatExport() {
       section.dataset.exportOpen = String(button.dataset.exportToggle !== 'collapse');
       scroller.style.transition = 'height 300ms cubic-bezier(0.32,0.72,0,1)';
       update();
-      const next = toggles.find(item => !item.hidden);
-      if (next) next.focus({ preventScroll: true }); else { scroller.tabIndex = 0; scroller.focus({ preventScroll: true }); }
+      const next = toggles.find(item => !item.hidden) ?? section.closest('details')?.querySelector('summary') ?? scroller.querySelector<HTMLElement>('[tabindex]');
+      next?.focus({ preventScroll: true });
     });
     updates.push(update); scroller.addEventListener('scroll', schedule, { passive: true });
     observer.observe(content); observer.observe(scroller);

--- a/artifacts/src/web/chat/export-runtime.ts
+++ b/artifacts/src/web/chat/export-runtime.ts
@@ -1,0 +1,70 @@
+/** This function is serialized into the download. Keep it self-contained and limited to host transcript controls. */
+export function initializeChatExport() {
+  const hostElements = <T extends HTMLElement>(selector: string) => [...document.querySelectorAll<T>(selector)].filter(element => !element.closest('.ui4a-surface'));
+  const updates: (() => void)[] = [];
+  let frame = 0;
+  const schedule = () => { if (!frame) frame = requestAnimationFrame(() => { frame = 0; for (const update of updates) update(); }); };
+  const observer = new ResizeObserver(schedule);
+  const restoreScroll = (element: HTMLElement) => {
+    if (element.clientHeight && element.dataset.exportScrollTop) { element.scrollTop = Number(element.dataset.exportScrollTop); delete element.dataset.exportScrollTop; }
+  };
+  for (const section of hostElements('[data-export-collapsible]')) {
+    const scroller = section.querySelector<HTMLElement>('[data-export-scroller]');
+    const content = section.querySelector<HTMLElement>('[data-export-content]');
+    if (!scroller || !content) continue;
+    const cap = Number(section.dataset.exportCap), ramp = Number(section.dataset.exportRamp), reveal = Number(section.dataset.exportReveal);
+    const toggles = [...section.querySelectorAll<HTMLButtonElement>('[data-export-toggle]')];
+    const update = () => {
+      const height = content.getBoundingClientRect().height;
+      if (!height) return; // Closed native details are measured when they open, not frozen at zero height.
+      const overflowing = height > cap, collapsed = overflowing && section.dataset.exportOpen !== 'true';
+      scroller.style.height = `${collapsed ? cap : height}px`;
+      restoreScroll(scroller);
+      const ratio = (value: number) => Math.round(Math.min(1, Math.max(0, value / ramp)) * 50) / 50;
+      const top = collapsed ? ratio(scroller.scrollTop) : 0, bottom = collapsed ? ratio(scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop) : 0;
+      section.style.setProperty('--fade-top', String(top)); section.style.setProperty('--fade-bottom', String(bottom));
+      for (const button of toggles) {
+        button.hidden = button.dataset.exportToggle === 'collapse' ? !(overflowing && !collapsed) : !collapsed || (button.dataset.exportToggle === 'top' ? top : bottom) <= reveal;
+        button.setAttribute('aria-expanded', String(!collapsed));
+      }
+    };
+    for (const button of toggles) button.addEventListener('click', () => {
+      section.dataset.exportOpen = String(button.dataset.exportToggle !== 'collapse');
+      scroller.style.transition = 'height 300ms cubic-bezier(0.32,0.72,0,1)';
+      update();
+      const next = toggles.find(item => !item.hidden);
+      if (next) next.focus({ preventScroll: true }); else { scroller.tabIndex = 0; scroller.focus({ preventScroll: true }); }
+    });
+    updates.push(update); scroller.addEventListener('scroll', schedule, { passive: true });
+    observer.observe(content); observer.observe(scroller);
+  }
+  for (const section of hostElements('.reasoning')) {
+    const viewport = section.querySelector<HTMLElement>('.reasoning-viewport');
+    const content = section.querySelector<HTMLElement>('.reasoning-content');
+    if (!viewport || !content) continue;
+    const update = () => {
+      restoreScroll(viewport);
+      const bottom = Math.max(0, viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop);
+      viewport.style.setProperty('--reasoning-fade-top', String(Math.min(1, viewport.scrollTop / 24)));
+      viewport.style.setProperty('--reasoning-fade-bottom', String(Math.min(1, bottom / 24)));
+      if (viewport.scrollHeight > viewport.clientHeight + 2) viewport.tabIndex = 0; else viewport.removeAttribute('tabindex');
+    };
+    const button = section.querySelector<HTMLButtonElement>('[data-export-reasoning-toggle]');
+    button?.addEventListener('click', () => {
+      const open = button.getAttribute('aria-expanded') !== 'true';
+      button.setAttribute('aria-expanded', String(open)); button.toggleAttribute('data-open', open);
+      button.title = open ? '仅显示最新摘要' : '查看先前摘要';
+      button.querySelector('span')!.textContent = open ? '仅显示最新' : `${button.dataset.reasoningCount} 段摘要`;
+      for (const entry of section.querySelectorAll<HTMLElement>('[data-reasoning-entry]')) {
+        entry.hidden = !open && entry.dataset.reasoningLatest !== 'true'; entry.classList.toggle('reasoning-current', !open);
+      }
+      if (!open) viewport.scrollTop = viewport.scrollHeight;
+      update();
+    });
+    updates.push(update); viewport.addEventListener('scroll', schedule, { passive: true });
+    observer.observe(content); observer.observe(viewport);
+  }
+  document.addEventListener('toggle', schedule, true);
+  document.addEventListener('load', schedule, true);
+  schedule();
+}

--- a/artifacts/src/web/chat/export.test.tsx
+++ b/artifacts/src/web/chat/export.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Streamdown } from 'streamdown';
+import { Reasoning } from '../components/chat/Reasoning';
+import { exportRehypePlugins } from './export-links';
+
+test('export metadata preserves link destinations while keeping the live safety button', () => {
+  const html = renderToStaticMarkup(<Streamdown rehypePlugins={exportRehypePlugins}>{'[Reference](https://example.com/?a=1&b=2)'}</Streamdown>);
+  expect(html).toContain('data-export-link="https://example.com/?a=1&amp;b=2"');
+  expect(html).toContain('<button');
+  expect(html).toContain('Reference</button>');
+});
+
+test('export metadata cannot bypass Markdown URL sanitization', () => {
+  const html = renderToStaticMarkup(<Streamdown rehypePlugins={exportRehypePlugins}>{'[Unsafe](javascript:alert%281%29)'}</Streamdown>);
+  expect(html).not.toContain('data-export-link="javascript:');
+  expect(html).not.toContain('href="javascript:');
+});
+
+test('unopened summary history remains in the transcript without becoming visible', () => {
+  const html = renderToStaticMarkup(<Reasoning live={false} parts={[
+    { type: 'reasoning', text: '**First**\n\nEarlier context', state: 'done', providerMetadata: { macaron: { reasoningKind: 'summary' } } },
+    { type: 'reasoning', text: '**Latest**\n\nCurrent context', state: 'done', providerMetadata: { macaron: { reasoningKind: 'summary' } } },
+  ]} />);
+  expect(html).toContain('Earlier context'); expect(html).toContain('Current context');
+  expect(html).toMatch(/hidden=""[^>]*data-reasoning-latest="false"/);
+  expect(html).toContain('data-export-reasoning-toggle="true"');
+});

--- a/artifacts/src/web/chat/export.ts
+++ b/artifacts/src/web/chat/export.ts
@@ -1,0 +1,40 @@
+import { snapshotDocument } from '../ui4a/export';
+import { highlighter } from '../theme/themes';
+import { initializeChatExport } from './export-runtime';
+import { defaultUrlTransform } from 'streamdown';
+
+export async function chatHtml(transcript: HTMLElement, title: string): Promise<string> {
+  const output = snapshotDocument(transcript, title, 'chat');
+  for (const wrapper of output.querySelectorAll<HTMLElement>('[data-export-link]')) {
+    const button = wrapper.querySelector('button[data-streamdown="link"]');
+    if (!button) continue;
+    const link = output.createElement('a'); link.href = defaultUrlTransform(wrapper.dataset.exportLink!, 'href', { type: 'element', tagName: 'a', properties: {}, children: [] }) ?? ''; link.rel = 'noreferrer'; link.target = '_blank';
+    link.className = button.className; link.dataset.streamdown = 'link'; link.append(...button.childNodes); button.replaceWith(link);
+  }
+  output.querySelectorAll('[data-streamdown="link-safety-modal"]').forEach(element => element.remove());
+  for (const button of output.querySelectorAll('button')) if (!button.closest('.ui4a-surface') && !button.matches('[data-export-toggle], [data-export-reasoning-toggle]')) button.remove();
+  // CodeBlock lazily highlights on intersection; closed tools must also export ready-to-read syntax.
+  for (const pre of output.querySelectorAll<HTMLElement>('pre[data-code-language]')) {
+    const code = pre.querySelector('code');
+    if (!code) continue;
+    const lang = pre.dataset.codeLanguage!, theme = pre.dataset.codeTheme!;
+    const engine = await highlighter(lang, theme);
+    const { tokens } = engine.codeToTokens(code.textContent ?? '', { lang, theme });
+    code.replaceChildren();
+    for (const [index, line] of tokens.entries()) {
+      if (index) code.append('\n');
+      for (const token of line) {
+        const span = output.createElement('span'); span.textContent = token.content;
+        if (token.color) span.style.color = token.color;
+        if (token.fontStyle && (token.fontStyle & 1)) span.style.fontStyle = 'italic';
+        if (token.fontStyle && (token.fontStyle & 2)) span.style.fontWeight = 'bold';
+        code.append(span);
+      }
+    }
+  }
+  // Only this fixed transcript controller may execute; generated cards remain static and have no host bridge.
+  const nonce = crypto.randomUUID();
+  output.querySelector<HTMLMetaElement>('meta[http-equiv="Content-Security-Policy"]')!.content = `script-src 'nonce-${nonce}'; object-src 'none'; base-uri 'none'; form-action 'none'`;
+  const script = output.createElement('script'); script.setAttribute('nonce', nonce); script.textContent = `(${initializeChatExport.toString()})();`; output.body.append(script);
+  return `<!doctype html>\n${output.documentElement.outerHTML}`;
+}

--- a/artifacts/src/web/chat/export.ts
+++ b/artifacts/src/web/chat/export.ts
@@ -12,7 +12,10 @@ export async function chatHtml(transcript: HTMLElement, title: string): Promise<
     link.className = button.className; link.dataset.streamdown = 'link'; link.append(...button.childNodes); button.replaceWith(link);
   }
   output.querySelectorAll('[data-streamdown="link-safety-modal"]').forEach(element => element.remove());
-  for (const button of output.querySelectorAll('button')) if (!button.closest('.ui4a-surface') && !button.matches('[data-export-toggle], [data-export-reasoning-toggle]')) button.remove();
+  for (const button of output.querySelectorAll('button')) {
+    if (button.closest('.ui4a-surface') || button.matches('[data-export-toggle], [data-export-reasoning-toggle]')) continue;
+    if (button.matches('[data-streamdown="link"]')) button.replaceWith(...button.childNodes); else button.remove();
+  }
   // CodeBlock lazily highlights on intersection; closed tools must also export ready-to-read syntax.
   for (const pre of output.querySelectorAll<HTMLElement>('pre[data-code-language]')) {
     const code = pre.querySelector('code');

--- a/artifacts/src/web/components/ExportMenu.tsx
+++ b/artifacts/src/web/components/ExportMenu.tsx
@@ -3,27 +3,32 @@ import { useEffect, useState, type RefObject } from 'react';
 import { Icon } from './Icon';
 import { downloadHtml, snapshotHtml } from '../ui4a/export';
 
-export function ExportMenu({ target, filename = 'macaron-card', disabled = false }: { target: RefObject<HTMLElement | null>; filename?: string; disabled?: boolean }) {
+export function ExportMenu({ target, filename = 'macaron-card', disabled = false, kind = 'surface' }: { target: RefObject<HTMLElement | null>; filename?: string; disabled?: boolean; kind?: 'surface' | 'chat' }) {
+  const label = kind === 'chat' ? '对话 HTML' : ' HTML 快照';
   const [busy, setBusy] = useState(false), [feedback, setFeedback] = useState<{ text: string; error?: boolean }>();
   useEffect(() => { if (!feedback || feedback.error) return; const timer = setTimeout(() => setFeedback(undefined), 2000); return () => clearTimeout(timer); }, [feedback]);
   const run = async (copy: boolean) => {
     setBusy(true); setFeedback(undefined);
     try {
-      const surface = target.current?.querySelector<HTMLElement>('[data-ui4a-ready="true"]');
+      const surface = target.current?.querySelector<HTMLElement>(kind === 'chat' ? '[data-chat-content]' : '[data-ui4a-ready="true"]');
       if (!surface || disabled) throw new Error('预览尚未就绪，请稍后重试');
-      const html = snapshotHtml(surface, filename);
-      if (copy) { if (!navigator.clipboard) throw new Error('浏览器不支持复制，请下载 HTML'); await navigator.clipboard.writeText(html); }
-      else downloadHtml(html, filename);
+      if (copy && !navigator.clipboard) throw new Error('浏览器不支持复制，请下载 HTML');
+      const html = kind === 'chat' ? import('../chat/export').then(module => module.chatHtml(surface, filename)) : snapshotHtml(surface, filename);
+      if (copy) {
+        // Start the clipboard operation during the click, even when chat highlighting completes asynchronously.
+        if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) await navigator.clipboard.write([new ClipboardItem({ 'text/plain': Promise.resolve(html).then(text => new Blob([text], { type: 'text/plain' })) })]);
+        else await navigator.clipboard.writeText(await html);
+      } else downloadHtml(await html, filename);
       setFeedback({ text: copy ? '已复制 HTML' : '已下载 HTML' });
     } catch (error) { setFeedback({ text: error instanceof Error ? error.message : '导出失败，请重试', error: true }); }
     finally { setBusy(false); }
   };
   return <div className="relative shrink-0">
     <Menu>
-      <MenuButton type="button" title={disabled ? '预览完成后可导出' : '导出 HTML 快照'} aria-label="导出 HTML 快照" disabled={disabled || busy} onClick={() => setFeedback(undefined)} className="interactive grid size-9 place-items-center rounded-md text-muted hover:bg-surface-3 hover:text-hover-fg data-[open]:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-40"><Icon name={busy ? 'ellipsis' : 'arrowDown'} /></MenuButton>
+      <MenuButton type="button" title={disabled ? kind === 'chat' ? '对话完成后可导出' : '预览完成后可导出' : `导出${label}`} aria-label={`导出${label}`} disabled={disabled || busy} onClick={() => setFeedback(undefined)} className="interactive grid size-9 place-items-center rounded-md text-muted hover:bg-surface-3 hover:text-hover-fg data-[open]:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-40"><Icon name={busy ? 'ellipsis' : 'arrowDown'} /></MenuButton>
       <MenuItems anchor={{ to: 'bottom end', gap: 6, padding: 8 }} className="theme-menu z-50 w-44 max-w-[calc(100vw-16px)] rounded-lg p-1 outline-none">
-        <MenuItem><button type="button" onClick={() => void run(false)} className="interactive flex min-h-10 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg"><Icon name="arrowDown" />下载 HTML 快照</button></MenuItem>
-        <MenuItem><button type="button" onClick={() => void run(true)} className="interactive block min-h-10 w-full rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg">复制 HTML 快照</button></MenuItem>
+        <MenuItem><button type="button" onClick={() => void run(false)} className="interactive flex min-h-10 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg"><Icon name="arrowDown" />下载{label}</button></MenuItem>
+        <MenuItem><button type="button" onClick={() => void run(true)} className="interactive block min-h-10 w-full rounded-md px-3 py-2 text-left text-sm data-[focus]:bg-surface-3 data-[focus]:text-hover-fg">复制{label}</button></MenuItem>
       </MenuItems>
     </Menu>
     {feedback ? <div role={feedback.error ? 'alert' : 'status'} className={`theme-widget absolute top-full right-0 z-20 mt-1 w-52 max-w-[calc(100vw-24px)] rounded-md p-2 text-xs break-words ${feedback.error ? 'text-danger' : 'text-fg'}`}><div className="flex items-start gap-1"><span className="min-w-0 flex-1">{feedback.text}</span><button type="button" onClick={() => setFeedback(undefined)} aria-label="关闭导出提示" className="grid size-6 shrink-0 place-items-center rounded hover:bg-surface-3"><Icon name="x" className="size-3" /></button></div></div> : null}

--- a/artifacts/src/web/components/ExportMenu.tsx
+++ b/artifacts/src/web/components/ExportMenu.tsx
@@ -9,18 +9,19 @@ export function ExportMenu({ target, filename = 'macaron-card', disabled = false
   useEffect(() => { if (!feedback || feedback.error) return; const timer = setTimeout(() => setFeedback(undefined), 2000); return () => clearTimeout(timer); }, [feedback]);
   const run = async (copy: boolean) => {
     setBusy(true); setFeedback(undefined);
+    let preparationError: unknown;
     try {
       const surface = target.current?.querySelector<HTMLElement>(kind === 'chat' ? '[data-chat-content]' : '[data-ui4a-ready="true"]');
       if (!surface || disabled) throw new Error('预览尚未就绪，请稍后重试');
       if (copy && !navigator.clipboard) throw new Error('浏览器不支持复制，请下载 HTML');
-      const html = kind === 'chat' ? import('../chat/export').then(module => module.chatHtml(surface, filename)) : snapshotHtml(surface, filename);
+      const html = kind === 'chat' ? import('../chat/export').then(module => module.chatHtml(surface, filename)).catch(error => { preparationError = error; throw error; }) : snapshotHtml(surface, filename);
       if (copy) {
         // Start the clipboard operation during the click, even when chat highlighting completes asynchronously.
         if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) await navigator.clipboard.write([new ClipboardItem({ 'text/plain': Promise.resolve(html).then(text => new Blob([text], { type: 'text/plain' })) })]);
         else await navigator.clipboard.writeText(await html);
       } else downloadHtml(await html, filename);
       setFeedback({ text: copy ? '已复制 HTML' : '已下载 HTML' });
-    } catch (error) { setFeedback({ text: error instanceof Error ? error.message : '导出失败，请重试', error: true }); }
+    } catch (error) { const reason = preparationError ?? error; setFeedback({ text: reason instanceof Error ? reason.message : '导出失败，请重试', error: true }); }
     finally { setBusy(false); }
   };
   return <div className="relative shrink-0">

--- a/artifacts/src/web/components/chat/Conversation.tsx
+++ b/artifacts/src/web/components/chat/Conversation.tsx
@@ -23,10 +23,10 @@ export function Conversation({ instance, session, store }: { instance: Chat<Chat
   const suggestions = session.suggestions;
   const queued = store.queue(session.id);
   return <div className="@container relative flex h-full min-w-0 flex-1 flex-col">
-    <div ref={viewport} data-chat-column className="min-h-0 flex-1 overflow-y-auto"><div ref={content} className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
+    <div ref={viewport} data-chat-column className="min-h-0 flex-1 overflow-y-auto"><div ref={content} data-chat-content className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
       {chat.messages.map(message => <Message key={message.id} message={message} streaming={streaming && message.id === last?.id} cwd={session.cwd} sessionId={session.id} onSend={send} onArtifact={openArtifact} onApprove={approve} />)}
       {chat.status === 'submitted' ? <p className="flex items-center gap-2 text-xs text-muted" role="status"><span className="size-1.5 animate-pulse rounded-full bg-accent" />正在连接…</p> : null}
-      {chat.error || session.status === 'error' ? <div role="alert" className="flex items-center gap-3 rounded-xl border border-danger/40 px-3 py-2 text-xs text-danger"><span className="min-w-0 flex-1 break-words">{chat.error?.message ?? session.error ?? '这轮没有跑完'}</span><Button size="sm" variant="ghost" onClick={() => void store.retry(session.id)}>重试</Button></div> : null}
+      {chat.error || session.status === 'error' ? <div role="alert" className="flex items-center gap-3 rounded-xl border border-danger/40 px-3 py-2 text-xs text-danger"><span className="min-w-0 flex-1 break-words">{chat.error?.message ?? session.error ?? '这轮没有跑完'}</span><Button data-export-control size="sm" variant="ghost" onClick={() => void store.retry(session.id)}>重试</Button></div> : null}
     </div></div>
     <button type="button" onClick={() => scrollToBottom()} inert={stuck} className={`interactive absolute bottom-24 left-1/2 z-30 -translate-x-1/2 theme-widget rounded-full px-3 py-1.5 text-xs text-muted hover:text-fg ${stuck ? 'translate-y-1 opacity-0' : 'opacity-100'}`}>回到底部 ↓</button>
     <div className="px-3"><div className="mx-auto w-full max-w-3xl">

--- a/artifacts/src/web/components/chat/MessageBody.tsx
+++ b/artifacts/src/web/components/chat/MessageBody.tsx
@@ -5,6 +5,7 @@ import { CodeBlock } from '../code/CodeBlock';
 import { Collapsible } from '../code/Collapsible';
 import { parseSegments } from './segments';
 import { ExportMenu } from '../ExportMenu';
+import { exportRehypePlugins } from '../../chat/export-links';
 
 const Ui4aSurface = lazy(() => import('../../ui4a/Ui4aSurface').then(module => ({ default: module.Ui4aSurface })));
 const PLUGINS = { cjk };
@@ -17,12 +18,12 @@ const COMPONENTS = { pre: Pre };
 
 export const MessageBody = memo(function MessageBody({ text, messageId, streaming, sessionId, onSend, allowUi = true }: { text: string; messageId: string; streaming: boolean; sessionId: string; onSend: (text: string) => void; allowUi?: boolean }) {
   const segments = useMemo(() => allowUi ? parseSegments(text) : [{ kind: 'markdown' as const, text }], [allowUi, text]);
-  return <div className="flex flex-col gap-3">{segments.map((segment, index) => segment.kind === 'markdown' ? <div key={index} className="md text-sm leading-relaxed"><Streamdown plugins={PLUGINS} components={COMPONENTS} controls={false} animated={ANIMATION} isAnimating={streaming}>{segment.text}</Streamdown></div> : <InlineUi4a key={index} source={segment.code} streaming={streaming && !segment.complete} scope={`${sessionId}:inline:${messageId}:${index}`} sessionId={sessionId} onSend={onSend} />)}</div>;
+  return <div className="flex flex-col gap-3">{segments.map((segment, index) => segment.kind === 'markdown' ? <div key={index} className="md text-sm leading-relaxed"><Streamdown plugins={PLUGINS} rehypePlugins={exportRehypePlugins} components={COMPONENTS} controls={false} animated={ANIMATION} isAnimating={streaming}>{segment.text}</Streamdown></div> : <InlineUi4a key={index} source={segment.code} streaming={streaming && !segment.complete} scope={`${sessionId}:inline:${messageId}:${index}`} sessionId={sessionId} onSend={onSend} />)}</div>;
 });
 
 function InlineUi4a({ source, ...props }: { source: string; streaming: boolean; scope: string; sessionId: string; onSend: (text: string) => void }) {
   const [showSource, setShowSource] = useState(false);
   const target = useRef<HTMLDivElement>(null);
   const fallback = <div className="theme-code overflow-clip rounded-xl"><Collapsible><CodeBlock code={source} /></Collapsible></div>;
-  return <div><div className="flex h-10 items-center justify-end gap-1"><button type="button" onClick={() => setShowSource(value => !value)} aria-pressed={showSource} className="interactive h-9 rounded-md px-2 text-xs text-muted hover:bg-surface-3 hover:text-hover-fg">{showSource ? '预览' : '源码'}</button><ExportMenu target={target} disabled={props.streaming || showSource} /></div><div ref={target}>{showSource ? fallback : <Suspense fallback={fallback}><Ui4aSurface source={source} {...props} /></Suspense>}</div></div>;
+  return <div><div data-export-control className="flex h-10 items-center justify-end gap-1"><button type="button" onClick={() => setShowSource(value => !value)} aria-pressed={showSource} className="interactive h-9 rounded-md px-2 text-xs text-muted hover:bg-surface-3 hover:text-hover-fg">{showSource ? '预览' : '源码'}</button><ExportMenu target={target} disabled={props.streaming || showSource} /></div><div ref={target}>{showSource ? fallback : <Suspense fallback={fallback}><Ui4aSurface source={source} {...props} /></Suspense>}</div></div>;
 }

--- a/artifacts/src/web/components/chat/Reasoning.css
+++ b/artifacts/src/web/components/chat/Reasoning.css
@@ -8,7 +8,7 @@
 .reasoning-viewport { max-height: min(14rem, 36svh); overflow: auto; overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: var(--border) transparent; transition: --reasoning-fade-top 140ms ease, --reasoning-fade-bottom 140ms ease; mask-image: linear-gradient(to bottom, rgb(0 0 0 / calc(1 - var(--reasoning-fade-top))) 0, #000 16px, #000 calc(100% - 16px), rgb(0 0 0 / calc(1 - var(--reasoning-fade-bottom))) 100%); }
 .reasoning[data-reasoning-kind='summary'] .reasoning-viewport { max-height: min(10rem, 30svh); }
 .reasoning-content { min-width: 0; overflow-wrap: anywhere; padding-block: 4px; }
-.reasoning-content [data-reasoning-entry] + [data-reasoning-entry] { margin-top: .75rem; }
+.reasoning-content [data-reasoning-entry]:not([hidden]) ~ [data-reasoning-entry]:not([hidden]) { margin-top: .75rem; }
 .reasoning-content :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) { margin: 0; font-size: inherit; }
 .reasoning-content :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) + :where(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6, pre) { margin-top: .5rem; }
 .reasoning-content :where(strong, [data-streamdown='strong'], h1, h2, h3, h4, h5, h6) { color: var(--fg); font-weight: 500; }

--- a/artifacts/src/web/components/chat/Reasoning.tsx
+++ b/artifacts/src/web/components/chat/Reasoning.tsx
@@ -9,12 +9,13 @@ import { cjk } from '@streamdown/cjk';
 import { Icon } from '../Icon';
 import { analyzeReasoning } from './reasoning-model';
 import { useReasoningScroll } from './useReasoningScroll';
+import { exportRehypePlugins } from '../../chat/export-links';
 import './Reasoning.css';
 
 const PLUGINS = { cjk };
 const Markdown = memo(function Markdown({ text, live }: { text: string; live: boolean }) {
   // Reasoning is text, never an executable UI4A surface. Streamdown handles incomplete Markdown.
-  return <Streamdown plugins={PLUGINS} controls={false} isAnimating={live}>{text}</Streamdown>;
+  return <Streamdown plugins={PLUGINS} rehypePlugins={exportRehypePlugins} controls={false} isAnimating={live}>{text}</Streamdown>;
 });
 
 export const Reasoning = memo(function Reasoning({ parts, live }: { parts: readonly ReasoningUIPart[]; live: boolean }) {
@@ -38,12 +39,13 @@ function ReasoningView({ presentation, active, historyOpen }: { presentation: Re
       <span className="reasoning-sr-only" role="status">{active ? '正在思考' : ''}</span>
       <div id={regionId} ref={viewport} className="reasoning-viewport" role="region" aria-label={kind === 'summary' ? '思考摘要' : '思考过程'} tabIndex={overflowing ? 0 : undefined}>
         <div ref={content} className="reasoning-content">
-          {visible.map(entry => <div key={entry.key} data-reasoning-entry data-reasoning-latest={kind === 'summary' ? entry.key === entries.at(-1)?.key : undefined} className={kind === 'summary' && !historyOpen ? 'reasoning-current' : undefined}><Markdown text={entry.text} live={active} /></div>)}
+          {/* Keep earlier summaries mounted so exports include history that has never been opened. */}
+          {entries.map(entry => <div key={entry.key} hidden={kind === 'summary' && !historyOpen && entry.key !== entries.at(-1)?.key} data-reasoning-entry data-reasoning-latest={kind === 'summary' ? entry.key === entries.at(-1)?.key : undefined} className={kind === 'summary' && !historyOpen ? 'reasoning-current' : undefined}><Markdown text={entry.text} live={active} /></div>)}
           {!entries.length && active ? <span className="reasoning-placeholder">正在思考</span> : null}
         </div>
       </div>
       {(kind === 'summary' && entries.length > 1) || (overflowing && !following && active && !historyOpen) ? <div className="reasoning-actions">
-        {kind === 'summary' && entries.length > 1 ? <DisclosureButton aria-controls={regionId} className="reasoning-action" onClick={() => { if (historyOpen) resume(); }} title={historyOpen ? '仅显示最新摘要' : '查看先前摘要'}><Icon name="chevronDown" className="reasoning-action-icon" /><span>{historyOpen ? '仅显示最新' : `${entries.length} 段摘要`}</span></DisclosureButton> : null}
+        {kind === 'summary' && entries.length > 1 ? <DisclosureButton data-export-reasoning-toggle data-reasoning-count={entries.length} aria-controls={regionId} className="reasoning-action" onClick={() => { if (historyOpen) resume(); }} title={historyOpen ? '仅显示最新摘要' : '查看先前摘要'}><Icon name="chevronDown" className="reasoning-action-icon" /><span>{historyOpen ? '仅显示最新' : `${entries.length} 段摘要`}</span></DisclosureButton> : null}
         {overflowing && !following && active && !historyOpen ? <button type="button" className="reasoning-action reasoning-resume" onClick={resume} title="继续跟随思考"><Icon name="arrowDown" className="reasoning-action-icon" /><span>跟随最新</span></button> : null}
       </div> : null}
     </div>

--- a/artifacts/src/web/components/code/CodeBlock.tsx
+++ b/artifacts/src/web/components/code/CodeBlock.tsx
@@ -48,5 +48,5 @@ export function CodeBlock({ code, lang = 'tsx', className = '' }: { code: string
     for (const token of tokens) for (const [index, content] of token.content.split('\n').entries()) { if (index) result.push([]); if (content) result.at(-1)!.push({ ...token, content }); }
     return result;
   }, [tokens]);
-  return <pre ref={mount} tabIndex={0} aria-label="代码" className={`theme-code scroll-x m-0 p-3 text-xs leading-5 ${className}`}><code>{tokens.length ? lines.map((line, index) => <Fragment key={index}><CodeLine tokens={line} signature={line.map(token => `${token.content}:${token.color}:${token.fontStyle}`).join('|')} />{index < lines.length - 1 ? '\n' : ''}</Fragment>) : code}</code></pre>;
+  return <pre ref={mount} data-code-language={normalizeLanguage(lang)} data-code-theme={appearance.syntax} tabIndex={0} aria-label="代码" className={`theme-code scroll-x m-0 p-3 text-xs leading-5 ${className}`}><code>{tokens.length ? lines.map((line, index) => <Fragment key={index}><CodeLine tokens={line} signature={line.map(token => `${token.content}:${token.color}:${token.fontStyle}`).join('|')} />{index < lines.length - 1 ? '\n' : ''}</Fragment>) : code}</code></pre>;
 }

--- a/artifacts/src/web/components/code/Collapsible.tsx
+++ b/artifacts/src/web/components/code/Collapsible.tsx
@@ -77,17 +77,18 @@ export function Collapsible({ children, className = "" }: { children: React.Reac
     <div className={className}>
       {/* 模糊层和展开开关都贴着**窗口**的边，所以定位基准要在这一层。
           两个渐隐强度在这里落地并补间，底下的蒙版和模糊层都是从它们算出来的（继承），因此永远同步 */}
-      <div className="relative" style={{ "--fade-top": collapsed ? edges.top : 0, "--fade-bottom": collapsed ? edges.bottom : 0, transition: `--fade-top ${EASE}, --fade-bottom ${EASE}` } as React.CSSProperties}>
+      <div data-export-collapsible data-export-open={open} data-export-cap={CAP} data-export-ramp={RAMP} data-export-reveal={REVEAL} className="relative" style={{ "--fade-top": collapsed ? edges.top : 0, "--fade-bottom": collapsed ? edges.bottom : 0, transition: `--fade-top ${EASE}, --fade-bottom ${EASE}` } as React.CSSProperties}>
         {/* 高度给到具体像素而不是 max-height：收起态是常量，展开态跟着测量值走。
             `overflow-y-auto` 而不是 hidden —— 跟随尾部靠的就是真的滚动，用户也能自己滚回去看。
             滚动条一律藏起来：蒙版是盖在整个窗口上的，会把滚动条一起糊掉，露着比藏着更难看 */}
         <div
           ref={scroller}
+          data-export-scroller
           className="no-scrollbar overflow-y-auto"
           onTransitionEnd={(event) => event.propertyName === "height" && setToggling(false)}
           style={{ height: collapsed ? CAP : height || undefined, transition: toggling ? "height 300ms cubic-bezier(0.32,0.72,0,1)" : undefined, maskImage: MASK, WebkitMaskImage: MASK }}
         >
-          <div ref={inner}>{children}</div>
+          <div ref={inner} data-export-content>{children}</div>
         </div>
         {/* 强度为 0 时这两层是零高度的空盒子，所以常挂着也不额外合成 —— 但必须常挂着，
             卸掉重挂就没有过渡可言了 */}
@@ -95,17 +96,18 @@ export function Collapsible({ children, className = "" }: { children: React.Reac
         <ProgressiveFade side="bottom" size={FADE} step={BLUR_STEP} />
         {/* 开关浮在被截断的那条边上，居中。哪条边藏了东西就出现在哪条边 —— 跟随尾部时藏的是上面，
             按钮也就只出现在顶上。一律自带底色：它压着的是代码，而渐隐带最多只糊掉一部分 */}
-        {collapsed && edges.top > REVEAL ? <Toggle side="top" label="↑ 展开" fade onClick={() => toggle(true)} /> : null}
-        {collapsed && edges.bottom > REVEAL ? <Toggle side="bottom" label="展开 ↓" fade onClick={() => toggle(true)} /> : null}
-        {overflowing && !collapsed ? <Toggle side="bottom" label="收起 ↑" onClick={() => toggle(false)} /> : null}
+        <Toggle side="top" label="↑ 展开" fade hidden={!(collapsed && edges.top > REVEAL)} onClick={() => toggle(true)} />
+        <Toggle side="bottom" label="展开 ↓" fade hidden={!(collapsed && edges.bottom > REVEAL)} onClick={() => toggle(true)} />
+        <Toggle side="bottom" label="收起 ↑" hidden={!(overflowing && !collapsed)} onClick={() => toggle(false)} />
       </div>
     </div>
   );
 }
 
-function Toggle({ side, label, onClick, fade }: { side: "top" | "bottom"; label: string; onClick: () => void; fade?: boolean }) {
+function Toggle({ side, label, onClick, fade, hidden }: { side: "top" | "bottom"; label: string; onClick: () => void; fade?: boolean; hidden: boolean }) {
   return (
     <button
+      type="button" hidden={hidden} data-export-toggle={fade ? side : 'collapse'}
       onClick={onClick}
       // `inset-x-0` + `mx-auto w-fit` 才是绝对定位下的水平居中；只给 left-1/2 会连按钮自身宽度一起偏
       className={`interactive absolute inset-x-0 z-10 mx-auto w-fit rounded-full border border-secondary-border bg-secondary px-2 py-0.5 text-[11px] text-secondary-fg hover:bg-secondary-hover ${side === "top" ? "top-1.5" : "bottom-1.5"}`}

--- a/artifacts/src/web/ui4a/export.ts
+++ b/artifacts/src/web/ui4a/export.ts
@@ -1,5 +1,9 @@
 /** Capture the visible result, never the generated module or its privileged host bridges. */
 export function snapshotHtml(surface: HTMLElement, title: string): string {
+  return `<!doctype html>\n${snapshotDocument(surface, title).documentElement.outerHTML}`;
+}
+
+export function snapshotDocument(surface: HTMLElement, title: string, kind: 'surface' | 'chat' = 'surface'): Document {
   const sourceDocument = surface.ownerDocument;
   const output = sourceDocument.implementation.createHTMLDocument(title);
   const root = sourceDocument.documentElement;
@@ -18,7 +22,7 @@ export function snapshotHtml(surface: HTMLElement, title: string): string {
     style.media = sheet.media.mediaText; output.head.append(style);
   }
   // App chrome locks body scrolling; exported documents need their own scrollable viewport.
-  const layout = output.createElement('style'); layout.textContent = 'html,body{height:auto;min-height:100%;overflow:auto}body{margin:0}.ui4a-surface{min-height:100vh}'; output.head.append(layout);
+  const layout = output.createElement('style'); layout.textContent = `html,body{height:auto;min-height:100%;overflow:auto}body{margin:0;container-type:inline-size}${kind === 'surface' ? '.ui4a-surface{min-height:100vh}' : '[data-chat-content] [hidden]{display:none!important}'}`; output.head.append(layout);
   const clone = surface.cloneNode(true) as HTMLElement;
   // Canvas inherits a panel palette that is different from the document palette.
   const computed = sourceDocument.defaultView!.getComputedStyle(surface);
@@ -26,6 +30,7 @@ export function snapshotHtml(surface: HTMLElement, title: string): string {
   const originals = [surface, ...surface.querySelectorAll('*')], copies = [clone, ...clone.querySelectorAll('*')];
   for (let index = 0; index < originals.length; index++) {
     const original = originals[index]!, copy = copies[index]!;
+    if (kind === 'chat' && original.scrollTop) copy.setAttribute('data-export-scroll-top', String(original.scrollTop));
     if (original instanceof HTMLInputElement) {
       if (original.type === 'password' || original.type === 'file') copy.removeAttribute('value');
       else copy.setAttribute('value', original.value);
@@ -59,7 +64,7 @@ export function snapshotHtml(surface: HTMLElement, title: string): string {
   // The selected picture is already captured in img.currentSrc; old source sets can override it when reopened.
   clone.querySelectorAll('script, iframe, object, embed, picture source, [data-export-control]').forEach(node => node.remove());
   output.body.append(clone);
-  return `<!doctype html>\n${output.documentElement.outerHTML}`;
+  return output;
 }
 
 export function downloadHtml(html: string, filename: string) {


### PR DESCRIPTION
Export a complete conversation from the title bar as HTML, using the current theme and the existing message markup. The file contains the transcript only, with working tool disclosures, long-output expand/collapse, reasoning history, highlighted code, and ordinary links.

Follow-up to #225. Inline cards remain static snapshots; the sidebar, composer, suggestions, and approval actions are omitted. A nonce-authorized, self-contained script restores transcript controls without connecting to the app or executing generated card code. External assets may still need network access.

Validation:
- Typecheck and build passed; 335 tests passed, 2 native integration tests skipped.
- Production-build downloads reopened with `file://` in Edge. Verified initially closed tools, 140-line output expanding from 320px to 2844px and back, hidden summary history, keyboard activation, hyperlinks, and clipboard export.
- Dark and GitHub Light exports retain the application's computed colors, fonts, and spacing; desktop and 360/390px mobile layouts checked.
- `m km` reviewed placement and mobile layout; `m clhh` reviewed the implementation and the final error, focus, and link fallbacks were corrected.