### PR TITLE
avoid interrupting reasoning scroll bounce

### DIFF
--- a/artifacts/src/web/components/chat/reasoning-scroll.test.ts
+++ b/artifacts/src/web/components/chat/reasoning-scroll.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test';
+import { followReasoningScroll, reasoningScrollTop } from './reasoning-scroll';
+
+function viewport(top: number, scrollHeight = 1000, clientHeight = 200) {
+  const writes: number[] = [];
+  const element = { scrollHeight, clientHeight, get scrollTop() { return top; }, set scrollTop(value: number) { writes.push(value); top = value; } };
+  return { element, writes, position(value: number) { top = value; } };
+}
+
+test('bottom and subpixel scroll events do not reset native scrolling', () => {
+  const { element, writes } = viewport(799.5);
+  expect(followReasoningScroll(element, true, false)).toBe(800);
+  expect(writes).toEqual([]);
+  const atBottom = viewport(800);
+  followReasoningScroll(atBottom.element, true, true);
+  expect(atBottom.writes).toEqual([]);
+});
+
+test.each([-40, 840])('elastic offset %s survives content growth and measurement', top => {
+  const { element, writes } = viewport(top);
+  followReasoningScroll(element, true, false);
+  element.scrollHeight = 1020;
+  followReasoningScroll(element, true, false);
+  expect(element.scrollTop).toBe(top);
+  expect(writes).toEqual([]);
+});
+
+test('bottom rebound remains at the logical bottom instead of looking like an upward gesture', () => {
+  expect([800, 840, 820, 805, 800].map(top => reasoningScrollTop(viewport(top).element))).toEqual([800, 800, 800, 800, 800]);
+  expect([0, -40, -10, 0].map(top => reasoningScrollTop(viewport(top).element))).toEqual([0, 0, 0, 0]);
+});
+
+test('live following still tracks layout changes, but paused or finished reasoning stays put', () => {
+  const live = viewport(800, 1100);
+  expect(followReasoningScroll(live.element, true, false)).toBe(900);
+  expect(live.writes).toEqual([900]);
+  const paused = viewport(300, 1100);
+  followReasoningScroll(paused.element, false, false);
+  expect(paused.writes).toEqual([]);
+});
+
+test('explicit resume can exit overscroll, including while history is open', () => {
+  const { element, writes } = viewport(-40);
+  followReasoningScroll(element, false, true);
+  expect(writes).toEqual([800]);
+});
+
+test('initial live content pins once; content without overflow does not produce invalid offsets', () => {
+  const live = viewport(0);
+  followReasoningScroll(live.element, true, false);
+  expect(live.writes).toEqual([800]);
+  const short = viewport(-12, 100, 200);
+  expect(followReasoningScroll(short.element, true, false)).toBe(0);
+  expect(reasoningScrollTop(short.element)).toBe(0);
+  expect(short.writes).toEqual([]);
+});
+
+test('a follow skipped during overscroll is recovered after settlement without another resize', () => {
+  const view = viewport(850, 1020);
+  followReasoningScroll(view.element, true, false);
+  expect(view.writes).toEqual([]);
+  view.position(800);
+  followReasoningScroll(view.element, true, false);
+  expect(view.writes).toEqual([820]);
+});

--- a/artifacts/src/web/components/chat/reasoning-scroll.ts
+++ b/artifacts/src/web/components/chat/reasoning-scroll.ts
@@ -1,0 +1,12 @@
+type ScrollViewport = Pick<HTMLElement, 'scrollTop' | 'scrollHeight' | 'clientHeight'>;
+
+export const reasoningScrollTop = (element: ScrollViewport) => Math.min(Math.max(0, element.scrollHeight - element.clientHeight), Math.max(0, element.scrollTop));
+
+export function followReasoningScroll(element: ScrollViewport, following: boolean, force: boolean): number {
+  const gap = Math.max(0, element.scrollHeight - element.clientHeight);
+  const rawTop = element.scrollTop;
+  // Safari exposes elastic offsets outside [0, gap]. A scrollTop write cancels that native motion.
+  const bouncing = rawTop < 0 || rawTop > gap;
+  if (force ? rawTop !== gap : following && !bouncing && gap - rawTop > 1) element.scrollTop = gap;
+  return gap;
+}

--- a/artifacts/src/web/components/chat/useReasoningScroll.ts
+++ b/artifacts/src/web/components/chat/useReasoningScroll.ts
@@ -1,5 +1,6 @@
 'use client';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { followReasoningScroll, reasoningScrollTop } from './reasoning-scroll';
 
 const EDGE_RAMP = 24;
 const BOTTOM_TOLERANCE = 2;
@@ -25,14 +26,13 @@ export function useReasoningScroll(contentKey: string, live: boolean) {
     const inner = content.current;
     if (!element || !inner) return;
     let frame = 0;
-    let lastTop = element.scrollTop;
+    let lastTop = reasoningScrollTop(element);
     let lastHeight = element.scrollHeight;
     const measure = () => {
       frame = 0;
-      const gap = Math.max(0, element.scrollHeight - element.clientHeight);
-      if (forcePin.current || (liveRef.current && followingRef.current)) element.scrollTop = gap;
+      const gap = followReasoningScroll(element, liveRef.current && followingRef.current, forcePin.current);
       forcePin.current = false;
-      const top = Math.max(0, element.scrollTop);
+      const top = reasoningScrollTop(element);
       const bottom = Math.max(0, gap - top);
       if (bottom <= BOTTOM_TOLERANCE) followingRef.current = true;
       else if (!liveRef.current) followingRef.current = false;
@@ -48,7 +48,8 @@ export function useReasoningScroll(contentKey: string, live: boolean) {
     };
     schedule.current = requestMeasure;
     const onScroll = () => {
-      const top = element.scrollTop;
+      // Elastic rebound is not an upward gesture; compare only positions inside the scrollable range.
+      const top = reasoningScrollTop(element);
       const shrank = element.scrollHeight < lastHeight;
       if (!shrank && top < lastTop - 0.5) followingRef.current = false;
       if (element.scrollHeight - element.clientHeight - top <= BOTTOM_TOLERANCE) followingRef.current = true;


### PR DESCRIPTION
While reasoning is streaming, its follow loop writes `scrollTop` on every scroll event. Safari exposes native rubber-band offsets outside the normal range, so those writes can snap a bouncing viewport back to the bottom. Rebound can also be mistaken for an upward user scroll.

Skip automatic writes while the raw offset is outside the scrollable range and avoid redundant/subpixel bottom writes. Clamp only the readings used for direction and edge fades. Explicit resume and normal live following still work; `overscroll-behavior: contain` remains unchanged because it permits local bounce.

Supersedes #227, which addressed scroll chaining rather than rubber-banding.

Validation:
- 343 tests passed, 2 native integration tests skipped; typecheck and build passed.
- Eight focused regressions cover both elastic boundaries, rebound direction, content growth, pause/resume, subpixel positions, and settlement after a skipped follow.
- Real React hook A/B in Edge with injected Safari-style offsets: the old hook writes `840 -> 800`; the new hook preserves `840` with zero writes, preserves rebound, then follows subsequent content growth. These checks verify JavaScript noninterference, not physical iOS bounce.
- Two bounded `m clhh` review passes.

Native bounce still depends on browser/host support. CSS cannot enable it in a host that disables it; physical iOS/trackpad feel has not been validated.