### PR TITLE
restore meaningful chat feedback motion

### DIFF
--- a/artifacts/src/web/components/chat/Reasoning.tsx
+++ b/artifacts/src/web/components/chat/Reasoning.tsx
@@ -1,14 +1,14 @@
 'use client';
 /* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- The named overflowing region must support keyboard scrolling. */
 
-import { memo, useId, useMemo } from 'react';
+import { memo, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Disclosure, DisclosureButton } from '@headlessui/react';
 import type { ReasoningUIPart } from 'ai';
 import { Streamdown } from 'streamdown';
 import { markdownPlugins } from '../../chat/markdown';
 import { normalizeMath } from '../../chat/math';
 import { Icon } from '../Icon';
-import { analyzeReasoning } from './reasoning-model';
+import { analyzeReasoning, createSummaryArrivalTracker } from './reasoning-model';
 import { useReasoningScroll } from './useReasoningScroll';
 import { exportRehypePlugins } from '../../chat/export-links';
 import './Reasoning.css';
@@ -33,6 +33,30 @@ function ReasoningView({ presentation, active, historyOpen }: { presentation: Re
   const visible = kind === 'summary' && !historyOpen ? entries.slice(-1) : entries;
   const contentKey = `${historyOpen}:${visible.map(entry => `${entry.key}:${entry.text}`).join('\n')}`;
   const { viewport, content, following, overflowing, resume } = useReasoningScroll(contentKey, active && !historyOpen);
+  const [arrivals] = useState(() => createSummaryArrivalTracker(entries));
+  const arrival = useRef<Animation | null>(null);
+  useLayoutEffect(() => {
+    const enabled = kind === 'summary' && active && !historyOpen;
+    if (!enabled) arrival.current?.cancel();
+    const reduced = matchMedia('(prefers-reduced-motion: reduce)');
+    const isNew = arrivals.isNew(entries, enabled);
+    if (!enabled) { arrivals.consume(entries); return; }
+    // Background or reduced-motion arrivals are intentionally consumed without replay when the view returns.
+    if (!isNew || document.hidden || reduced.matches) { if (entries.at(-1)?.state !== 'streaming' || document.hidden || reduced.matches) arrivals.consume(entries); return; }
+    const latest = content.current?.querySelector<HTMLElement>(':scope > [data-reasoning-latest="true"]');
+    if (!latest || latest.hidden || !latest.animate) return;
+    // Animate this arrival once. Token renders and display:none history toggles cannot restart a WAAPI animation.
+    arrival.current?.cancel();
+    const animation = latest.animate([{ opacity: 0.55 }, { opacity: 1 }], { duration: 160, easing: 'cubic-bezier(0.23, 1, 0.32, 1)' });
+    arrivals.consume(entries);
+    arrival.current = animation;
+    const cancel = () => { if (reduced.matches || document.hidden) animation.cancel(); };
+    const cleanup = () => { reduced.removeEventListener('change', cancel); document.removeEventListener('visibilitychange', cancel); };
+    // Only active arrivals subscribe; old reasoning blocks must not accumulate document listeners.
+    reduced.addEventListener('change', cancel); document.addEventListener('visibilitychange', cancel);
+    animation.onfinish = cleanup; animation.oncancel = cleanup;
+  }, [entries, kind, active, historyOpen, arrivals, content]);
+  useEffect(() => () => arrival.current?.cancel(), []);
   return <>
     <div className="reasoning-indicator" aria-hidden="true" />
     <div className="reasoning-main">

--- a/artifacts/src/web/components/chat/reasoning-model.ts
+++ b/artifacts/src/web/components/chat/reasoning-model.ts
@@ -1,7 +1,7 @@
 import type { ReasoningUIPart } from 'ai';
 import { parseMarkdownIntoBlocks } from 'streamdown';
 
-type ReasoningEntry = { key: string; text: string };
+type ReasoningEntry = { key: string; text: string; state?: ReasoningUIPart['state'] };
 type ReasoningKind = 'summary' | 'full';
 
 export function reasoningRunAt(parts: readonly { type: string }[], index: number): ReasoningUIPart[] | undefined {
@@ -25,7 +25,7 @@ function summaryEntries(part: ReasoningUIPart, partIndex: number, live: boolean)
   let headingCount = 0;
   let headingsOnly = true;
   const flush = () => {
-    if (text.trim()) entries.push({ key: `${prefix}:${entries.length}`, text: text.trim() });
+    if (text.trim()) entries.push({ key: `${prefix}:${entries.length}`, text: text.trim(), state: part.state });
     text = '';
   };
   const blocks = parseMarkdownIntoBlocks(part.text);
@@ -53,6 +53,18 @@ function summaryEntries(part: ReasoningUIPart, partIndex: number, live: boolean)
   }
   flush();
   return { entries, headingCount, headingsOnly };
+}
+
+/** Treat mounted history and first-seen completed parts as baseline, even while another part is live. */
+export function createSummaryArrivalTracker(initial: readonly ReasoningEntry[]) {
+  const seen = new Set(initial.map(entry => entry.key));
+  return {
+    isNew(entries: readonly ReasoningEntry[], enabled: boolean) {
+      const latest = entries.at(-1);
+      return Boolean(enabled && latest?.state === 'streaming' && !seen.has(latest.key));
+    },
+    consume(entries: readonly ReasoningEntry[]) { for (const entry of entries) seen.add(entry.key); },
+  };
 }
 
 export function analyzeReasoning(parts: readonly ReasoningUIPart[], live = false): { kind: ReasoningKind; entries: ReasoningEntry[] } {

--- a/artifacts/src/web/components/chat/reasoning.test.ts
+++ b/artifacts/src/web/components/chat/reasoning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { ReasoningUIPart } from 'ai';
-import { analyzeReasoning, reasoningRunAt } from './reasoning-model';
+import { analyzeReasoning, createSummaryArrivalTracker, reasoningRunAt } from './reasoning-model';
 
 const part = (text: string, extra: Partial<ReasoningUIPart> = {}): ReasoningUIPart => ({ type: 'reasoning', text, ...extra });
 const summary = (text: string, extra: Partial<ReasoningUIPart> = {}) => part(text, { providerMetadata: { macaron: { reasoningKind: 'summary' } }, ...extra });
@@ -96,5 +96,43 @@ describe('reasoning presentation', () => {
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0].text).toBe('**Inspecting the source**');
     expect(analyzeReasoning([part('', { state: 'done' })])).toEqual({ kind: 'full', entries: [] });
+  });
+});
+
+describe('summary arrival identity', () => {
+  const entries = (text: string, state: 'streaming' | 'done' = 'streaming') => analyzeReasoning([summary(text, { id: 'summary', state })], true).entries;
+  test('seeds the initial snapshot and remounted history without replaying', () => {
+    const current = entries('**Current**');
+    const tracker = createSummaryArrivalTracker(current);
+    expect(tracker.isNew(current, true)).toBe(false);
+    expect(tracker.isNew(entries('**Current**\nMore text'), true)).toBe(false);
+  });
+  test('fades each new live identity once, not each token or repeated appearance', () => {
+    const first = entries('**First**'), next = entries('**First**\n\n**Next**');
+    const arrives = createSummaryArrivalTracker(first);
+    expect(arrives.isNew(next, true)).toBe(true); arrives.consume(next);
+    expect(arrives.isNew(entries('**First**\n\n**Next**\nNew token'), true)).toBe(false);
+    arrives.consume(first);
+    expect(arrives.isNew(next, true)).toBe(false);
+  });
+  test('consumes hidden history arrivals and completed backfill even when the turn is live', () => {
+    const arrives = createSummaryArrivalTracker([]);
+    expect(arrives.isNew(entries('**History**', 'done'), true)).toBe(false); arrives.consume(entries('**History**', 'done'));
+    expect(arrives.isNew(entries('**History**\n\n**Hidden arrival**'), false)).toBe(false); arrives.consume(entries('**History**\n\n**Hidden arrival**'));
+    expect(arrives.isNew(entries('**History**\n\n**Hidden arrival**'), true)).toBe(false);
+    expect(arrives.isNew(entries('**History**\n\n**Hidden arrival**\n\n**Visible arrival**'), true)).toBe(true);
+  });
+  test('history-open arrivals become baseline before the latest view is restored', () => {
+    const arrives = createSummaryArrivalTracker(entries('**Initial**'));
+    const hidden = entries('**Initial**\n\n**Hidden**');
+    expect(arrives.isNew(hidden, false)).toBe(false); arrives.consume(hidden);
+    expect(arrives.isNew(hidden, true)).toBe(false);
+  });
+  test('unknown provenance is baseline, and incomplete headings do not count as arrivals', () => {
+    const initial = analyzeReasoning([summary('**Existing**', { id: 'summary' })], true).entries;
+    const arrives = createSummaryArrivalTracker([]);
+    expect(arrives.isNew(initial, true)).toBe(false); arrives.consume(initial);
+    expect(arrives.isNew(entries('**Existing**\n\n**Incompl'), true)).toBe(false);
+    expect(arrives.isNew(entries('**Existing**\n\n**Complete**'), true)).toBe(true);
   });
 });

--- a/artifacts/src/web/components/ui4a-ui.tsx
+++ b/artifacts/src/web/components/ui4a-ui.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from 'react';
+import { useState, type ComponentProps, type ReactNode } from 'react';
 import { Button as HeadlessButton, Field as HeadlessField, Input, Label, Description, Disclosure as HeadlessDisclosure, DisclosureButton, DisclosurePanel, Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 import { Icon } from './Icon';
 
@@ -23,5 +23,6 @@ export function Tabs({ items, value, onChange }: { items: { id: string; label: R
 }
 
 export function Disclosure({ title, children, defaultOpen }: { title: ReactNode; children: ReactNode; defaultOpen?: boolean }) {
-  return <HeadlessDisclosure defaultOpen={defaultOpen}>{({ open }) => <div className="overflow-clip rounded-lg bg-surface-2"><DisclosureButton className={`interactive flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-surface-3 hover:text-hover-fg ${focus}`}>{title}<Icon name="chevronRight" className={`size-4 shrink-0 ${open ? 'rotate-90' : ''}`} /></DisclosureButton><DisclosurePanel static hidden={!open} className="px-3 py-3 text-sm">{children}</DisclosurePanel></div>}</HeadlessDisclosure>;
+  const [keyboard, setKeyboard] = useState(true);
+  return <HeadlessDisclosure defaultOpen={defaultOpen}>{({ open }) => <div className="overflow-clip rounded-lg bg-surface-2"><DisclosureButton onClickCapture={event => setKeyboard(event.detail === 0)} className={`interactive flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-surface-3 hover:text-hover-fg ${focus}`}>{title}<Icon name="chevronRight" className={`size-4 shrink-0 ${open ? 'rotate-90' : ''}`} /></DisclosureButton><div data-ui4a-disclosure-panel data-keyboard={keyboard || undefined} inert={!open} aria-hidden={!open} className={`grid transition-[grid-template-rows] duration-180 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}><div className="overflow-hidden"><DisclosurePanel static className="px-3 py-3 text-sm">{children}</DisclosurePanel></div></div></div>}</HeadlessDisclosure>;
 }

--- a/artifacts/src/web/styles.css
+++ b/artifacts/src/web/styles.css
@@ -44,8 +44,9 @@ button.pressable:focus-visible:active { scale: none; }
 .select-popup:dir(rtl) { --popup-origin-x: 0%; }
 .select-popup:dir(rtl)[data-anchor~='start'] { --popup-origin-x: 100%; }
 /* Keyboard actions settle immediately, including when Escape interrupts a pointer-opened popup. */
-.select-popup[data-keyboard], [data-export-collapsible][data-keyboard], [data-export-collapsible][data-keyboard] > [data-export-scroller], [data-export-collapsible][data-keyboard] > [data-export-toggle] { transition: none !important; }
+.select-popup[data-keyboard], [data-ui4a-disclosure-panel][data-keyboard], [data-export-collapsible][data-keyboard], [data-export-collapsible][data-keyboard] > [data-export-scroller], [data-export-collapsible][data-keyboard] > [data-export-toggle] { transition: none !important; }
 [data-export-toggle][data-export-fallback] { opacity: 1 !important; }
+.tool-disclosure-icon { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
 .tool-call[open] > summary .tool-disclosure-icon { transform: rotate(90deg); }
 .tool-call > summary:focus-visible { outline-offset: -2px; }
 /* Notifications live outside scrolling panels; expand the close hit area without enlarging its glyph. */


### PR DESCRIPTION
Restores motion only where it communicates a state change without disrupting streamed content.

- Restore the tool-call chevron's short transform transition for harness-driven open/close state.
- Restore UI4A Disclosure's 180ms pointer reveal while keeping keyboard and reduced-motion activation immediate.
- Fade genuinely new live reasoning summaries once per mounted view with WAAPI; history toggles, token updates, remounts, background tabs, reduced motion, and offline exports do not replay it.

The long code-output height transition remains instant because its interaction is coupled to streaming content and tail-follow scrolling.

Validation: 360 tests passed, 2 skipped; typecheck and production build passed. Edge checks covered summary arrival identity, history/backfill/remount behavior, reduced motion, tool state changes, Disclosure reversal, streamed growth, and stuck/unstuck chat layouts. Claude reviewed the final diff and approved. No dependencies added.